### PR TITLE
Feat/33/nest api enhancement:  Nest API 고도화 - 요약 정보 정렬 및 핀 필터링 추가

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
@@ -45,9 +45,10 @@ public class NestGpsController {
     @GetMapping("/summaries")
     public ApiResponseDto<List<NestSummaryResponseDto>> getNestsByIds(
             @AuthenticationPrincipal UserPrincipal principal,
-            @RequestParam List<Long> ids) {
+            @RequestParam List<Long> ids,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return ApiResponseDto.success(nestService.getNestsByIds(principal.getId(), ids));
+        return ApiResponseDto.success(nestService.getNestsByIds(principal.getId(), ids, pageable.getSort()));
     }
 
     /**
@@ -73,8 +74,9 @@ public class NestGpsController {
     public ApiResponseDto<List<NestPinResponseDto>> getNearbyPins(
             @RequestParam Double latitude,
             @RequestParam Double longitude,
-            @RequestParam(required = false) Double radiusMeter) {
+            @RequestParam(required = false) Double radiusMeter,
+            @RequestParam(required = false) List<Long> categoryIds) {
 
-        return ApiResponseDto.success(nestService.getNearbyPins(latitude, longitude, radiusMeter));
+        return ApiResponseDto.success(nestService.getNearbyPins(latitude, longitude, radiusMeter, categoryIds));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryCustom.java
@@ -5,11 +5,13 @@ import com.dodo.dodoserver.domain.nest.dto.NestQueryDto;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
 public interface NestRepositoryCustom {
-    List<NestPinResponseDto> findNearbyPins(Point point, Double radiusMeter);
+    List<NestPinResponseDto> findNearbyPins(Point point, Double radiusMeter, List<Long> categoryIds);
     Page<NestQueryDto> findNearbyNests(Point point, Double radiusMeter, List<Long> categoryIds, Pageable pageable);
+    List<NestQueryDto> findNestsByIdsCustom(List<Long> nestIds, Sort sort);
     Double calculateDistance(Long nestId, Point point);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
@@ -38,7 +38,7 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<NestPinResponseDto> findNearbyPins(Point point, Double radiusMeter) {
+    public List<NestPinResponseDto> findNearbyPins(Point point, Double radiusMeter, List<Long> categoryIds) {
         NumberTemplate<Double> distance = Expressions.numberTemplate(Double.class,
                 "ST_Distance_Sphere({0}, {1})", nestLocation.point, point);
 
@@ -50,8 +50,59 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 ))
                 .from(nest)
                 .join(nest.location, nestLocation)
-                .where(distance.loe(radiusMeter), nest.deletedAt.isNull())
+                .leftJoin(nestCategory).on(nestCategory.nest.eq(nest))
+                .where(
+                        distance.loe(radiusMeter),
+                        categoryIn(categoryIds),
+                        nest.deletedAt.isNull()
+                )
+                .groupBy(nest.id)
                 .fetch();
+    }
+
+    @Override
+    public List<NestQueryDto> findNestsByIdsCustom(List<Long> nestIds, Sort sort) {
+        NumberExpression<Long> likeCount = Expressions.asNumber(
+                JPAExpressions.select(nestReaction.count())
+                        .from(nestReaction)
+                        .where(nestReaction.nest.id.eq(nest.id)
+                                .and(nestReaction.reactionType.eq(ReactionType.LIKE)))
+        ).coalesce(0L);
+
+        JPAQuery<NestQueryDto> query = queryFactory
+                .select(Projections.constructor(NestQueryDto.class,
+                        nest,
+                        likeCount,
+                        Expressions.numberTemplate(Double.class, "null")
+                ))
+                .from(nest)
+                .where(nest.id.in(nestIds), nest.deletedAt.isNull());
+
+        for (OrderSpecifier<?> specifier : getOrderSpecifiers(sort, null)) {
+            query.orderBy(specifier);
+        }
+
+        List<NestQueryDto> content = query.fetch();
+
+        if (!content.isEmpty()) {
+            Map<Long, List<String>> categoryMap = queryFactory
+                    .select(nestCategory.nest.id, category.name)
+                    .from(nestCategory)
+                    .join(nestCategory.category, category)
+                    .where(nestCategory.nest.id.in(nestIds))
+                    .fetch()
+                    .stream()
+                    .collect(Collectors.groupingBy(
+                            t -> t.get(nestCategory.nest.id),
+                            Collectors.mapping(t -> t.get(category.name), Collectors.toList())
+                    ));
+
+            content.forEach(dto -> dto.setCategoryNames(
+                    categoryMap.getOrDefault(dto.getNest().getId(), Collections.emptyList())
+            ));
+        }
+
+        return content;
     }
 
     @Override

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
@@ -50,13 +50,11 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 ))
                 .from(nest)
                 .join(nest.location, nestLocation)
-                .leftJoin(nestCategory).on(nestCategory.nest.eq(nest))
                 .where(
                         distance.loe(radiusMeter),
                         categoryIn(categoryIds),
                         nest.deletedAt.isNull()
                 )
-                .groupBy(nest.id)
                 .fetch();
     }
 
@@ -125,13 +123,11 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 ))
                 .from(nest)
                 .join(nest.location, nestLocation)
-                .leftJoin(nestCategory).on(nestCategory.nest.eq(nest))
                 .where(
                         distance.loe(radiusMeter),
                         categoryIn(categoryIds),
                         nest.deletedAt.isNull()
                 )
-                .groupBy(nest.id)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
@@ -167,7 +163,6 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 .select(nest.id.countDistinct())
                 .from(nest)
                 .join(nest.location, nestLocation)
-                .leftJoin(nestCategory).on(nestCategory.nest.eq(nest))
                 .where(
                         distance.loe(radiusMeter),
                         categoryIn(categoryIds),
@@ -191,7 +186,12 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
     }
 
     private BooleanExpression categoryIn(List<Long> categoryIds) {
-        return categoryIds != null && !categoryIds.isEmpty() ? nestCategory.category.id.in(categoryIds) : null;
+        return categoryIds != null && !categoryIds.isEmpty() ?
+                JPAExpressions.selectOne()
+                        .from(nestCategory)
+                        .where(nestCategory.nest.eq(nest)
+                                .and(nestCategory.category.id.in(categoryIds)))
+                        .exists() : null;
     }
 
     private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort, Point point) {

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
@@ -73,7 +73,7 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 .select(Projections.constructor(NestQueryDto.class,
                         nest,
                         likeCount,
-                        Expressions.numberTemplate(Double.class, "null")
+                        Expressions.numberTemplate(Double.class, "NULL")
                 ))
                 .from(nest)
                 .where(nest.id.in(nestIds), nest.deletedAt.isNull());

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestQueryDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestQueryDto.java
@@ -23,4 +23,11 @@ public class NestQueryDto {
         this.likeCount = likeCount;
         this.distance = distance;
     }
+
+    public NestQueryDto(Nest nest, Object likeCount, Double distance) {
+        this.nest = nest;
+        this.likeCount = (likeCount instanceof Long) ? (Long) likeCount : 
+                         (likeCount instanceof Number) ? ((Number) likeCount).longValue() : 0L;
+        this.distance = distance;
+    }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -19,6 +19,7 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -250,24 +251,29 @@ public class NestService {
     }
 
     /**
-     * ID 리스트 둥지 요약 정보 조회 (N+1 최적화)
+     * ID 리스트 둥지 요약 정보 조회 (정렬 추가)
      */
     @Transactional(readOnly = true)
-    public List<NestSummaryResponseDto> getNestsByIds(Long userId, List<Long> nestIds) {
+    public List<NestSummaryResponseDto> getNestsByIds(Long userId, List<Long> nestIds, Sort sort) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        List<Nest> nests = nestRepository.findAllById(nestIds);
-        if (nests.isEmpty()) return Collections.emptyList();
+        if (nestIds == null || nestIds.isEmpty()) return Collections.emptyList();
+
+        List<NestQueryDto> nestDtos = nestRepository.findNestsByIdsCustom(nestIds, sort);
+        if (nestDtos.isEmpty()) return Collections.emptyList();
+
+        List<Nest> nestEntities = nestDtos.stream().map(NestQueryDto::getNest).collect(Collectors.toList());
 
         // 해금 이력 일괄 조회
-        Set<Long> unlockedNestIds = unlockHistoryRepository.findAllByUserAndNestIn(user, nests).stream()
+        Set<Long> unlockedNestIds = unlockHistoryRepository.findAllByUserAndNestIn(user, nestEntities).stream()
                 .map(uh -> uh.getNest().getId())
                 .collect(Collectors.toSet());
 
-        return nests.stream().map(nest -> {
+        return nestDtos.stream().map(dto -> {
+            Nest nest = dto.getNest();
             boolean isUnlocked = nest.getCreator().equals(user) || unlockedNestIds.contains(nest.getId());
-            return NestSummaryResponseDto.from(nest, isUnlocked);
+            return NestSummaryResponseDto.from(nest, isUnlocked, dto.getLikeCount(), dto.getDistance(), dto.getCategoryNames());
         }).collect(Collectors.toList());
     }
 
@@ -430,10 +436,10 @@ public class NestService {
      * 현재 위치 기반 반경 내 모든 둥지 핀 정보 조회
      */
     @Transactional(readOnly = true)
-    public List<NestPinResponseDto> getNearbyPins(Double latitude, Double longitude, Double radiusMeter) {
+    public List<NestPinResponseDto> getNearbyPins(Double latitude, Double longitude, Double radiusMeter, List<Long> categoryIds) {
         double radius = (radiusMeter != null) ? radiusMeter : 5000.0;
         Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude)); // (x,y)
-        return nestRepository.findNearbyPins(point, radius);
+        return nestRepository.findNearbyPins(point, radius, categoryIds);
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -255,10 +255,10 @@ public class NestService {
      */
     @Transactional(readOnly = true)
     public List<NestSummaryResponseDto> getNestsByIds(Long userId, List<Long> nestIds, Sort sort) {
+        if (nestIds == null || nestIds.isEmpty()) return Collections.emptyList();
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if (nestIds == null || nestIds.isEmpty()) return Collections.emptyList();
 
         List<NestQueryDto> nestDtos = nestRepository.findNestsByIdsCustom(nestIds, sort);
         if (nestDtos.isEmpty()) return Collections.emptyList();

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestGpsControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestGpsControllerTest.java
@@ -95,7 +95,7 @@ class NestGpsControllerTest {
     void getNestsByIds_success() throws Exception {
         List<Long> ids = List.of(1L, 2L);
         NestSummaryResponseDto summary = NestSummaryResponseDto.builder().id(1L).content("테스트").build();
-        given(nestService.getNestsByIds(any(), eq(ids))).willReturn(List.of(summary));
+        given(nestService.getNestsByIds(any(), eq(ids), any())).willReturn(List.of(summary));
 
         mockMvc.perform(get("/api/v1/nests/summaries")
                         .param("ids", "1,2"))
@@ -124,7 +124,7 @@ class NestGpsControllerTest {
     @WithMockUserPrincipal
     void getNearbyPins_success() throws Exception {
         NestPinResponseDto pin = new NestPinResponseDto(1L, 37.5, 127.0);
-        given(nestService.getNearbyPins(any(), any(), any())).willReturn(List.of(pin));
+        given(nestService.getNearbyPins(any(), any(), any(), any())).willReturn(List.of(pin));
 
         mockMvc.perform(get("/api/v1/nests/pins")
                         .param("latitude", "37.5")

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -395,12 +395,14 @@ class NestServiceTest {
         List<Long> ids = List.of(1L, 2L);
         Nest n1 = Nest.builder().id(1L).creator(user).images(new ArrayList<>()).build();
         Nest n2 = Nest.builder().id(2L).creator(user).images(new ArrayList<>()).build();
+        NestQueryDto dto1 = new NestQueryDto(n1, 0L, null);
+        NestQueryDto dto2 = new NestQueryDto(n2, 0L, null);
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-        given(nestRepository.findAllById(ids)).willReturn(List.of(n1, n2));
+        given(nestRepository.findNestsByIdsCustom(eq(ids), any())).willReturn(List.of(dto1, dto2));
         given(unlockHistoryRepository.findAllByUserAndNestIn(eq(user), any())).willReturn(new ArrayList<>());
 
-        List<NestSummaryResponseDto> result = nestService.getNestsByIds(user.getId(), ids);
+        List<NestSummaryResponseDto> result = nestService.getNestsByIds(user.getId(), ids, org.springframework.data.domain.Sort.unsorted());
 
         assertThat(result).hasSize(2);
     }


### PR DESCRIPTION
## 📌 개요 (Overview)
둥지 요약 정보 조회 및 핀 조회 API를 고도화하였습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
 1. 둥지 요약 정보 조회 (/api/v1/nests/summaries) 고도화
   - 정렬(Sorting) 기능 추가: createdAt(최신순), likeCount(좋아요순), viewCount(조회수순) 옵션을 지원합니다.
   - 성능 최적화: QueryDSL 커스텀 메서드를 통해 좋아요 수와 카테고리 목록을 일괄 조회하여 N+1 문제를 해결하였습니다.
   - 응답 규격 개선: content 첫 줄 추출 로직을 적용하고, likeCount, isAd 등 누락된 필드를 보강하였습니다. (요청에 따라 distance 필드는 null로 유지)

  2. 주변 핀 정보 조회 (/api/v1/nests/pins) 기능 개선
   - 카테고리 필터링 추가: categoryIds 파라미터를 통해 선택된 카테고리에 해당하는 둥지만 지도에 표시할 수 있도록 수정하였습니다.

  3. 버그 수정 및 안정성 강화
   - Nest 도메인: QueryDSL 프로젝션 과정에서 발생하던 ExpressionException을 해결하기 위해 NestQueryDto 생성자를 보완하였습니다.
   - User 도메인: UserDeviceServiceTest에서 발생하던 NullPointerException을 해결하고 방어 로직을 추가하였습니다.

## 📸 스크린샷 / 결과 (Screenshots / Results)
UI 변경사항이나 API 테스트 결과(Postman, Swagger 등)를 캡처하여 첨부해 주세요. (권장)


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #33 

## 📝 추가 참고 사항 (Additional Notes)
✦ getNestsByIds API(/api/v1/nests/summaries)는 Spring Data의 Pageable 규격을 사용하므로, 쿼리 파라미터에 sort=필드명,방향 형식을 사용하여 정렬할 수 있습니다.

  현재 구현된 코드 기준 주요 사용 예시는 다음과 같습니다.

  1. 최신순 정렬 (기본값)
  기본적으로 최신순으로 정렬되지만, 명시적으로 사용할 수 있습니다.
   * URL: GET /api/v1/nests/summaries?ids=1,2,3&sort=createdAt,desc

  2. 좋아요 많은 순 정렬 (인기순)
  가장 인기가 많은 둥지를 먼저 보여주고 싶을 때 사용합니다.
   * URL: GET /api/v1/nests/summaries?ids=1,2,3&sort=likeCount,desc

  3. 조회수 높은 순 정렬
  조회수가 높은 순서대로 정렬합니다.
   * URL: GET /api/v1/nests/summaries?ids=1,2,3&sort=viewCount,desc

  4. 다중 조건 정렬
  좋아요 수가 같다면 최신순으로 정렬하는 등 복합 조건을 사용할 수 있습니다.
   * URL: GET /api/v1/nests/summaries?ids=1,2,3&sort=likeCount,desc&sort=createdAt,desc

  💡 참고 사항
   * 필드명 매핑: 코드 내 NestRepositoryImpl의 getOrderSpecifiers 로직에 따라 다음 키워드들이 허용됩니다.
       * createdAt, created_at
       * viewCount, view_count
       * like, likeCount
   * 방향: asc(오름차순), desc(내림차순) 모두 지원합니다.
