### PR TITLE
feat/#26: 배포 전 자동 테스트 실행 및 PR 환경 배포 제한

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -7,8 +7,29 @@ on:
     branches: [ "develop" ]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Tests
+        run: ./gradlew test --no-daemon
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,6 +68,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-and-push # 빌드가 성공해야 배포 시작
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code (for docker-compose.yml)
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ temp/
 service-account.json
 **/service-account.json
 /src/main/resources/firebase/
+/GEMINI.md


### PR DESCRIPTION
## 📌 개요 (Overview)
배포 프로세스의 안정성을 확보하기 위해 빌드 및 배포 전 자동 테스트 단계를 추가하고, 
실제 배포가 발생하는 시점을 Pull Request 단계로 제한하도록 워크플로우를 수정했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - 자동 테스트 Job (test) 추가:
     - 빌드 전 ./gradlew test를 수행하여 테스트 실패 시 전체 워크플로우가 즉시 중단되도록 했습니다.
   - 배포 프로세스 의존성 설정:
     - build-and-push Job이 test Job의 성공을 전제로 하도록 (needs: test) 설정했습니다.
   - 이벤트 기반 실행 제어:
     - build-and-push 및 deploy Job에 if: github.event_name == 'pull_request' 조건을 추가했습니다.
     - PR 시: [테스트 -> 빌드 -> 배포]가 모두 진행되어 실제 배포 환경까지 검증합니다.
     - Merge(Push) 시: 배포 없이 [테스트]만 수행하여 브랜치의 안정성을 최종 확인합니다.




## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #26 
