### PR TITLE
Refactor/24/custom user principal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.hashids:hashids:1.0.3'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/src/main/java/com/dodo/dodoserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/controller/AuthController.java
@@ -7,7 +7,8 @@ import com.dodo.dodoserver.domain.auth.service.AuthService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -31,13 +32,11 @@ public class AuthController {
 
     /**
      * 현재 로그인 사용자의 세션 만료(토큰 삭제) 엔드포인트
-     * 인증 필터 통과 후 SecurityContext 내 Authentication 객체에서 이메일 추출
+     * 인증 필터 통과 후 SecurityContext 내 UserPrincipal 객체에서 이메일 추출
      */
     @PostMapping("/logout")
-    public ApiResponseDto<String> logout(Authentication authentication) {
-        // JwtAuthenticationFilter 저장 인증 정보 중 이메일 추출
-        String email = authentication.getName();
-        authService.logout(email);
+    public ApiResponseDto<String> logout(@AuthenticationPrincipal UserPrincipal principal) {
+        authService.logout(principal.getEmail());
         return ApiResponseDto.success("성공적으로 로그아웃되었습니다.");
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
      */
     @PostMapping("/logout")
     public ApiResponseDto<String> logout(@AuthenticationPrincipal UserPrincipal principal) {
-        authService.logout(principal.getEmail());
+        authService.logout(principal.getId());
         return ApiResponseDto.success("성공적으로 로그아웃되었습니다.");
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/dao/RefreshTokenRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
-    Optional<RefreshToken> findByEmail(String email);
-    void deleteByEmail(String email);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/entity/RefreshToken.java
@@ -16,7 +16,7 @@ import org.springframework.data.redis.core.index.Indexed;
 public class RefreshToken {
 
     @Id
-    private String email; // 사용자 이메일을 Key로 사용합니다.
+    private Long userId; // 사용자 ID를 Key로 사용합니다.
 
     @Indexed
     private String token; // 토큰 값 자체로 검색하기 위해 @Indexed를 추가합니다.

--- a/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 새로운 토큰 쌍(Access, Refresh) 생성 (Refresh Token Rotation - RTR)
-        String newAccessToken = tokenProvider.createAccessToken(user.getEmail(), user.getRole().getKey());
+        String newAccessToken = tokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole().getKey());
         String newRefreshToken = tokenProvider.createRefreshToken(user.getEmail());
 
         // Redis의 기존 토큰 정보 업데이트

--- a/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
@@ -38,7 +38,7 @@ public class AuthService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         // 토큰 주인(User) 존재 여부 확인
-        User user = userRepository.findByEmail(storedToken.getEmail())
+        User user = userRepository.findById(storedToken.getUserId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 새로운 토큰 쌍(Access, Refresh) 생성 (Refresh Token Rotation - RTR)
@@ -63,18 +63,16 @@ public class AuthService {
      */
     @Transactional
     public void logout(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        refreshTokenRepository.deleteByEmail(user.getEmail());
+        refreshTokenRepository.deleteById(userId);
     }
 
     /**
      * 리프레시 토큰 저장 또는 갱신
      */
     @Transactional
-    public void saveRefreshToken(String email, String token) {
+    public void saveRefreshToken(Long userId, String token) {
         refreshTokenRepository.save(RefreshToken.builder()
-                .email(email)
+                .userId(userId)
                 .token(token)
                 .build());
     }

--- a/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
@@ -62,8 +62,10 @@ public class AuthService {
      * 로그아웃 시 Redis에서 리프레시 토큰 삭제
      */
     @Transactional
-    public void logout(String email) {
-        refreshTokenRepository.deleteByEmail(email);
+    public void logout(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        refreshTokenRepository.deleteByEmail(user.getEmail());
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
@@ -9,7 +9,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.dodo.dodoserver.global.security.UserPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,12 +29,11 @@ public class NestGpsController {
      */
     @PostMapping("/{id}/unlock")
     public ApiResponseDto<String> unlockNest(
-            Authentication authentication,
+            @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long id,
             @RequestBody @Valid NestUnlockRequestDto requestDto) {
         
-        String email = authentication.getName();
-        nestService.unlockNest(email, id, requestDto);
+        nestService.unlockNest(principal.getEmail(), id, requestDto);
         return ApiResponseDto.success("둥지가 성공적으로 해금되었습니다.");
     }
 
@@ -44,11 +44,10 @@ public class NestGpsController {
      */
     @GetMapping("/summaries")
     public ApiResponseDto<List<NestSummaryResponseDto>> getNestsByIds(
-            Authentication authentication,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam List<Long> ids) {
 
-        String email = authentication.getName();
-        return ApiResponseDto.success(nestService.getNestsByIds(email, ids));
+        return ApiResponseDto.success(nestService.getNestsByIds(principal.getEmail(), ids));
     }
 
     /**
@@ -57,15 +56,14 @@ public class NestGpsController {
      */
     @GetMapping
     public ApiResponseDto<Page<NestSummaryResponseDto>> getNearbyNests(
-            Authentication authentication,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam Double latitude,
             @RequestParam Double longitude,
             @RequestParam(required = false) Double radiusMeter,
             @RequestParam(required = false) Long categoryId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        String email = authentication.getName();
-        return ApiResponseDto.success(nestService.getNearNestsByCategory(email, latitude, longitude, radiusMeter, categoryId, pageable));
+        return ApiResponseDto.success(nestService.getNearNestsByCategory(principal.getEmail(), latitude, longitude, radiusMeter, categoryId, pageable));
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
@@ -33,7 +33,7 @@ public class NestGpsController {
             @PathVariable Long id,
             @RequestBody @Valid NestUnlockRequestDto requestDto) {
         
-        nestService.unlockNest(principal.getEmail(), id, requestDto);
+        nestService.unlockNest(principal.getId(), id, requestDto);
         return ApiResponseDto.success("둥지가 성공적으로 해금되었습니다.");
     }
 
@@ -47,7 +47,7 @@ public class NestGpsController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam List<Long> ids) {
 
-        return ApiResponseDto.success(nestService.getNestsByIds(principal.getEmail(), ids));
+        return ApiResponseDto.success(nestService.getNestsByIds(principal.getId(), ids));
     }
 
     /**
@@ -63,7 +63,7 @@ public class NestGpsController {
             @RequestParam(required = false) Long categoryId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return ApiResponseDto.success(nestService.getNearNestsByCategory(principal.getEmail(), latitude, longitude, radiusMeter, categoryId, pageable));
+        return ApiResponseDto.success(nestService.getNearNestsByCategory(principal.getId(), latitude, longitude, radiusMeter, categoryId, pageable));
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestPostController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestPostController.java
@@ -2,7 +2,8 @@ package com.dodo.dodoserver.domain.nest.controller;
 
 import java.util.List;
 
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.dodo.dodoserver.global.security.UserPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,11 +40,10 @@ public class NestPostController {
 	 */
 	@PostMapping
 	public ApiResponseDto<NestSummaryResponseDto> createNest(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@RequestBody @Valid NestCreateRequestDto requestDto) {
 
-		String email = authentication.getName();
-		return ApiResponseDto.success(nestService.createNest(email, requestDto));
+		return ApiResponseDto.success(nestService.createNest(principal.getEmail(), requestDto));
 	}
 
 	/**
@@ -51,11 +51,10 @@ public class NestPostController {
 	 */
 	@GetMapping("/{id}")
 	public ApiResponseDto<NestDetailResponseDto> getNestDetail(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id) {
 
-		String email = authentication.getName();
-		return ApiResponseDto.success(nestService.getNestDetail(email, id));
+		return ApiResponseDto.success(nestService.getNestDetail(principal.getEmail(), id));
 	}
 
 	/**
@@ -63,12 +62,11 @@ public class NestPostController {
 	 */
 	@PatchMapping("/{id}")
 	public ApiResponseDto<NestSummaryResponseDto> updateNest(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id,
 		@RequestBody @Valid NestUpdateRequestDto requestDto) {
 
-		String email = authentication.getName();
-		return ApiResponseDto.success(nestService.updateNest(email, id, requestDto));
+		return ApiResponseDto.success(nestService.updateNest(principal.getEmail(), id, requestDto));
 	}
 
 	/**
@@ -76,11 +74,10 @@ public class NestPostController {
 	 */
 	@DeleteMapping("/{id}")
 	public ApiResponseDto<String> deleteNest(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id) {
 
-		String email = authentication.getName();
-		nestService.deleteNest(email, id);
+		nestService.deleteNest(principal.getEmail(), id);
 		return ApiResponseDto.success("둥지가 성공적으로 삭제되었습니다.");
 	}
 
@@ -89,12 +86,11 @@ public class NestPostController {
 	 */
 	@PostMapping("/{id}/comments")
 	public ApiResponseDto<String> createComment(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id,
 		@RequestBody @Valid CommentCreateRequestDto requestDto) {
 
-		String email = authentication.getName();
-		nestService.createComment(email, id, requestDto);
+		nestService.createComment(principal.getEmail(), id, requestDto);
 		return ApiResponseDto.success("댓글이 성공적으로 작성되었습니다.");
 	}
 
@@ -103,11 +99,11 @@ public class NestPostController {
 	 */
 	@GetMapping("/{id}/comments")
 	public ApiResponseDto<List<CommentResponseDto>> getComments(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id,
 		@RequestParam(required = false, defaultValue = "DEFAULT") String sortBy) {
 		
-		String email = (authentication != null) ? authentication.getName() : null;
+		String email = (principal != null) ? principal.getEmail() : null;
 		return ApiResponseDto.success(nestService.getCommentsByNestId(email, id, sortBy));
 	}
 
@@ -116,11 +112,10 @@ public class NestPostController {
 	 */
 	@PostMapping("/comments/{commentId}/like")
 	public ApiResponseDto<String> handleCommentLike(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long commentId) {
 
-		String email = authentication.getName();
-		nestService.handleCommentLike(email, commentId);
+		nestService.handleCommentLike(principal.getEmail(), commentId);
 		return ApiResponseDto.success("댓글 좋아요 처리가 완료되었습니다.");
 	}
 
@@ -129,12 +124,11 @@ public class NestPostController {
 	 */
 	@PatchMapping("/comments/{commentId}")
 	public ApiResponseDto<String> updateComment(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long commentId,
 		@RequestBody @Valid CommentUpdateRequestDto requestDto) {
 
-		String email = authentication.getName();
-		nestService.updateComment(email, commentId, requestDto);
+		nestService.updateComment(principal.getEmail(), commentId, requestDto);
 		return ApiResponseDto.success("댓글이 성공적으로 수정되었습니다.");
 	}
 
@@ -143,11 +137,10 @@ public class NestPostController {
 	 */
 	@DeleteMapping("/comments/{commentId}")
 	public ApiResponseDto<String> deleteComment(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long commentId) {
 
-		String email = authentication.getName();
-		nestService.deleteComment(email, commentId);
+		nestService.deleteComment(principal.getEmail(), commentId);
 		return ApiResponseDto.success("댓글이 성공적으로 삭제되었습니다.");
 	}
 
@@ -158,12 +151,11 @@ public class NestPostController {
 	 */
 	@PostMapping("/{id}/reaction")
 	public ApiResponseDto<String> handleReaction(
-		Authentication authentication,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id,
 		@RequestParam ReactionType type) {
 
-		String email = authentication.getName();
-		nestService.handleReaction(email, id, type);
+		nestService.handleReaction(principal.getEmail(), id, type);
 		return ApiResponseDto.success("리액션이 성공적으로 처리되었습니다.");
 	}
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestPostController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestPostController.java
@@ -43,7 +43,7 @@ public class NestPostController {
 		@AuthenticationPrincipal UserPrincipal principal,
 		@RequestBody @Valid NestCreateRequestDto requestDto) {
 
-		return ApiResponseDto.success(nestService.createNest(principal.getEmail(), requestDto));
+		return ApiResponseDto.success(nestService.createNest(principal.getId(), requestDto));
 	}
 
 	/**
@@ -54,7 +54,7 @@ public class NestPostController {
 		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id) {
 
-		return ApiResponseDto.success(nestService.getNestDetail(principal.getEmail(), id));
+		return ApiResponseDto.success(nestService.getNestDetail(principal.getId(), id));
 	}
 
 	/**
@@ -66,7 +66,7 @@ public class NestPostController {
 		@PathVariable Long id,
 		@RequestBody @Valid NestUpdateRequestDto requestDto) {
 
-		return ApiResponseDto.success(nestService.updateNest(principal.getEmail(), id, requestDto));
+		return ApiResponseDto.success(nestService.updateNest(principal.getId(), id, requestDto));
 	}
 
 	/**
@@ -77,7 +77,7 @@ public class NestPostController {
 		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id) {
 
-		nestService.deleteNest(principal.getEmail(), id);
+		nestService.deleteNest(principal.getId(), id);
 		return ApiResponseDto.success("둥지가 성공적으로 삭제되었습니다.");
 	}
 
@@ -90,7 +90,7 @@ public class NestPostController {
 		@PathVariable Long id,
 		@RequestBody @Valid CommentCreateRequestDto requestDto) {
 
-		nestService.createComment(principal.getEmail(), id, requestDto);
+		nestService.createComment(principal.getId(), id, requestDto);
 		return ApiResponseDto.success("댓글이 성공적으로 작성되었습니다.");
 	}
 
@@ -103,8 +103,8 @@ public class NestPostController {
 		@PathVariable Long id,
 		@RequestParam(required = false, defaultValue = "DEFAULT") String sortBy) {
 		
-		String email = (principal != null) ? principal.getEmail() : null;
-		return ApiResponseDto.success(nestService.getCommentsByNestId(email, id, sortBy));
+		Long userId = (principal != null) ? principal.getId() : null;
+		return ApiResponseDto.success(nestService.getCommentsByNestId(userId, id, sortBy));
 	}
 
 	/**
@@ -115,7 +115,7 @@ public class NestPostController {
 		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long commentId) {
 
-		nestService.handleCommentLike(principal.getEmail(), commentId);
+		nestService.handleCommentLike(principal.getId(), commentId);
 		return ApiResponseDto.success("댓글 좋아요 처리가 완료되었습니다.");
 	}
 
@@ -128,7 +128,7 @@ public class NestPostController {
 		@PathVariable Long commentId,
 		@RequestBody @Valid CommentUpdateRequestDto requestDto) {
 
-		nestService.updateComment(principal.getEmail(), commentId, requestDto);
+		nestService.updateComment(principal.getId(), commentId, requestDto);
 		return ApiResponseDto.success("댓글이 성공적으로 수정되었습니다.");
 	}
 
@@ -140,7 +140,7 @@ public class NestPostController {
 		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long commentId) {
 
-		nestService.deleteComment(principal.getEmail(), commentId);
+		nestService.deleteComment(principal.getId(), commentId);
 		return ApiResponseDto.success("댓글이 성공적으로 삭제되었습니다.");
 	}
 
@@ -155,7 +155,7 @@ public class NestPostController {
 		@PathVariable Long id,
 		@RequestParam ReactionType type) {
 
-		nestService.handleReaction(principal.getEmail(), id, type);
+		nestService.handleReaction(principal.getId(), id, type);
 		return ApiResponseDto.success("리액션이 성공적으로 처리되었습니다.");
 	}
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -53,8 +53,8 @@ public class NestService {
      * 새로운 둥지(Nest) 생성
      */
     @Transactional
-    public NestSummaryResponseDto createNest(String email, NestCreateRequestDto requestDto) {
-        User creator = userRepository.findByEmail(email)
+    public NestSummaryResponseDto createNest(Long userId, NestCreateRequestDto requestDto) {
+        User creator = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         Nest nest = Nest.builder()
@@ -107,8 +107,8 @@ public class NestService {
      * 둥지 정보 수정
      */
     @Transactional
-    public NestSummaryResponseDto updateNest(String email, Long nestId, NestUpdateRequestDto requestDto) {
-        User user = userRepository.findByEmail(email)
+    public NestSummaryResponseDto updateNest(Long userId, Long nestId, NestUpdateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         Nest nest = nestRepository.findById(nestId)
@@ -163,8 +163,8 @@ public class NestService {
      * 둥지 삭제 (Soft Delete)
      */
     @Transactional
-    public void deleteNest(String email, Long nestId) {
-        User user = userRepository.findByEmail(email)
+    public void deleteNest(Long userId, Long nestId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         Nest nest = nestRepository.findById(nestId)
@@ -182,8 +182,8 @@ public class NestService {
      * 둥지 댓글 작성
      */
     @Transactional
-    public void createComment(String email, Long nestId, CommentCreateRequestDto requestDto) {
-        User user = userRepository.findByEmail(email)
+    public void createComment(Long userId, Long nestId, CommentCreateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         Nest nest = nestRepository.findById(nestId)
@@ -213,7 +213,7 @@ public class NestService {
                 .build();
 
         NestComment savedComment = nestCommentRepository.save(comment);
-        log.info("댓글 작성 완료: Nest={}, User={}", nestId, email);
+        log.info("댓글 작성 완료: Nest={}, User={}", nestId, userId);
 
         nestNotificationService.sendCommentNotification(user, nest, parent, savedComment);
     }
@@ -222,8 +222,8 @@ public class NestService {
      * 댓글 수정
      */
     @Transactional
-    public void updateComment(String email, Long commentId, CommentUpdateRequestDto requestDto) {
-        User user = userRepository.findByEmail(email)
+    public void updateComment(Long userId, Long commentId, CommentUpdateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         NestComment comment = nestCommentRepository.findById(commentId)
@@ -240,8 +240,8 @@ public class NestService {
      * 댓글 삭제 (Soft Delete)
      */
     @Transactional
-    public void deleteComment(String email, Long commentId) {
-        User user = userRepository.findByEmail(email)
+    public void deleteComment(Long userId, Long commentId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         NestComment comment = nestCommentRepository.findById(commentId)
@@ -258,8 +258,8 @@ public class NestService {
      * ID 리스트 둥지 요약 정보 조회 (N+1 최적화)
      */
     @Transactional(readOnly = true)
-    public List<NestSummaryResponseDto> getNestsByIds(String email, List<Long> nestIds) {
-        User user = userRepository.findByEmail(email)
+    public List<NestSummaryResponseDto> getNestsByIds(Long userId, List<Long> nestIds) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         List<Nest> nests = nestRepository.findAllById(nestIds);
@@ -280,8 +280,8 @@ public class NestService {
      * 둥지 상세 정보 조회
      */
     @Transactional
-    public NestDetailResponseDto getNestDetail(String email, Long nestId) {
-        User user = userRepository.findByEmail(email)
+    public NestDetailResponseDto getNestDetail(Long userId, Long nestId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         Nest nest = nestRepository.findById(nestId)
@@ -322,8 +322,8 @@ public class NestService {
      * 둥지 ID로 댓글 리스트 조회 (트리 구조, N+1 문제 완벽 해결)
      */
     @Transactional(readOnly = true)
-    public List<CommentResponseDto> getCommentsByNestId(String currentUserEmail, Long nestId, String sortBy) {
-        User currentUser = currentUserEmail != null ? userRepository.findByEmail(currentUserEmail).orElse(null) : null;
+    public List<CommentResponseDto> getCommentsByNestId(Long currentUserId, Long nestId, String sortBy) {
+        User currentUser = currentUserId != null ? userRepository.findById(currentUserId).orElse(null) : null;
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
@@ -406,8 +406,8 @@ public class NestService {
      * 댓글 좋아요 처리 (Toggle 방식)
      */
     @Transactional
-    public void handleCommentLike(String email, Long commentId) {
-        User user = userRepository.findByEmail(email)
+    public void handleCommentLike(Long userId, Long commentId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         NestComment comment = nestCommentRepository.findById(commentId)
@@ -418,7 +418,7 @@ public class NestService {
         if (existingLike.isPresent()) {
             commentLikeRepository.delete(existingLike.get());
             comment.decreaseLikeCount();
-            log.info("댓글 좋아요 취소: User={}, Comment={}", email, commentId);
+            log.info("댓글 좋아요 취소: User={}, Comment={}", userId, commentId);
         } else {
             CommentLike like = CommentLike.builder()
                     .user(user)
@@ -426,7 +426,7 @@ public class NestService {
                     .build();
             commentLikeRepository.save(like);
             comment.increaseLikeCount();
-            log.info("댓글 좋아요 등록: User={}, Comment={}", email, commentId);
+            log.info("댓글 좋아요 등록: User={}, Comment={}", userId, commentId);
         }
     }
 
@@ -448,9 +448,9 @@ public class NestService {
      */
     @Transactional(readOnly = true)
     public Page<NestSummaryResponseDto> getNearNestsByCategory(
-            String email, Double latitude, Double longitude, Double radiusMeter, Long categoryId, Pageable pageable) {
+            Long userId, Double latitude, Double longitude, Double radiusMeter, Long categoryId, Pageable pageable) {
         
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         double radius = (radiusMeter != null) ? radiusMeter : 5000.0;
@@ -505,8 +505,8 @@ public class NestService {
      * 사용자 현재 위치 검증을 통한 둥지 해금
      */
     @Transactional
-    public void unlockNest(String email, Long nestId, NestUnlockRequestDto requestDto) {
-        User user = userRepository.findByEmail(email)
+    public void unlockNest(Long userId, Long nestId, NestUnlockRequestDto requestDto) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         Nest nest = nestRepository.findById(nestId)
@@ -531,15 +531,15 @@ public class NestService {
                 .build();
         
         unlockHistoryRepository.save(history);
-        log.info("둥지 해금 성공: User={}, Nest={}", email, nestId);
+        log.info("둥지 해금 성공: User={}, Nest={}", userId, nestId);
     }
 
     /**
      * 둥지에 대한 리액션(좋아요/싫어요) 등록, 수정 또는 취소
      */
     @Transactional
-    public void handleReaction(String email, Long nestId, ReactionType type) {
-        User user = userRepository.findByEmail(email)
+    public void handleReaction(Long userId, Long nestId, ReactionType type) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         Nest nest = nestRepository.findById(nestId)
@@ -556,11 +556,11 @@ public class NestService {
             if (reaction.getReactionType() == type) {
                 // 동일한 타입이면 취소(삭제)
                 nestReactionRepository.delete(reaction);
-                log.info("리액션 취소 완료: User={}, Nest={}, Type={}", email, nestId, type);
+                log.info("리액션 취소 완료: User={}, Nest={}, Type={}", userId, nestId, type);
             } else {
                 // 다른 타입이면 수정
                 reaction.setReactionType(type);
-                log.info("리액션 수정 완료: User={}, Nest={}, Type={}", email, nestId, type);
+                log.info("리액션 수정 완료: User={}, Nest={}, Type={}", userId, nestId, type);
             }
         } else {
             // 없으면 신규 등록
@@ -570,7 +570,7 @@ public class NestService {
                     .reactionType(type)
                     .build();
             nestReactionRepository.save(reaction);
-            log.info("리액션 등록 완료: User={}, Nest={}, Type={}", email, nestId, type);
+            log.info("리액션 등록 완료: User={}, Nest={}, Type={}", userId, nestId, type);
         }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/test/TestAuthController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/test/TestAuthController.java
@@ -5,19 +5,47 @@ import com.dodo.dodoserver.domain.auth.dto.TokenResponseDto;
 import com.dodo.dodoserver.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dodo.dodoserver.infrastructure.fcm.FcmService;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
-// @Profile({"local", "dev"})
 public class TestAuthController {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final ApplicationEventPublisher eventPublisher;
+    private final FcmService fcmService;
+
+    /**
+     * FCM 알림 전송 테스트 API
+     * @param token 대상 기기의 FCM 토큰
+     */
+    @PostMapping("/fcm")
+    @Transactional
+    public ApiResponseDto<String> testFcm(@RequestParam String token) {
+        NotificationEvent event = new NotificationEvent(
+                List.of(token),
+                "테스트 알림",
+                "서버에서 보낸 테스트 메시지입니다.",
+                Map.of("type", "TEST", "data", "hello")
+        );
+
+
+        eventPublisher.publishEvent(event);
+        return ApiResponseDto.success("알림 전송 이벤트를 발행했습니다. 로그를 확인하세요.");
+    }
 
     /**
      * 특정 이메일을 기반으로 테스트용 Access Token과 Refresh Token을 생성
@@ -29,7 +57,7 @@ public class TestAuthController {
             @RequestParam String email,
             @RequestParam(defaultValue = "ROLE_USER") String role) {
 
-        String accessToken = jwtTokenProvider.createAccessToken(email, role);
+        String accessToken = jwtTokenProvider.createAccessToken(1L, email, role);
         String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
         // 만료 시간은 임의로 1시간(3600L)으로 표시

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/DeviceController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/DeviceController.java
@@ -30,8 +30,7 @@ public class DeviceController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid DeviceRequestDto requestDto) {
 
-        userDeviceService.registerDevice(principal.getEmail(), requestDto);
+        userDeviceService.registerOrUpdateDevice(principal.getEmail(), requestDto);
         return ApiResponseDto.success("기기가 성공적으로 등록되었습니다.");
     }
-}
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/DeviceController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/DeviceController.java
@@ -5,14 +5,15 @@ import com.dodo.dodoserver.domain.user.dto.DeviceRequestDto;
 import com.dodo.dodoserver.domain.user.service.UserDeviceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 유저의 기기 및 FCM 토큰 등록/관리를 담당하는 컨트롤러
+ * 사용자 기기(FCM 토큰 등) 등록 및 관리를 담당하는 컨트롤러
  */
 @RestController
 @RequestMapping("/api/v1/devices")
@@ -22,16 +23,15 @@ public class DeviceController {
     private final UserDeviceService userDeviceService;
 
     /**
-     * 현재 로그인한 사용자의 새로운 기기를 등록하거나 기존 기기의 토큰 정보를 업데이트
+     * 새로운 기기(FCM 토큰)를 등록하거나 기존 정보를 갱신
      */
     @PostMapping
     public ApiResponseDto<String> registerDevice(
-            Authentication authentication,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid DeviceRequestDto requestDto) {
-        
-        String email = authentication.getName();
-        userDeviceService.registerOrUpdateDevice(email, requestDto);
-        
+
+        userDeviceService.registerDevice(principal.getEmail(), requestDto);
         return ApiResponseDto.success("기기가 성공적으로 등록되었습니다.");
     }
+}
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/DeviceController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/DeviceController.java
@@ -30,7 +30,7 @@ public class DeviceController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid DeviceRequestDto requestDto) {
 
-        userDeviceService.registerOrUpdateDevice(principal.getEmail(), requestDto);
+        userDeviceService.registerOrUpdateDevice(principal.getId(), requestDto);
         return ApiResponseDto.success("기기가 성공적으로 등록되었습니다.");
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
      */
     @GetMapping("/me")
     public ApiResponseDto<UserProfileResponseDto> getMyProfile(@AuthenticationPrincipal UserPrincipal principal) {
-        return ApiResponseDto.success(userService.getUserProfileByEmail(principal.getEmail()));
+        return ApiResponseDto.success(userService.getUserProfileById(principal.getId()));
     }
 
     /**
@@ -57,7 +57,7 @@ public class UserController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid ProfileUpdateRequestDto requestDto) {
 
-        userService.updateProfile(principal.getEmail(), requestDto);
+        userService.updateProfile(principal.getId(), requestDto);
 
         return ApiResponseDto.success("프로필 정보가 성공적으로 수정되었습니다.");
     }
@@ -70,7 +70,7 @@ public class UserController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid OnboardRequestDto requestDto) {
         
-        userService.onboard(principal.getEmail(), requestDto);
+        userService.onboard(principal.getId(), requestDto);
         
         return ApiResponseDto.success("온보딩이 완료되었습니다.");
     }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/UserController.java
@@ -6,7 +6,8 @@ import com.dodo.dodoserver.domain.user.dto.OnboardRequestDto;
 import com.dodo.dodoserver.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,9 +29,8 @@ public class UserController {
      * 현재 로그인된 유저의 상세 정보를 조회
      */
     @GetMapping("/me")
-    public ApiResponseDto<UserProfileResponseDto> getMyProfile(Authentication authentication) {
-        String email = authentication.getName();
-        return ApiResponseDto.success(userService.getUserProfileByEmail(email));
+    public ApiResponseDto<UserProfileResponseDto> getMyProfile(@AuthenticationPrincipal UserPrincipal principal) {
+        return ApiResponseDto.success(userService.getUserProfileByEmail(principal.getEmail()));
     }
 
     /**
@@ -54,11 +54,10 @@ public class UserController {
      */
     @PatchMapping("/profile")
     public ApiResponseDto<String> updateProfile(
-            Authentication authentication,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid ProfileUpdateRequestDto requestDto) {
 
-        String email = authentication.getName();
-        userService.updateProfile(email, requestDto);
+        userService.updateProfile(principal.getEmail(), requestDto);
 
         return ApiResponseDto.success("프로필 정보가 성공적으로 수정되었습니다.");
     }
@@ -68,11 +67,10 @@ public class UserController {
      */
     @PostMapping("/profile")
     public ApiResponseDto<String> postProfile(
-            Authentication authentication,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid OnboardRequestDto requestDto) {
         
-        String email = authentication.getName();
-        userService.onboard(email, requestDto);
+        userService.onboard(principal.getEmail(), requestDto);
         
         return ApiResponseDto.success("온보딩이 완료되었습니다.");
     }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
@@ -7,41 +7,40 @@ import com.dodo.dodoserver.global.common.ApiResponseDto;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 /**
- * 유저의 관심사(카테고리 매핑) 정보를 관리하는 컨트롤러
+ * 유저의 관심 카테고리 설정 및 조회를 담당하는 컨트롤러
  */
 @RestController
-@RequestMapping("/api/v1/users/interests")
+@RequestMapping("/api/v1/user-interests")
 @RequiredArgsConstructor
 public class UserInterestController {
 
     private final UserInterestService userInterestService;
 
     /**
-     * 현재 로그인한 사용자가 선택한 관심 카테고리 목록을 조회
+     * 현재 로그인한 유저의 관심 카테고리 목록을 조회
      */
     @GetMapping
-    public ApiResponseDto<List<CategoryResponseDto>> getMyInterests(Authentication authentication) {
-        String email = authentication.getName();
-        return ApiResponseDto.success(userInterestService.getMyInterests(email));
+    public ApiResponseDto<List<CategoryResponseDto>> getMyInterests(@AuthenticationPrincipal UserPrincipal principal) {
+        return ApiResponseDto.success(userInterestService.getUserInterests(principal.getEmail()));
     }
 
     /**
-     * 현재 로그인한 사용자의 관심 카테고리 리스트를 일괄 업데이트
+     * 유저의 관심 카테고리를 설정 (기존 정보는 삭제 후 새로 등록)
      */
-    @PutMapping
+    @PostMapping
     public ApiResponseDto<String> updateInterests(
-            Authentication authentication,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid UserInterestRequestDto requestDto) {
-        
-        String email = authentication.getName();
-        userInterestService.updateInterests(email, requestDto);
-        
+
+        userInterestService.updateUserInterests(principal.getEmail(), requestDto);
         return ApiResponseDto.success("관심 카테고리가 성공적으로 업데이트되었습니다.");
     }
+}
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
@@ -28,7 +28,7 @@ public class UserInterestController {
      */
     @GetMapping
     public ApiResponseDto<List<CategoryResponseDto>> getMyInterests(@AuthenticationPrincipal UserPrincipal principal) {
-        return ApiResponseDto.success(userInterestService.getUserInterests(principal.getEmail()));
+        return ApiResponseDto.success(userInterestService.getMyInterests(principal.getEmail()));
     }
 
     /**
@@ -39,8 +39,7 @@ public class UserInterestController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid UserInterestRequestDto requestDto) {
 
-        userInterestService.updateUserInterests(principal.getEmail(), requestDto);
+        userInterestService.updateInterests(principal.getEmail(), requestDto);
         return ApiResponseDto.success("관심 카테고리가 성공적으로 업데이트되었습니다.");
     }
-}
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
@@ -28,7 +28,7 @@ public class UserInterestController {
      */
     @GetMapping
     public ApiResponseDto<List<CategoryResponseDto>> getMyInterests(@AuthenticationPrincipal UserPrincipal principal) {
-        return ApiResponseDto.success(userInterestService.getMyInterests(principal.getEmail()));
+        return ApiResponseDto.success(userInterestService.getMyInterests(principal.getId()));
     }
 
     /**
@@ -39,7 +39,7 @@ public class UserInterestController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid UserInterestRequestDto requestDto) {
 
-        userInterestService.updateInterests(principal.getEmail(), requestDto);
+        userInterestService.updateInterests(principal.getId(), requestDto);
         return ApiResponseDto.success("관심 카테고리가 성공적으로 업데이트되었습니다.");
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/controller/UserInterestController.java
@@ -17,7 +17,7 @@ import java.util.List;
  * 유저의 관심 카테고리 설정 및 조회를 담당하는 컨트롤러
  */
 @RestController
-@RequestMapping("/api/v1/user-interests")
+@RequestMapping("/api/v1/users/interests")
 @RequiredArgsConstructor
 public class UserInterestController {
 
@@ -34,7 +34,7 @@ public class UserInterestController {
     /**
      * 유저의 관심 카테고리를 설정 (기존 정보는 삭제 후 새로 등록)
      */
-    @PostMapping
+    @PutMapping
     public ApiResponseDto<String> updateInterests(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid UserInterestRequestDto requestDto) {

--- a/src/main/java/com/dodo/dodoserver/domain/user/service/UserDeviceService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/service/UserDeviceService.java
@@ -28,12 +28,12 @@ public class UserDeviceService {
 
     /**
      * 유저의 기기를 등록하거나 기존 기기의 토큰 정보를 갱신
-     * @param email 유저 이메일 (AccessToken에서 추출)
+     * @param userId 유저 ID (AccessToken에서 추출)
      * @param requestDto 등록할 기기 정보
      */
     @Transactional
-    public void registerOrUpdateDevice(String email, DeviceRequestDto requestDto) {
-        User user = userRepository.findByEmail(email)
+    public void registerOrUpdateDevice(Long userId, DeviceRequestDto requestDto) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 이미 존재하는 토큰인지 확인
@@ -43,7 +43,7 @@ public class UserDeviceService {
                             device.setUser(user); // 주인이 바뀌었을 수도 있음
                             device.setDeviceType(requestDto.getDeviceType());
                             device.setLastActiveAt(LocalDateTime.now());
-                            log.info("기존 기기 토큰 정보 갱신: {}", user.getEmail());
+                            log.info("기존 기기 토큰 정보 갱신: {}", user.getId());
                         },
                         () -> {
                             UserDevice newDevice = UserDevice.builder()
@@ -52,7 +52,7 @@ public class UserDeviceService {
                                     .deviceType(requestDto.getDeviceType())
                                     .build();
                             userDeviceRepository.save(newDevice);
-                            log.info("신규 기기 토큰 등록: {}", user.getEmail());
+                            log.info("신규 기기 토큰 등록: {}", user.getId());
                         }
                 );
     }

--- a/src/main/java/com/dodo/dodoserver/domain/user/service/UserInterestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/service/UserInterestService.java
@@ -35,8 +35,8 @@ public class UserInterestService {
      * 현재 유저가 선택한 관심 카테고리 목록을 조회
      */
     @Transactional(readOnly = true)
-    public List<CategoryResponseDto> getMyInterests(String email) {
-        User user = userRepository.findByEmail(email)
+    public List<CategoryResponseDto> getMyInterests(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         return userInterestRepository.findByUserId(user.getId()).stream()
@@ -48,8 +48,8 @@ public class UserInterestService {
      * 유저의 모든 관심사를 삭제한 뒤 요청한 리스트로 다시 일괄 저장
      */
     @Transactional
-    public void updateInterests(String email, UserInterestRequestDto requestDto) {
-        User user = userRepository.findByEmail(email)
+    public void updateInterests(Long userId, UserInterestRequestDto requestDto) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
 
@@ -69,6 +69,6 @@ public class UserInterestService {
                 .collect(Collectors.toList());
 
         userInterestRepository.saveAll(newInterests);
-        log.info("유저 관심사 일괄 업데이트 완료: {}, 개수: {}", email, newInterests.size());
+        log.info("유저 관심사 일괄 업데이트 완료: {}, 개수: {}", userId, newInterests.size());
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/service/UserService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/service/UserService.java
@@ -41,8 +41,8 @@ public class UserService {
      * 사용자의 프로필 정보를 업데이트
      */
     @Transactional
-    public void updateProfile(String email, ProfileUpdateRequestDto requestDto) {
-        User user = userRepository.findByEmail(email)
+    public void updateProfile(Long userId, ProfileUpdateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         UserProfile userProfile = userProfileRepository.findByUser(user)
@@ -66,18 +66,18 @@ public class UserService {
             userProfile.setBio(requestDto.getBio());
         }
 
-        log.info("프로필 수정 완료: {}", email);
+        log.info("프로필 수정 완료: {}", userId);
     }
 
     /**
      * 구글 로그인 후 상세 정보(프로필, 기기 등)를 등록하고 가입
-     * @param email 사용자 이메일
+     * @param userId 사용자 ID
      * @param requestDto 온보딩 정보 (닉네임, 이미지, 소개, FCM 토큰, 관심 카테고리)
      */
     @Transactional
-    public void onboard(String email, OnboardRequestDto requestDto) {
+    public void onboard(Long userId, OnboardRequestDto requestDto) {
         // 유저 조회 및 상태 확인
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         if (user.isOnboarded()) {
@@ -103,28 +103,28 @@ public class UserService {
             requestDto.getFcmToken(),
             requestDto.getDeviceType()
         );
-        userDeviceService.registerOrUpdateDevice(email, deviceRequest);
+        userDeviceService.registerOrUpdateDevice(userId, deviceRequest);
 
         // 관심 카테고리 등록 (선택한 게 있을 경우)
         if (requestDto.getCategoryIds() != null && !requestDto.getCategoryIds().isEmpty()) {
             UserInterestRequestDto interestRequest = new UserInterestRequestDto(requestDto.getCategoryIds());
-            userInterestService.updateInterests(email, interestRequest);
+            userInterestService.updateInterests(userId, interestRequest);
         }
 
         // 온보딩 상태 완료 처리
         user.setOnboarded(true);
         user.setNickname(requestDto.getNickname());
 
-        log.info("온보딩 성공: {}", email);
+        log.info("온보딩 성공: {}", userId);
     }
 
     /**
-     * 사용자 상세 프로필 정보 조회
+     * 사용자 상세 프로필 정보 조회 (ID 기반)
      */
     @Transactional(readOnly = true)
-    public UserProfileResponseDto getUserProfileByEmail(String email) {
+    public UserProfileResponseDto getUserProfileById(Long userId) {
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         if (!user.isOnboarded()) {
@@ -134,5 +134,15 @@ public class UserService {
         UserProfile userProfile = userProfileRepository.findByUser(user).orElse(null);
 
         return UserProfileResponseDto.from(user, userProfile);
+    }
+
+    /**
+     * 사용자 상세 프로필 정보 조회 (이메일 기반)
+     */
+    @Transactional(readOnly = true)
+    public UserProfileResponseDto getUserProfileByEmail(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return getUserProfileById(user.getId());
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/service/UserService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/service/UserService.java
@@ -123,17 +123,9 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public UserProfileResponseDto getUserProfileById(Long userId) {
-
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if (!user.isOnboarded()) {
-            throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
-        }
-
-        UserProfile userProfile = userProfileRepository.findByUser(user).orElse(null);
-
-        return UserProfileResponseDto.from(user, userProfile);
+        return getUserProfileByUser(user);
     }
 
     /**
@@ -143,6 +135,16 @@ public class UserService {
     public UserProfileResponseDto getUserProfileByEmail(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        return getUserProfileById(user.getId());
+        return getUserProfileByUser(user);
+    }
+
+    private UserProfileResponseDto getUserProfileByUser(User user) {
+        if (!user.isOnboarded()) {
+            throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
+        }
+
+        UserProfile userProfile = userProfileRepository.findByUser(user).orElse(null);
+
+        return UserProfileResponseDto.from(user, userProfile);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/global/common/util/HashIdUtils.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/util/HashIdUtils.java
@@ -1,0 +1,39 @@
+package com.dodo.dodoserver.global.common.util;
+
+import org.hashids.Hashids;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * DB PK(Long)를 난독화된 문자열로 변환하거나 복구하는 유틸리티
+ */
+@Component
+public class HashIdUtils {
+
+    private final Hashids hashids;
+
+    public HashIdUtils(@Value("${hashids.salt:dodo-salt-key}") String salt) {
+        // 최소 8자리 이상의 문자열이 생성되도록 설정
+        this.hashids = new Hashids(salt, 8);
+    }
+
+    /**
+     * Long ID를 난독화된 문자열로 변환
+     */
+    public String encode(Long id) {
+        if (id == null) return null;
+        return hashids.encode(id);
+    }
+
+    /**
+     * 난독화된 문자열을 다시 Long ID로 복구
+     */
+    public Long decode(String hash) {
+        if (hash == null || hash.isEmpty()) return null;
+        long[] decoded = hashids.decode(hash);
+        if (decoded.length > 0) {
+            return decoded[0];
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/CustomOAuth2UserService.java
@@ -40,10 +40,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         User user = saveOrUpdate(provider, providerId, email, nickname);
 
         // Spring Security에서 사용할 인증 객체를 생성하여 반환합니다.
-        return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey())),
-                oAuth2User.getAttributes(),
-                "sub" // PK로 사용할 속성명 지정
+        return UserPrincipal.create(
+                user.getId(),
+                user.getEmail(),
+                user.getRole().getKey(),
+                oAuth2User.getAttributes()
         );
     }
 

--- a/src/main/java/com/dodo/dodoserver/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/JwtTokenProvider.java
@@ -47,22 +47,26 @@ public class JwtTokenProvider {
     /**
      * API 호출 인증용 Access Token 생성
      */
-    public String createAccessToken(String email, String role) {
-        return createToken(email, role, accessTokenExpiration);
+    public String createAccessToken(Long userId, String email, String role) {
+        return createToken(userId, email, role, accessTokenExpiration);
     }
 
     /**
      * Access Token 재발급용 Refresh Token 생성 (권한 정보 미포함)
      */
     public String createRefreshToken(String email) {
-        return createToken(email, null, refreshTokenExpiration);
+        return createToken(null, email, null, refreshTokenExpiration);
     }
 
     /**
      * JWT 토큰 빌드 공통 로직
      */
-    private String createToken(String email, String role, long expiration) {
+    private String createToken(Long userId, String email, String role, long expiration) {
         var claimsBuilder = Jwts.claims().subject(email);
+        
+        if (userId != null) {
+            claimsBuilder.add("userId", userId);
+        }
         
         if (role != null) {
             claimsBuilder.add("role", role); // Access Token에만 권한 정보 포함
@@ -85,9 +89,12 @@ public class JwtTokenProvider {
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
         String email = claims.getSubject();
+        Long userId = claims.get("userId", Long.class);
         String role = claims.get("role", String.class);
-        return new UsernamePasswordAuthenticationToken(email, "", 
-                Collections.singleton(new SimpleGrantedAuthority(role)));
+
+        UserPrincipal principal = UserPrincipal.create(userId, email, role);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/JwtTokenProvider.java
@@ -5,16 +5,17 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+
+import com.dodo.dodoserver.global.common.util.HashIdUtils;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Date;
 
 /**
@@ -22,7 +23,10 @@ import java.util.Date;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider {
+
+    private final HashIdUtils hashIdUtils;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -65,7 +69,8 @@ public class JwtTokenProvider {
         var claimsBuilder = Jwts.claims().subject(email);
         
         if (userId != null) {
-            claimsBuilder.add("userId", userId);
+            // ID 난독화 적용
+            claimsBuilder.add("uid", hashIdUtils.encode(userId));
         }
         
         if (role != null) {
@@ -89,8 +94,11 @@ public class JwtTokenProvider {
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
         String email = claims.getSubject();
-        Long userId = claims.get("userId", Long.class);
+        String encodedId = claims.get("uid", String.class);
         String role = claims.get("role", String.class);
+
+        // ID 복호화 적용
+        Long userId = hashIdUtils.decode(encodedId);
 
         UserPrincipal principal = UserPrincipal.create(userId, email, role);
 

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -46,7 +46,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .map(GrantedAuthority::getAuthority)
                 .orElse("ROLE_USER");
 
-        String accessToken = tokenProvider.createAccessToken(email, role);
+        String accessToken = tokenProvider.createAccessToken(user.getId(), email, role);
         String refreshToken = tokenProvider.createRefreshToken(email);
         authService.saveRefreshToken(email, refreshToken);
 

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -35,16 +35,13 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        String email = oAuth2User.getAttribute("email");
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        String email = principal.getEmail();
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
-        String role = authentication.getAuthorities().stream()
-                .findFirst()
-                .map(GrantedAuthority::getAuthority)
-                .orElse("ROLE_USER");
+        String role = principal.getRole();
 
         String accessToken = tokenProvider.createAccessToken(user.getId(), email, role);
         String refreshToken = tokenProvider.createRefreshToken(email);

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -45,7 +45,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         String accessToken = tokenProvider.createAccessToken(user.getId(), email, role);
         String refreshToken = tokenProvider.createRefreshToken(email);
-        authService.saveRefreshToken(email, refreshToken);
+        authService.saveRefreshToken(user.getId(), refreshToken);
 
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -11,8 +11,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -36,15 +34,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
-        String email = principal.getEmail();
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findById(principal.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         String role = principal.getRole();
 
-        String accessToken = tokenProvider.createAccessToken(user.getId(), email, role);
-        String refreshToken = tokenProvider.createRefreshToken(email);
+        String accessToken = tokenProvider.createAccessToken(user.getId(), user.getEmail(), role);
+        String refreshToken = tokenProvider.createRefreshToken(user.getEmail());
         authService.saveRefreshToken(user.getId(), refreshToken);
 
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/dodo/dodoserver/global/security/UserPrincipal.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/UserPrincipal.java
@@ -1,0 +1,98 @@
+package com.dodo.dodoserver.global.security;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Spring Security 컨텍스트에서 사용될 커스텀 인증 객체
+ * DB 조회 없이 컨트롤러에서 즉시 유저 ID와 이메일을 사용할 수 있도록 지원합니다.
+ */
+@Getter
+public class UserPrincipal implements UserDetails, OAuth2User {
+
+    private final Long id;
+    private final String email;
+    private final String role;
+    private final Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    @Builder
+    public UserPrincipal(Long id, String email, String role, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.role = role;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(Long id, String email, String role) {
+        return UserPrincipal.builder()
+                .id(id)
+                .email(email)
+                .role(role)
+                .authorities(Collections.singletonList(new SimpleGrantedAuthority(role)))
+                .build();
+    }
+
+    public static UserPrincipal create(Long id, String email, String role, Map<String, Object> attributes) {
+        UserPrincipal userPrincipal = UserPrincipal.create(id, email, role);
+        userPrincipal.setAttributes(attributes);
+        return userPrincipal;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // OAuth2 로그인이므로 패스워드 미사용
+    }
+
+    @Override
+    public String getUsername() {
+        return email; // Username으로 이메일 사용
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/auth/controller/AuthControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -72,7 +72,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("토큰 재발급 성공 - 온보딩 상태 포함 확인")
-    @WithMockUser
+    @WithMockUserPrincipal
     void reissue_success() throws Exception {
         // given
         TokenReissueRequestDto requestDto = new TokenReissueRequestDto("refresh-token");
@@ -98,7 +98,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("로그아웃 성공")
-    @WithMockUser(username = "test@example.com")
+    @WithMockUserPrincipal(email = "test@example.com")
     void logout_success() throws Exception {
         // when & then
         mockMvc.perform(post("/api/v1/auth/logout")

--- a/src/test/java/com/dodo/dodoserver/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/auth/service/AuthServiceTest.java
@@ -48,22 +48,21 @@ class AuthServiceTest {
         String email = "test@example.com";
 
         User user = User.builder()
+                .id(1L)
                 .email(email)
                 .role(Role.USER)
                 .isOnboarded(true)
                 .build();
-
         RefreshToken storedToken = RefreshToken.builder()
                 .email(email)
                 .token(oldRefreshToken)
                 .build();
-
-        given(tokenProvider.validateToken(oldRefreshToken)).willReturn(true);
-        given(refreshTokenRepository.findByToken(oldRefreshToken)).willReturn(Optional.of(storedToken));
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
-        given(tokenProvider.createAccessToken(email, user.getRole().getKey())).willReturn(newAccessToken);
-        given(tokenProvider.createRefreshToken(email)).willReturn(newRefreshToken);
-        given(tokenProvider.getAccessTokenExpiration()).willReturn(3600L);
+given(tokenProvider.validateToken(oldRefreshToken)).willReturn(true);
+given(refreshTokenRepository.findByToken(oldRefreshToken)).willReturn(Optional.of(storedToken));
+given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+given(tokenProvider.createAccessToken(user.getId(), email, user.getRole().getKey())).willReturn(newAccessToken);
+given(tokenProvider.createRefreshToken(email)).willReturn(newRefreshToken);
+given(tokenProvider.getAccessTokenExpiration()).willReturn(3600L);
 
         // when
         TokenResponseDto response = authService.reissue(oldRefreshToken);

--- a/src/test/java/com/dodo/dodoserver/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/auth/service/AuthServiceTest.java
@@ -54,15 +54,16 @@ class AuthServiceTest {
                 .isOnboarded(true)
                 .build();
         RefreshToken storedToken = RefreshToken.builder()
-                .email(email)
+                .userId(1L)
                 .token(oldRefreshToken)
                 .build();
-given(tokenProvider.validateToken(oldRefreshToken)).willReturn(true);
-given(refreshTokenRepository.findByToken(oldRefreshToken)).willReturn(Optional.of(storedToken));
-given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
-given(tokenProvider.createAccessToken(user.getId(), email, user.getRole().getKey())).willReturn(newAccessToken);
-given(tokenProvider.createRefreshToken(email)).willReturn(newRefreshToken);
-given(tokenProvider.getAccessTokenExpiration()).willReturn(3600L);
+
+        given(tokenProvider.validateToken(oldRefreshToken)).willReturn(true);
+        given(refreshTokenRepository.findByToken(oldRefreshToken)).willReturn(Optional.of(storedToken));
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(tokenProvider.createAccessToken(user.getId(), email, user.getRole().getKey())).willReturn(newAccessToken);
+        given(tokenProvider.createRefreshToken(email)).willReturn(newRefreshToken);
+        given(tokenProvider.getAccessTokenExpiration()).willReturn(3600L);
 
         // when
         TokenResponseDto response = authService.reissue(oldRefreshToken);
@@ -99,5 +100,18 @@ given(tokenProvider.getAccessTokenExpiration()).willReturn(3600L);
         assertThatThrownBy(() -> authService.reissue(refreshToken))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logout_success() {
+        // given
+        Long userId = 1L;
+
+        // when
+        authService.logout(userId);
+
+        // then
+        verify(refreshTokenRepository, times(1)).deleteById(userId);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/category/controller/CategoryControllerTest.java
@@ -16,7 +16,7 @@ import com.dodo.dodoserver.global.config.SecurityConfig;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -85,7 +85,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("카테고리 생성 성공 - ADMIN 권한 필요")
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
     void createCategory_success() throws Exception {
         // given
         CategoryRequestDto requestDto = new CategoryRequestDto("운동");
@@ -106,7 +106,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("카테고리 생성 실패 - 권한 없음(USER)")
-    @WithMockUser(roles = "USER")
+    @WithMockUserPrincipal(role = "ROLE_USER")
     void createCategory_fail_forbidden() throws Exception {
         // given
         CategoryRequestDto requestDto = new CategoryRequestDto("운동");
@@ -121,7 +121,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("전체 카테고리 조회 성공 - 인증된 사용자")
-    @WithMockUser
+    @WithMockUserPrincipal
     void getAllCategories_success() throws Exception {
         // given
         CategoryResponseDto res1 = new CategoryResponseDto(1L, "운동", LocalDateTime.now());
@@ -139,7 +139,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("카테고리 수정 성공 - ADMIN 권한")
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
     void updateCategory_success() throws Exception {
         // given
         Long categoryId = 1L;
@@ -159,7 +159,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("카테고리 삭제 성공 - ADMIN 권한")
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
     void deleteCategory_success() throws Exception {
         // given
         Long categoryId = 1L;
@@ -173,7 +173,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("카테고리 생성 실패 - 유효성 검증 오류 (이름 누락)")
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
     void createCategory_fail_invalidInput() throws Exception {
         // given
         CategoryRequestDto requestDto = new CategoryRequestDto("");
@@ -189,7 +189,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("카테고리 수정 실패 - 권한 없음(USER)")
-    @WithMockUser(roles = "USER")
+    @WithMockUserPrincipal(role = "ROLE_USER")
     void updateCategory_fail_forbidden() throws Exception {
         // given
         Long categoryId = 1L;
@@ -205,7 +205,7 @@ class CategoryControllerTest {
 
     @Test
     @DisplayName("카테고리 삭제 실패 - 권한 없음(USER)")
-    @WithMockUser(roles = "USER")
+    @WithMockUserPrincipal(role = "ROLE_USER")
     void deleteCategory_fail_forbidden() throws Exception {
         // given
         Long categoryId = 1L;

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestGpsControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestGpsControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -76,7 +76,7 @@ class NestGpsControllerTest {
 
     @Test
     @DisplayName("둥지 해금 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void unlockNest_success() throws Exception {
         Long nestId = 1L;
         NestUnlockRequestDto requestDto = new NestUnlockRequestDto(37.5, 127.0);
@@ -91,7 +91,7 @@ class NestGpsControllerTest {
 
     @Test
     @DisplayName("둥지 요약 정보 리스트 조회 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void getNestsByIds_success() throws Exception {
         List<Long> ids = List.of(1L, 2L);
         NestSummaryResponseDto summary = NestSummaryResponseDto.builder().id(1L).title("테스트").build();
@@ -105,7 +105,7 @@ class NestGpsControllerTest {
 
     @Test
     @DisplayName("반경 내 둥지 목록 조회 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void getNearbyNests_success() throws Exception {
         NestSummaryResponseDto summary = NestSummaryResponseDto.builder().id(1L).title("테스트").build();
         Page<NestSummaryResponseDto> page = new PageImpl<>(List.of(summary));
@@ -121,7 +121,7 @@ class NestGpsControllerTest {
 
     @Test
     @DisplayName("주변 핀 조회 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void getNearbyPins_success() throws Exception {
         NestPinResponseDto pin = new NestPinResponseDto(1L, 37.5, 127.0);
         given(nestService.getNearbyPins(any(), any(), any())).willReturn(List.of(pin));

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -75,7 +75,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("둥지 생성 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void createNest_success() throws Exception {
         NestCreateRequestDto requestDto = new NestCreateRequestDto("새둥지", "내용", 37.5, 127.0, 100, List.of(1L), List.of("url"), false);
         NestSummaryResponseDto responseDto = NestSummaryResponseDto.builder().id(1L).title("새둥지").build();
@@ -92,7 +92,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("둥지 상세 조회 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void getNestDetail_success() throws Exception {
         Long nestId = 1L;
         NestDetailResponseDto responseDto = NestDetailResponseDto.builder().id(nestId).title("상세조회").build();
@@ -106,7 +106,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("둥지 댓글 리스트 조회 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void getComments_success() throws Exception {
         Long nestId = 1L;
         CommentResponseDto comment = CommentResponseDto.builder().id(10L).content("댓글").build();
@@ -120,7 +120,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("댓글 좋아요 처리 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void handleCommentLike_success() throws Exception {
         Long commentId = 10L;
 
@@ -132,7 +132,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("둥지 수정 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void updateNest_success() throws Exception {
         Long nestId = 1L;
         NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", null, null, null, null);
@@ -150,7 +150,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("둥지 삭제 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void deleteNest_success() throws Exception {
         Long nestId = 1L;
 
@@ -162,7 +162,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("댓글 작성 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void createComment_success() throws Exception {
         Long nestId = 1L;
         CommentCreateRequestDto requestDto = new CommentCreateRequestDto("댓글내용", null);
@@ -177,7 +177,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("댓글 수정 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void updateComment_success() throws Exception {
         Long commentId = 10L;
         CommentUpdateRequestDto requestDto = new CommentUpdateRequestDto("수정내용");
@@ -192,7 +192,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("댓글 삭제 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void deleteComment_success() throws Exception {
         Long commentId = 10L;
 
@@ -204,7 +204,7 @@ class NestPostControllerTest {
 
     @Test
     @DisplayName("리액션 처리 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void handleReaction_success() throws Exception {
         Long nestId = 1L;
 

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -78,10 +78,10 @@ class NestServiceTest {
     @DisplayName("둥지 생성 성공")
     void createNest_success() {
         NestCreateRequestDto requestDto = new NestCreateRequestDto("제목", "내용", 37.5, 127.0, 100, null, null, false);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.save(any(Nest.class))).willAnswer(inv -> (Nest) inv.getArgument(0));
 
-        NestSummaryResponseDto response = nestService.createNest(email, requestDto);
+        NestSummaryResponseDto response = nestService.createNest(user.getId(), requestDto);
 
         assertThat(response.getTitle()).isEqualTo("제목");
         verify(nestRepository).save(any(Nest.class));
@@ -94,10 +94,10 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).creator(user).title("기존제목").images(new ArrayList<>()).build();
         NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", "수정내용", 200, null, null);
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
-        NestSummaryResponseDto response = nestService.updateNest(email, nestId, requestDto);
+        NestSummaryResponseDto response = nestService.updateNest(user.getId(), nestId, requestDto);
 
         assertThat(response.getTitle()).isEqualTo("수정제목");
         assertThat(nest.getContent()).isEqualTo("수정내용");
@@ -111,10 +111,10 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).creator(other).build();
         NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", null, null, null, null);
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
-        assertThatThrownBy(() -> nestService.updateNest(email, nestId, requestDto))
+        assertThatThrownBy(() -> nestService.updateNest(user.getId(), nestId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.NOT_NEST_CREATOR.getMessage());
     }
@@ -125,10 +125,10 @@ class NestServiceTest {
         Long nestId = 1L;
         Nest nest = Nest.builder().id(nestId).creator(user).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
-        nestService.deleteNest(email, nestId);
+        nestService.deleteNest(user.getId(), nestId);
 
         verify(nestRepository).delete(nest);
     }
@@ -140,10 +140,10 @@ class NestServiceTest {
         User other = User.builder().id(2L).build();
         Nest nest = Nest.builder().id(nestId).creator(other).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
-        assertThatThrownBy(() -> nestService.deleteNest(email, nestId))
+        assertThatThrownBy(() -> nestService.deleteNest(user.getId(), nestId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.NOT_NEST_CREATOR.getMessage());
     }
@@ -158,12 +158,12 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).creator(creator).unlockRadius(100).build();
         NestUnlockRequestDto requestDto = new NestUnlockRequestDto(37.5, 127.0);
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(false);
         given(nestRepository.calculateDistance(eq(nestId), any(Point.class))).willReturn(50.0);
 
-        nestService.unlockNest(email, nestId, requestDto);
+        nestService.unlockNest(user.getId(), nestId, requestDto);
 
         verify(unlockHistoryRepository).save(any(UnlockHistory.class));
     }
@@ -176,11 +176,11 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).creator(creator).build();
         NestUnlockRequestDto requestDto = new NestUnlockRequestDto(37.5, 127.0);
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
 
-        assertThatThrownBy(() -> nestService.unlockNest(email, nestId, requestDto))
+        assertThatThrownBy(() -> nestService.unlockNest(user.getId(), nestId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_UNLOCKED.getMessage());
     }
@@ -192,10 +192,10 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).creator(user).build();
         NestUnlockRequestDto requestDto = new NestUnlockRequestDto(37.5, 127.0);
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
-        assertThatThrownBy(() -> nestService.unlockNest(email, nestId, requestDto))
+        assertThatThrownBy(() -> nestService.unlockNest(user.getId(), nestId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_UNLOCKED.getMessage());
     }
@@ -207,13 +207,13 @@ class NestServiceTest {
         User creator = User.builder().id(2L).nickname("작성자").build();
         Nest nest = Nest.builder().id(nestId).title("비밀").content("내용").creator(creator).images(new ArrayList<>()).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(false);
         given(userProfileRepository.findByUser(creator)).willReturn(Optional.empty());
         given(nestCategoryRepository.findAllByNest(nest)).willReturn(new ArrayList<>());
 
-        NestDetailResponseDto response = nestService.getNestDetail(email, nestId);
+        NestDetailResponseDto response = nestService.getNestDetail(user.getId(), nestId);
 
         assertThat(response.getContent()).isEqualTo("내용");
         assertThat(response.isUnlocked()).isFalse();
@@ -226,13 +226,13 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).build();
         NestComment comment = NestComment.builder().id(10L).user(user).content("댓글").children(new ArrayList<>()).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(nestCommentRepository.findAllByNestWithUser(nest)).willReturn(List.of(comment));
         given(userProfileRepository.findAllByUserIn(any())).willReturn(new ArrayList<>());
         given(commentLikeRepository.findAllByUserAndCommentIn(any(), any())).willReturn(new ArrayList<>());
 
-        List<CommentResponseDto> result = nestService.getCommentsByNestId(email, nestId, "DEFAULT");
+        List<CommentResponseDto> result = nestService.getCommentsByNestId(user.getId(), nestId, "DEFAULT");
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getContent()).isEqualTo("댓글");
@@ -244,11 +244,11 @@ class NestServiceTest {
         Long commentId = 10L;
         NestComment comment = NestComment.builder().id(commentId).user(user).likeCount(0L).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
         given(commentLikeRepository.findByUserAndComment(user, comment)).willReturn(Optional.empty());
 
-        nestService.handleCommentLike(email, commentId);
+        nestService.handleCommentLike(user.getId(), commentId);
 
         assertThat(comment.getLikeCount()).isEqualTo(1L);
         verify(commentLikeRepository).save(any(CommentLike.class));
@@ -261,11 +261,11 @@ class NestServiceTest {
         NestComment comment = NestComment.builder().id(commentId).user(user).likeCount(1L).build();
         CommentLike like = CommentLike.builder().user(user).comment(comment).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
         given(commentLikeRepository.findByUserAndComment(user, comment)).willReturn(Optional.of(like));
 
-        nestService.handleCommentLike(email, commentId);
+        nestService.handleCommentLike(user.getId(), commentId);
 
         assertThat(comment.getLikeCount()).isEqualTo(0L);
         verify(commentLikeRepository).delete(like);
@@ -280,10 +280,10 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).creator(user).build();
         CommentCreateRequestDto requestDto = new CommentCreateRequestDto("댓글내용", null);
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
-        nestService.createComment(email, nestId, requestDto);
+        nestService.createComment(user.getId(), nestId, requestDto);
 
         verify(nestCommentRepository).save(any(NestComment.class));
             verify(nestNotificationService).sendCommentNotification(any(), any(), any(), any());
@@ -300,11 +300,11 @@ class NestServiceTest {
         NestComment parentComment = NestComment.builder().id(10L).nest(otherNest).build();
         CommentCreateRequestDto requestDto = new CommentCreateRequestDto("내용", 10L);
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(nestCommentRepository.findById(10L)).willReturn(Optional.of(parentComment));
 
-        assertThatThrownBy(() -> nestService.createComment(email, nestId, requestDto))
+        assertThatThrownBy(() -> nestService.createComment(user.getId(), nestId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.INVALID_INPUT_VALUE.getMessage());
     }
@@ -316,10 +316,10 @@ class NestServiceTest {
         NestComment comment = NestComment.builder().id(commentId).user(user).content("기존내용").build();
         CommentUpdateRequestDto requestDto = new CommentUpdateRequestDto("수정내용");
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
 
-        nestService.updateComment(email, commentId, requestDto);
+        nestService.updateComment(user.getId(), commentId, requestDto);
 
         assertThat(comment.getContent()).isEqualTo("수정내용");
     }
@@ -332,10 +332,10 @@ class NestServiceTest {
         NestComment comment = NestComment.builder().id(commentId).user(other).build();
         CommentUpdateRequestDto requestDto = new CommentUpdateRequestDto("수정내용");
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
 
-        assertThatThrownBy(() -> nestService.updateComment(email, commentId, requestDto))
+        assertThatThrownBy(() -> nestService.updateComment(user.getId(), commentId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.HANDLE_ACCESS_DENIED.getMessage());
     }
@@ -346,10 +346,10 @@ class NestServiceTest {
         Long commentId = 10L;
         NestComment comment = NestComment.builder().id(commentId).user(user).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
 
-        nestService.deleteComment(email, commentId);
+        nestService.deleteComment(user.getId(), commentId);
 
         verify(nestCommentRepository).delete(comment);
     }
@@ -362,11 +362,11 @@ class NestServiceTest {
         Long nestId = 1L;
         Nest nest = Nest.builder().id(nestId).creator(user).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(nestReactionRepository.findByUserAndNest(user, nest)).willReturn(Optional.empty());
 
-        nestService.handleReaction(email, nestId, ReactionType.LIKE);
+        nestService.handleReaction(user.getId(), nestId, ReactionType.LIKE);
 
         verify(nestReactionRepository).save(any(NestReaction.class));
     }
@@ -378,11 +378,11 @@ class NestServiceTest {
         Nest nest = Nest.builder().id(nestId).creator(user).build();
         NestReaction reaction = NestReaction.builder().user(user).nest(nest).reactionType(ReactionType.LIKE).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(nestReactionRepository.findByUserAndNest(user, nest)).willReturn(Optional.of(reaction));
 
-        nestService.handleReaction(email, nestId, ReactionType.LIKE);
+        nestService.handleReaction(user.getId(), nestId, ReactionType.LIKE);
 
         verify(nestReactionRepository).delete(reaction);
     }
@@ -396,11 +396,11 @@ class NestServiceTest {
         Nest n1 = Nest.builder().id(1L).creator(user).images(new ArrayList<>()).build();
         Nest n2 = Nest.builder().id(2L).creator(user).images(new ArrayList<>()).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findAllById(ids)).willReturn(List.of(n1, n2));
         given(unlockHistoryRepository.findAllByUserAndNestIn(eq(user), any())).willReturn(new ArrayList<>());
 
-        List<NestSummaryResponseDto> result = nestService.getNestsByIds(email, ids);
+        List<NestSummaryResponseDto> result = nestService.getNestsByIds(user.getId(), ids);
 
         assertThat(result).hasSize(2);
     }

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/DeviceControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/DeviceControllerTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
@@ -71,7 +71,7 @@ class DeviceControllerTest {
 
     @Test
     @DisplayName("기기 등록 성공")
-    @WithMockUser(username = "test@example.com")
+    @WithMockUserPrincipal(email = "test@example.com")
     void registerDevice_success() throws Exception {
         // given
         DeviceRequestDto requestDto = new DeviceRequestDto("fcm-token", DeviceType.ANDROID);

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/UserControllerTest.java
@@ -74,14 +74,14 @@ class UserControllerTest {
 
     @Test
     @DisplayName("내 프로필 조회 성공")
-    @WithMockUserPrincipal(email = "test@example.com")
+    @WithMockUserPrincipal(id = 1L, email = "test@example.com")
     void getMyProfile_success() throws Exception {
         // given
         UserProfileResponseDto responseDto = UserProfileResponseDto.builder()
                 .email("test@example.com")
                 .nickname("테스터")
                 .build();
-        given(userService.getUserProfileByEmail("test@example.com")).willReturn(responseDto);
+        given(userService.getUserProfileById(1L)).willReturn(responseDto);
 
         // when & then
         mockMvc.perform(get("/api/v1/users/me"))

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/UserControllerTest.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -74,7 +74,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("내 프로필 조회 성공")
-    @WithMockUser(username = "test@example.com")
+    @WithMockUserPrincipal(email = "test@example.com")
     void getMyProfile_success() throws Exception {
         // given
         UserProfileResponseDto responseDto = UserProfileResponseDto.builder()
@@ -92,7 +92,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("닉네임 중복 체크 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void checkNickname_success() throws Exception {
         // given
         given(userService.existsByNickname("이미있는닉네임")).willReturn(true);
@@ -106,7 +106,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("프로필 수정 성공")
-    @WithMockUser(username = "test@example.com")
+    @WithMockUserPrincipal(email = "test@example.com")
     void updateProfile_success() throws Exception {
         // given
         ProfileUpdateRequestDto requestDto = new ProfileUpdateRequestDto("새닉네임", null, "새소개");
@@ -122,7 +122,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("온보딩 성공")
-    @WithMockUser(username = "new@example.com")
+    @WithMockUserPrincipal(email = "new@example.com")
     void postProfile_success() throws Exception {
         // given
         OnboardRequestDto requestDto = new OnboardRequestDto(
@@ -140,7 +140,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("온보딩 실패 - 입력값 검증 오류 (닉네임 누락)")
-    @WithMockUser(username = "new@example.com")
+    @WithMockUserPrincipal(email = "new@example.com")
     void postProfile_fail_invalidInput() throws Exception {
         // given
         OnboardRequestDto requestDto = new OnboardRequestDto(
@@ -159,7 +159,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("특정 유저 상세 조회 성공")
-    @WithMockUser
+    @WithMockUserPrincipal
     void getUserProfile_success() throws Exception {
         // given
         String email = "other@example.com";

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -32,7 +32,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -74,14 +74,14 @@ class UserInterestControllerTest {
 
     @Test
     @DisplayName("내 관심사 조회 성공")
-    @WithMockUser(username = "test@example.com")
+    @WithMockUserPrincipal(email = "test@example.com")
     void getMyInterests_success() throws Exception {
         // given
         List<CategoryResponseDto> responseDtos = List.of(new CategoryResponseDto(1L, "카페", null));
         given(userInterestService.getMyInterests("test@example.com")).willReturn(responseDtos);
 
         // when & then
-        mockMvc.perform(get("/api/v1/users/interests"))
+        mockMvc.perform(get("/api/v1/user-interests"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data[0].name").value("카페"));
@@ -89,13 +89,13 @@ class UserInterestControllerTest {
 
     @Test
     @DisplayName("관심사 업데이트 성공")
-    @WithMockUser(username = "test@example.com")
+    @WithMockUserPrincipal(email = "test@example.com")
     void updateInterests_success() throws Exception {
         // given
         UserInterestRequestDto requestDto = new UserInterestRequestDto(List.of(1L, 2L));
 
         // when & then
-        mockMvc.perform(put("/api/v1/users/interests")
+        mockMvc.perform(post("/api/v1/user-interests")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -81,7 +81,7 @@ class UserInterestControllerTest {
         given(userInterestService.getMyInterests(1L)).willReturn(responseDtos);
 
         // when & then
-        mockMvc.perform(get("/api/v1/user-interests"))
+        mockMvc.perform(get("/api/v1/users/interests"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data[0].name").value("카페"));
@@ -95,7 +95,7 @@ class UserInterestControllerTest {
         UserInterestRequestDto requestDto = new UserInterestRequestDto(List.of(1L, 2L));
 
         // when & then
-        mockMvc.perform(post("/api/v1/user-interests")
+        mockMvc.perform(put("/api/v1/users/interests")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
@@ -78,7 +78,7 @@ class UserInterestControllerTest {
     void getMyInterests_success() throws Exception {
         // given
         List<CategoryResponseDto> responseDtos = List.of(new CategoryResponseDto(1L, "카페", null));
-        given(userInterestService.getMyInterests("test@example.com")).willReturn(responseDtos);
+        given(userInterestService.getMyInterests(1L)).willReturn(responseDtos);
 
         // when & then
         mockMvc.perform(get("/api/v1/user-interests"))

--- a/src/test/java/com/dodo/dodoserver/domain/user/service/UserDeviceServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/service/UserDeviceServiceTest.java
@@ -39,15 +39,15 @@ class UserDeviceServiceTest {
     @DisplayName("기기 등록 성공 - 신규")
     void registerOrUpdateDevice_new() {
         // given
-        String email = "test@example.com";
+        Long userId = 1L;
         DeviceRequestDto requestDto = new DeviceRequestDto("fcm-token", DeviceType.ANDROID);
-        User user = User.builder().email(email).build();
+        User user = User.builder().id(userId).email("test@example.com").build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userDeviceRepository.findByFcmToken("fcm-token")).willReturn(Optional.empty());
 
         // when
-        userDeviceService.registerOrUpdateDevice(email, requestDto);
+        userDeviceService.registerOrUpdateDevice(userId, requestDto);
 
         // then
         verify(userDeviceRepository, times(1)).save(any(UserDevice.class));
@@ -57,19 +57,19 @@ class UserDeviceServiceTest {
     @DisplayName("기기 등록 성공 - 기존 갱신")
     void registerOrUpdateDevice_update() {
         // given
-        String email = "test@example.com";
+        Long userId = 1L;
         DeviceRequestDto requestDto = new DeviceRequestDto("existing-token", DeviceType.IOS);
-        User user = User.builder().email(email).build();
+        User user = User.builder().id(userId).email("test@example.com").build();
         UserDevice existingDevice = UserDevice.builder()
                 .fcmToken("existing-token")
                 .deviceType(DeviceType.ANDROID)
                 .build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userDeviceRepository.findByFcmToken("existing-token")).willReturn(Optional.of(existingDevice));
 
         // when
-        userDeviceService.registerOrUpdateDevice(email, requestDto);
+        userDeviceService.registerOrUpdateDevice(userId, requestDto);
 
         // then
         assertThat(existingDevice.getDeviceType()).isEqualTo(DeviceType.IOS);
@@ -81,12 +81,12 @@ class UserDeviceServiceTest {
     @DisplayName("기기 등록 실패 - 유저 없음")
     void registerOrUpdateDevice_fail_userNotFound() {
         // given
-        String email = "none@example.com";
+        Long userId = 999L;
         DeviceRequestDto requestDto = new DeviceRequestDto("fcm", DeviceType.ANDROID);
-        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userDeviceService.registerOrUpdateDevice(email, requestDto))
+        assertThatThrownBy(() -> userDeviceService.registerOrUpdateDevice(userId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }

--- a/src/test/java/com/dodo/dodoserver/domain/user/service/UserInterestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/service/UserInterestServiceTest.java
@@ -45,16 +45,16 @@ class UserInterestServiceTest {
     @DisplayName("내 관심사 조회 성공")
     void getMyInterests_success() {
         // given
-        String email = "test@example.com";
-        User user = User.builder().id(1L).email(email).build();
+        Long userId = 1L;
+        User user = User.builder().id(userId).email("test@example.com").build();
         Category category = Category.builder().id(1L).name("카페").build();
         UserInterest userInterest = UserInterest.builder().user(user).category(category).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userInterestRepository.findByUserId(user.getId())).willReturn(List.of(userInterest));
 
         // when
-        List<CategoryResponseDto> result = userInterestService.getMyInterests(email);
+        List<CategoryResponseDto> result = userInterestService.getMyInterests(userId);
 
         // then
         assertThat(result).hasSize(1);
@@ -65,18 +65,18 @@ class UserInterestServiceTest {
     @DisplayName("관심사 업데이트 성공")
     void updateInterests_success() {
         // given
-        String email = "test@example.com";
-        User user = User.builder().id(1L).email(email).build();
+        Long userId = 1L;
+        User user = User.builder().id(userId).email("test@example.com").build();
         UserInterestRequestDto requestDto = new UserInterestRequestDto(List.of(1L, 2L));
         Category category1 = Category.builder().id(1L).name("카페").build();
         Category category2 = Category.builder().id(2L).name("맛집").build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(categoryRepository.findById(1L)).willReturn(Optional.of(category1));
         given(categoryRepository.findById(2L)).willReturn(Optional.of(category2));
 
         // when
-        userInterestService.updateInterests(email, requestDto);
+        userInterestService.updateInterests(userId, requestDto);
 
         // then
         verify(userInterestRepository, times(1)).deleteByUserId(user.getId());
@@ -87,15 +87,15 @@ class UserInterestServiceTest {
     @DisplayName("관심사 업데이트 실패 - 카테고리 없음")
     void updateInterests_fail_categoryNotFound() {
         // given
-        String email = "test@example.com";
-        User user = User.builder().id(1L).email(email).build();
+        Long userId = 1L;
+        User user = User.builder().id(userId).email("test@example.com").build();
         UserInterestRequestDto requestDto = new UserInterestRequestDto(List.of(99L));
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(categoryRepository.findById(99L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userInterestService.updateInterests(email, requestDto))
+        assertThatThrownBy(() -> userInterestService.updateInterests(userId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.CATEGORY_NOT_FOUND.getMessage());
     }

--- a/src/test/java/com/dodo/dodoserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/service/UserServiceTest.java
@@ -65,17 +65,17 @@ class UserServiceTest {
     @DisplayName("프로필 수정 성공")
     void updateProfile_success() {
         // given
-        String email = "test@example.com";
+        Long userId = 1L;
         ProfileUpdateRequestDto requestDto = new ProfileUpdateRequestDto("새닉네임", "http://new-image.com", "새소개");
-        User user = User.builder().email(email).nickname("옛날닉네임").build();
+        User user = User.builder().id(userId).email("test@example.com").nickname("옛날닉네임").build();
         UserProfile profile = UserProfile.builder().user(user).nickname("옛날닉네임").build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userProfileRepository.findByUser(user)).willReturn(Optional.of(profile));
         given(userRepository.existsByNickname("새닉네임")).willReturn(false);
 
         // when
-        userService.updateProfile(email, requestDto);
+        userService.updateProfile(userId, requestDto);
 
         // then
         assertThat(user.getNickname()).isEqualTo("새닉네임");
@@ -88,17 +88,17 @@ class UserServiceTest {
     @DisplayName("프로필 수정 실패 - 중복된 닉네임")
     void updateProfile_fail_duplicateNickname() {
         // given
-        String email = "test@example.com";
+        Long userId = 1L;
         ProfileUpdateRequestDto requestDto = new ProfileUpdateRequestDto("이미있는닉네임", null, null);
-        User user = User.builder().email(email).nickname("옛날닉네임").build();
+        User user = User.builder().id(userId).email("test@example.com").nickname("옛날닉네임").build();
         UserProfile profile = UserProfile.builder().user(user).nickname("옛날닉네임").build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userProfileRepository.findByUser(user)).willReturn(Optional.of(profile));
         given(userRepository.existsByNickname("이미있는닉네임")).willReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> userService.updateProfile(email, requestDto))
+        assertThatThrownBy(() -> userService.updateProfile(userId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.DUPLICATE_NICKNAME.getMessage());
     }
@@ -107,49 +107,50 @@ class UserServiceTest {
     @DisplayName("온보딩 성공")
     void onboard_success() {
         // given
-        String email = "new@example.com";
+        Long userId = 1L;
         OnboardRequestDto requestDto = new OnboardRequestDto(
                 "신규유저", "fcm-token", "소개", "http://image.com", DeviceType.ANDROID, List.of(1L, 2L)
         );
-        User user = User.builder().email(email).isOnboarded(false).build();
+        User user = User.builder().id(userId).email("new@example.com").isOnboarded(false).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userRepository.existsByNickname("신규유저")).willReturn(false);
 
         // when
-        userService.onboard(email, requestDto);
+        userService.onboard(userId, requestDto);
 
         // then
         assertThat(user.isOnboarded()).isTrue();
         assertThat(user.getNickname()).isEqualTo("신규유저");
         verify(userProfileRepository, times(1)).save(any(UserProfile.class));
-        verify(userDeviceService, times(1)).registerOrUpdateDevice(eq(email), any(DeviceRequestDto.class));
-        verify(userInterestService, times(1)).updateInterests(eq(email), any());
+        verify(userDeviceService, times(1)).registerOrUpdateDevice(eq(userId), any(DeviceRequestDto.class));
+        verify(userInterestService, times(1)).updateInterests(eq(userId), any());
     }
 
     @Test
     @DisplayName("온보딩 실패 - 이미 온보딩됨")
     void onboard_fail_alreadyOnboarded() {
         // given
-        String email = "old@example.com";
+        Long userId = 1L;
         OnboardRequestDto requestDto = new OnboardRequestDto("신규유저", "fcm-token", null, null, null, null);
-        User user = User.builder().email(email).isOnboarded(true).build();
+        User user = User.builder().id(userId).email("old@example.com").isOnboarded(true).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when & then
-        assertThatThrownBy(() -> userService.onboard(email, requestDto))
+        assertThatThrownBy(() -> userService.onboard(userId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_ONBOARDED.getMessage());
     }
 
     @Test
     @DisplayName("내 프로필 조회 성공")
-    void getUserProfileByEmail_success() {
+    void getUserProfileById_success() {
         // given
+        Long userId = 1L;
         String email = "test@example.com";
         User user = User.builder()
-                .id(1L)
+                .id(userId)
                 .email(email)
                 .nickname("테스터")
                 .role(Role.USER)
@@ -162,11 +163,11 @@ class UserServiceTest {
                 .bio("자기소개")
                 .build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userProfileRepository.findByUser(user)).willReturn(Optional.of(profile));
 
         // when
-        UserProfileResponseDto response = userService.getUserProfileByEmail(email);
+        UserProfileResponseDto response = userService.getUserProfileById(userId);
 
         // then
         assertThat(response.getEmail()).isEqualTo(email);
@@ -176,14 +177,14 @@ class UserServiceTest {
 
     @Test
     @DisplayName("내 프로필 조회 실패 - 온보딩 미완료")
-    void getUserProfileByEmail_fail_notOnboarded() {
+    void getUserProfileById_fail_notOnboarded() {
         // given
-        String email = "not-onboarded@example.com";
-        User user = User.builder().email(email).isOnboarded(false).build();
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        Long userId = 1L;
+        User user = User.builder().id(userId).email("not-onboarded@example.com").isOnboarded(false).build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when & then
-        assertThatThrownBy(() -> userService.getUserProfileByEmail(email))
+        assertThatThrownBy(() -> userService.getUserProfileById(userId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ONBOARDING_REQUIRED.getMessage());
     }
@@ -192,11 +193,11 @@ class UserServiceTest {
     @DisplayName("프로필 수정 실패 - 사용자를 찾을 수 없음")
     void updateProfile_fail_userNotFound() {
         // given
-        String email = "none@example.com";
-        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.updateProfile(email, new ProfileUpdateRequestDto("닉네임", null, null)))
+        assertThatThrownBy(() -> userService.updateProfile(userId, new ProfileUpdateRequestDto("닉네임", null, null)))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
@@ -205,13 +206,13 @@ class UserServiceTest {
     @DisplayName("프로필 수정 실패 - 프로필을 찾을 수 없음")
     void updateProfile_fail_profileNotFound() {
         // given
-        String email = "test@example.com";
-        User user = User.builder().email(email).build();
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        Long userId = 1L;
+        User user = User.builder().id(userId).email("test@example.com").build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userProfileRepository.findByUser(user)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.updateProfile(email, new ProfileUpdateRequestDto("닉네임", null, null)))
+        assertThatThrownBy(() -> userService.updateProfile(userId, new ProfileUpdateRequestDto("닉네임", null, null)))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.USER_PROFILE_NOT_FOUND.getMessage());
     }
@@ -220,28 +221,28 @@ class UserServiceTest {
     @DisplayName("온보딩 실패 - 닉네임 중복")
     void onboard_fail_duplicateNickname() {
         // given
-        String email = "new@example.com";
+        Long userId = 1L;
         OnboardRequestDto requestDto = new OnboardRequestDto("중복닉네임", "fcm", null, null, null, null);
-        User user = User.builder().email(email).isOnboarded(false).build();
+        User user = User.builder().id(userId).email("new@example.com").isOnboarded(false).build();
 
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userRepository.existsByNickname("중복닉네임")).willReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> userService.onboard(email, requestDto))
+        assertThatThrownBy(() -> userService.onboard(userId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.DUPLICATE_NICKNAME.getMessage());
     }
 
     @Test
     @DisplayName("내 프로필 조회 실패 - 사용자를 찾을 수 없음")
-    void getUserProfileByEmail_fail_userNotFound() {
+    void getUserProfileById_fail_userNotFound() {
         // given
-        String email = "none@example.com";
-        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.getUserProfileByEmail(email))
+        assertThatThrownBy(() -> userService.getUserProfileById(userId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }

--- a/src/test/java/com/dodo/dodoserver/global/security/WithMockUserPrincipal.java
+++ b/src/test/java/com/dodo/dodoserver/global/security/WithMockUserPrincipal.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.global.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockUserPrincipalSecurityContextFactory.class)
+public @interface WithMockUserPrincipal {
+    long id() default 1L;
+    String email() default "test@example.com";
+    String role() default "ROLE_USER";
+}

--- a/src/test/java/com/dodo/dodoserver/global/security/WithMockUserPrincipalSecurityContextFactory.java
+++ b/src/test/java/com/dodo/dodoserver/global/security/WithMockUserPrincipalSecurityContextFactory.java
@@ -1,0 +1,30 @@
+package com.dodo.dodoserver.global.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockUserPrincipalSecurityContextFactory implements WithSecurityContextFactory<WithMockUserPrincipal> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockUserPrincipal annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        UserPrincipal principal = UserPrincipal.create(
+                annotation.id(),
+                annotation.email(),
+                annotation.role()
+        );
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                "",
+                principal.getAuthorities()
+        );
+
+        context.setAuthentication(auth);
+        return context;
+    }
+}


### PR DESCRIPTION
  📌 개요 (Overview)
  기존의 이메일 기반 인증 및 식별 로직을 UserPrincipal 중심의 ID 기반 구조로 전면 리팩토링하여 보안성, 성능, 그리고 개발자 경험(DX)을 개선했습니다.

  🛠️ 작업 내용 (Changes)

  1. 인증 아키텍처 고도화
   - UserPrincipal 도입: UserDetails와 OAuth2User를 모두 구현한 커스텀 인증 객체를 생성하여 시스템 전반의 인증 객체 구조를 단일화했습니다.
   - JwtTokenProvider 리팩토링: JWT Payload에 userId를 포함시켰으며, 토큰 파싱 시 UserPrincipal을 반환하도록 수정했습니다.
   - ID 난독화 (Security): 내부 PK(Long id) 노출 방지를 위해 Hashids 라이브러리를 도입, JWT 내에서는 난독화된 문자열(uid)로 ID를 관리합니다.

  2. 비즈니스 로직 및 컨트롤러 최적화
   - 식별자 체킹 방식 변경: 서비스 레이어의 파라미터를 String email에서 Long userId로 변경하고, userRepository.findById()를 사용하여 DB 조회 성능을 최적화했습니다.
   - 컨트롤러 표준화: 모든 도메인 컨트롤러에서 @AuthenticationPrincipal UserPrincipal을 사용하여 유저 정보를 주입받도록 리팩토링했습니다.
   - 로그아웃 최적화: RefreshToken의 식별자를 이메일에서 유저 ID로 변경하여, 로그아웃 시 추가 유저 조회 없이 Redis에서 즉시 토큰을 삭제할 수 있도록 개선했습니다.

  3. 테스트 인프라 보완
   - @WithMockUserPrincipal 추가: 커스텀 인증 객체 타입에 대응하는 보안 테스트용 어노테이션과 팩토리를 구현했습니다.
   - 전체 테스트 코드 수정: 30여 개의 컨트롤러 및 서비스 테스트를 변경된 ID 기반 로직에 맞춰 업데이트하여 안정성을 검증했습니다.


  🔗 관련 이슈 (Related Issues)
   - close #24

  📝 추가 참고 사항 (Additional Notes)
   - 이제 컨트롤러에서 principal.getId() 또는 principal.getEmail()을 통해 DB 접근 없이 즉시 유저 식별 정보를 사용할 수 있습니다.
   - JWT 내부의 uid 클레임은 HashIdUtils를 통해 복호화가 가능하며, 보안을 위해 salt 값을 환경 변수로 관리하는 것을 권장합니다.