### PR TITLE
feat/#21: 댓글 대댓글 시 알림 발송 로직 추가

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestNotificationService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestNotificationService.java
@@ -1,0 +1,78 @@
+package com.dodo.dodoserver.domain.nest.service;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
+
+/**
+ * 둥지 관련 알림(댓글, 답글 등) 발행 로직을 전담하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NestNotificationService {
+
+    private final UserDeviceRepository userDeviceRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 댓글 및 대댓글 알림 발행
+     */
+    public void sendCommentNotification(User commenter, Nest nest, NestComment parent, NestComment savedComment) {
+        User targetUser;
+        String type;
+        String title;
+        String body;
+
+        if (parent == null) {
+            targetUser = nest.getCreator();
+            type = TYPE_COMMENT;
+            title = TITLE_NEW_COMMENT;
+            body = String.format(BODY_NEW_COMMENT, commenter.getNickname());
+        } else {
+            targetUser = parent.getUser();
+            type = TYPE_REPLY;
+            title = TITLE_NEW_REPLY;
+            body = String.format(BODY_NEW_REPLY, commenter.getNickname());
+        }
+
+        // 본인 글에 본인이 댓글을 단 경우 알림 미발행
+        if (commenter.getId().equals(targetUser.getId())) {
+            return;
+        }
+
+        // 수신자의 FCM 토큰 목록 조회
+        List<String> fcmTokens = userDeviceRepository.findByUserId(targetUser.getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (fcmTokens.isEmpty()) {
+            return;
+        }
+
+        // 알림 데이터 구성
+        Map<String, String> data = new HashMap<>();
+        data.put(KEY_TYPE, type);
+        data.put(KEY_NEST_ID, nest.getId().toString());
+        data.put(KEY_COMMENT_ID, savedComment.getId().toString());
+
+        // 이벤트 발행
+        eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
+        log.info("댓글 알림 이벤트 발행 완료: TargetUser={}, Type={}", targetUser.getEmail(), type);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -31,8 +31,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -47,8 +45,7 @@ public class NestService {
     private final NestCommentRepository nestCommentRepository;
     private final UserProfileRepository userProfileRepository;
     private final CommentLikeRepository commentLikeRepository;
-    private final UserDeviceRepository userDeviceRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final NestNotificationService nestNotificationService;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -218,49 +215,7 @@ public class NestService {
         NestComment savedComment = nestCommentRepository.save(comment);
         log.info("댓글 작성 완료: Nest={}, User={}", nestId, email);
 
-        publishCommentNotification(user, nest, parent, savedComment);
-    }
-
-    /**
-     * 댓글 및 대댓글 알림 발행
-     */
-    private void publishCommentNotification(User commenter, Nest nest, NestComment parent, NestComment savedComment) {
-        User targetUser;
-        String type;
-        String title;
-        String body;
-
-        if (parent == null) {
-            targetUser = nest.getCreator();
-            type = TYPE_COMMENT;
-            title = TITLE_NEW_COMMENT;
-            body = String.format(BODY_NEW_COMMENT, commenter.getNickname());
-        } else {
-            targetUser = parent.getUser();
-            type = TYPE_REPLY;
-            title = TITLE_NEW_REPLY;
-            body = String.format(BODY_NEW_REPLY, commenter.getNickname());
-        }
-        if (commenter.getId().equals(targetUser.getId())) {
-            return;
-        }
-
-        List<String> fcmTokens = userDeviceRepository.findByUserId(targetUser.getId()).stream()
-                .map(UserDevice::getFcmToken)
-                .filter(Objects::nonNull)
-                .toList();
-
-        if (fcmTokens.isEmpty()) {
-            return;
-        }
-
-        Map<String, String> data = new HashMap<>();
-        data.put(KEY_TYPE, type);
-        data.put(KEY_NEST_ID, nest.getId().toString());
-        data.put(KEY_COMMENT_ID, savedComment.getId().toString());
-
-        eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
-        log.info("댓글 알림 이벤트 발행 완료: TargetUser={}, Type={}", targetUser.getEmail(), type);
+        nestNotificationService.sendCommentNotification(user, nest, parent, savedComment);
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -5,18 +5,22 @@ import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.*;
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.*;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
 import com.dodo.dodoserver.domain.user.dao.UserProfileRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
 import com.dodo.dodoserver.domain.user.entity.UserProfile;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -40,8 +44,9 @@ public class NestService {
     private final NestReactionRepository nestReactionRepository;
     private final NestCommentRepository nestCommentRepository;
     private final UserProfileRepository userProfileRepository;
-    private final NestImageRepository nestImageRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final UserDeviceRepository userDeviceRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -208,8 +213,53 @@ public class NestService {
                 .content(requestDto.getContent())
                 .build();
 
-        nestCommentRepository.save(comment);
+        NestComment savedComment = nestCommentRepository.save(comment);
         log.info("댓글 작성 완료: Nest={}, User={}", nestId, email);
+
+        publishCommentNotification(user, nest, parent, savedComment);
+    }
+
+    /**
+     * 댓글 및 대댓글 알림 발행
+     */
+    private void publishCommentNotification(User commenter, Nest nest, NestComment parent, NestComment savedComment) {
+        User targetUser;
+        String type;
+        String title;
+        String body;
+
+        if (parent == null) {
+            targetUser = nest.getCreator();
+            type = "COMMENT";
+            title = "둥지에 새 댓글이 달렸습니다!";
+            body = String.format("%s님이 댓글을 남겼습니다.", commenter.getNickname());
+        } else {
+            targetUser = parent.getUser();
+            type = "REPLY";
+            title = "내 댓글에 답글이 달렸습니다!";
+            body = String.format("%s님이 답글을 남겼습니다.", commenter.getNickname());
+        }
+
+        if (commenter.getId().equals(targetUser.getId())) {
+            return;
+        }
+
+        List<String> fcmTokens = userDeviceRepository.findByUserId(targetUser.getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (fcmTokens.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> data = new HashMap<>();
+        data.put("type", type);
+        data.put("nestId", nest.getId().toString());
+        data.put("commentId", savedComment.getId().toString());
+
+        eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
+        log.info("댓글 알림 이벤트 발행 완료: TargetUser={}, Type={}", targetUser.getEmail(), type);
     }
 
     /**
@@ -249,7 +299,7 @@ public class NestService {
     }
 
     /**
-     * ID 리스트 둥지 요약 정보 조회
+     * ID 리스트 둥지 요약 정보 조회 (N+1 최적화)
      */
     @Transactional(readOnly = true)
     public List<NestSummaryResponseDto> getNestsByIds(String email, List<Long> nestIds) {
@@ -450,15 +500,17 @@ public class NestService {
         double radius = (radiusMeter != null) ? radiusMeter : 5000.0;
         Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude));
 
+        // Native Query 정렬 불일치 해결: 엔티티 필드명을 DB 컬럼명으로 변환
         Pageable nativePageable = translateToNativePageable(pageable);
         Page<Nest> nests = nestRepository.findNearbyNests(point, radius, categoryId, nativePageable);
-
+        
         if (nests.isEmpty()) return Page.empty(pageable);
 
+        // 현재 페이지의 해금 이력 일괄 조회 (N+1 방지)
         Set<Long> unlockedNestIds = unlockHistoryRepository.findAllByUserAndNestIn(user, nests.getContent()).stream()
                 .map(uh -> uh.getNest().getId())
                 .collect(Collectors.toSet());
-        
+
         return nests.map(nest -> {
             boolean isUnlocked = nest.getCreator().equals(user) || unlockedNestIds.contains(nest.getId());
             return NestSummaryResponseDto.from(nest, isUnlocked);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -31,6 +31,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -230,16 +232,15 @@ public class NestService {
 
         if (parent == null) {
             targetUser = nest.getCreator();
-            type = "COMMENT";
-            title = "둥지에 새 댓글이 달렸습니다!";
-            body = String.format("%s님이 댓글을 남겼습니다.", commenter.getNickname());
+            type = TYPE_COMMENT;
+            title = TITLE_NEW_COMMENT;
+            body = String.format(BODY_NEW_COMMENT, commenter.getNickname());
         } else {
             targetUser = parent.getUser();
-            type = "REPLY";
-            title = "내 댓글에 답글이 달렸습니다!";
-            body = String.format("%s님이 답글을 남겼습니다.", commenter.getNickname());
+            type = TYPE_REPLY;
+            title = TITLE_NEW_REPLY;
+            body = String.format(BODY_NEW_REPLY, commenter.getNickname());
         }
-
         if (commenter.getId().equals(targetUser.getId())) {
             return;
         }
@@ -254,9 +255,9 @@ public class NestService {
         }
 
         Map<String, String> data = new HashMap<>();
-        data.put("type", type);
-        data.put("nestId", nest.getId().toString());
-        data.put("commentId", savedComment.getId().toString());
+        data.put(KEY_TYPE, type);
+        data.put(KEY_NEST_ID, nest.getId().toString());
+        data.put(KEY_COMMENT_ID, savedComment.getId().toString());
 
         eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
         log.info("댓글 알림 이벤트 발행 완료: TargetUser={}, Type={}", targetUser.getEmail(), type);

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -1,0 +1,23 @@
+package com.dodo.dodoserver.global.common.constants;
+
+
+public final class NotificationConstants {
+
+    // Data Keys
+    public static final String KEY_TYPE = "type";
+    public static final String KEY_NEST_ID = "nestId";
+    public static final String KEY_COMMENT_ID = "commentId";
+
+    // Type Values
+    public static final String TYPE_COMMENT = "COMMENT";
+    public static final String TYPE_REPLY = "REPLY";
+
+    // Message Templates
+    public static final String TITLE_NEW_COMMENT = "둥지에 새 댓글이 달렸습니다!";
+    public static final String BODY_NEW_COMMENT = "%s님이 댓글을 남겼습니다.";
+    public static final String TITLE_NEW_REPLY = "내 댓글에 답글이 달렸습니다!";
+    public static final String BODY_NEW_REPLY = "%s님이 답글을 남겼습니다.";
+
+    private NotificationConstants() {
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestNotificationServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestNotificationServiceTest.java
@@ -1,0 +1,122 @@
+package com.dodo.dodoserver.domain.nest.service;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.global.common.constants.NotificationConstants;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NestNotificationServiceTest {
+
+    @InjectMocks
+    private NestNotificationService nestNotificationService;
+
+    @Mock
+    private UserDeviceRepository userDeviceRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private User commenter;
+    private Nest nest;
+
+    @BeforeEach
+    void setUp() {
+        commenter = User.builder().id(1L).nickname("작성자").build();
+        User nestCreator = User.builder().id(2L).email("creator@test.com").build();
+        nest = Nest.builder().id(10L).creator(nestCreator).build();
+    }
+
+    @Test
+    @DisplayName("일반 댓글 작성 시 둥지 제작자에게 알림 발행")
+    void sendCommentNotification_Comment() {
+        // given
+        NestComment savedComment = NestComment.builder().id(100L).nest(nest).user(commenter).build();
+        UserDevice device = UserDevice.builder().fcmToken("token-123").build();
+
+        given(userDeviceRepository.findByUserId(nest.getCreator().getId())).willReturn(List.of(device));
+
+        // when
+        nestNotificationService.sendCommentNotification(commenter, nest, null, savedComment);
+
+        // then
+        ArgumentCaptor<NotificationEvent> captor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(captor.capture());
+        
+        NotificationEvent event = captor.getValue();
+        assertThat(event.title()).isEqualTo(NotificationConstants.TITLE_NEW_COMMENT);
+        assertThat(event.data().get(NotificationConstants.KEY_TYPE)).isEqualTo(NotificationConstants.TYPE_COMMENT);
+    }
+
+    @Test
+    @DisplayName("답글 작성 시 부모 댓글 작성자에게 알림 발행")
+    void sendCommentNotification_Reply() {
+        // given
+        User parentAuthor = User.builder().id(3L).email("parent@test.com").build();
+        NestComment parent = NestComment.builder().id(50L).user(parentAuthor).build();
+        NestComment savedComment = NestComment.builder().id(101L).nest(nest).user(commenter).parent(parent).build();
+        UserDevice device = UserDevice.builder().fcmToken("token-456").build();
+
+        given(userDeviceRepository.findByUserId(parentAuthor.getId())).willReturn(List.of(device));
+
+        // when
+        nestNotificationService.sendCommentNotification(commenter, nest, parent, savedComment);
+
+        // then
+        ArgumentCaptor<NotificationEvent> captor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(captor.capture());
+
+        NotificationEvent event = captor.getValue();
+        assertThat(event.title()).isEqualTo(NotificationConstants.TITLE_NEW_REPLY);
+        assertThat(event.data().get(NotificationConstants.KEY_TYPE)).isEqualTo(NotificationConstants.TYPE_REPLY);
+    }
+
+    @Test
+    @DisplayName("본인 글에 본인이 댓글을 달면 알림이 발행되지 않음")
+    void sendCommentNotification_SelfAction() {
+        // given
+        User sameUser = User.builder().id(2L).build(); // 둥지 제작자와 동일 ID
+        Nest selfNest = Nest.builder().id(10L).creator(sameUser).build();
+        NestComment savedComment = NestComment.builder().id(100L).nest(selfNest).user(sameUser).build();
+
+        // when
+        nestNotificationService.sendCommentNotification(sameUser, selfNest, null, savedComment);
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(userDeviceRepository, never()).findByUserId(any());
+    }
+
+    @Test
+    @DisplayName("FCM 토큰이 없으면 이벤트가 발행되지 않음")
+    void sendCommentNotification_NoTokens() {
+        // given
+        NestComment savedComment = NestComment.builder().id(100L).nest(nest).user(commenter).build();
+        given(userDeviceRepository.findByUserId(nest.getCreator().getId())).willReturn(List.of());
+
+        // when
+        nestNotificationService.sendCommentNotification(commenter, nest, null, savedComment);
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -56,6 +56,8 @@ class NestServiceTest {
     private NestImageRepository nestImageRepository;
     @Mock
     private CommentLikeRepository commentLikeRepository;
+    @Mock
+    private NestNotificationService nestNotificationService;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
     private User user;
@@ -284,6 +286,7 @@ class NestServiceTest {
         nestService.createComment(email, nestId, requestDto);
 
         verify(nestCommentRepository).save(any(NestComment.class));
+            verify(nestNotificationService).sendCommentNotification(any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
글 및 대댓글 작성 시 관련 사용자(게시물 작성자 또는 부모 댓글 작성자)에게 비동기 FCM 알림을 전송하는 기능을 구현

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - [x] 비동기 댓글 알림 시스템 구축
     - 댓글 작성 시 게시물 작성자에게, 대댓글 작성 시 부모 댓글 작성자에게 FCM 알림 전송.
     - 행위자와 수신자가 동일할 경우 발송 제외 로직 적용.
     - Spring Event를 활용하여 비즈니스 로직과 알림 발송 로직 분리 (결합도 감소).


## 🔗 관련 이슈 (Related Issues)
- close #21 


## 📝 추가 참고 사항 (Additional Notes)
### 알림 타입별 상세 명세 (Notification Types)

현재 Nest(둥지) 도메인에서 발생하는 알림 규격입니다.

### 1. 새 댓글 알림 (`COMMENT`)
-   상황: 사용자가 타인의 둥지에 새로운 댓글을 작성했을 때.
-   수신자: 둥지(게시물) 작성자.
-   Payload 구조:
    | Key | Value | Description |
    | :--- | :--- | :--- |
    | `type` | `COMMENT` | 알림 유형 구분 |
    | `nestId` | `{id}` | 댓글이 달린 둥지 ID (문자열) |
    | `commentId`| `{id}` | 작성된 댓글의 ID (문자열) |
-   **메시지 예시**:
    -   **Title**: `둥지에 새 댓글이 달렸습니다!`
    -   **Body**: `[닉네임]님이 댓글을 남겼습니다.`

### 2. 답글(대댓글) 알림 (`REPLY`)
-   상황: 사용자가 타인의 댓글에 답글을 작성했을 때.
-   수신자: 부모 댓글의 작성자.
-   Payload 구조:
    | Key | Value | Description |
    | :--- | :--- | :--- |
    | `type` | `REPLY` | 알림 유형 구분 |
    | `nestId` | `{id}` | 해당 둥지 ID (문자열) |
    | `commentId`| `{id}` | 작성된 답글의 ID (문자열) |
-   메시지 예시:
    -   Title: `내 댓글에 답글이 달렸습니다!`
    -   Body: `[닉네임]님이 답글을 남겼습니다.`
    
    
### 안드로이드 수신 처리 가이드 (Client Integration)

클라이언트(Android)는 `onMessageReceived`에서 아래와 같이 데이터를 처리할 것을 권장합니다.

1.  **데이터 파싱**: `RemoteMessage.getData()`를 통해 `nestId`와 `type`을 확인합니다.
2.  **화면 이동**:
    -   `type`이 `COMMENT` 또는 `REPLY`인 경우: `nestId`를 기반으로 **둥지 상세 화면**으로 이동합니다.
    -   추가적으로 `commentId`를 사용하여 해당 댓글을 강조(Highlight) 처리하거나 스크롤할 수 있습니다.
