### PR TITLE
Feat/35/nest draft implementation: 둥지 임시 저장(Draft) 기능 및 응답 DTO 최적화

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
@@ -4,8 +4,6 @@ import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.service.NestDraftService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.UserPrincipal;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Nest Draft", description = "둥지 임시 저장 API")
 @RestController
 @RequestMapping("/api/v1/nests/drafts")
 @RequiredArgsConstructor
@@ -21,6 +18,9 @@ public class NestDraftController {
 
     private final NestDraftService nestDraftService;
 
+    /**
+     * 임시 저장 생성
+     */
     @PostMapping
     public ApiResponseDto<NestDraftResponseDto> createDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -28,12 +28,18 @@ public class NestDraftController {
         return ApiResponseDto.success(nestDraftService.createDraft(userPrincipal.getId(), requestDto));
     }
 
+    /**
+     * 내 임시 저장 목록 조회
+     */
     @GetMapping
     public ApiResponseDto<List<NestDraftResponseDto>> getMyDrafts(
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         return ApiResponseDto.success(nestDraftService.getMyDrafts(userPrincipal.getId()));
     }
 
+    /**
+     * 임시 저장 상세 조회
+     */
     @GetMapping("/{id}")
     public ApiResponseDto<NestDraftResponseDto> getDraftDetail(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -41,6 +47,9 @@ public class NestDraftController {
         return ApiResponseDto.success(nestDraftService.getDraftDetail(userPrincipal.getId(), id));
     }
 
+    /**
+     * 임시 저장 수정
+     */
     @PatchMapping("/{id}")
     public ApiResponseDto<NestDraftResponseDto> updateDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -49,6 +58,9 @@ public class NestDraftController {
         return ApiResponseDto.success(nestDraftService.updateDraft(userPrincipal.getId(), id, requestDto));
     }
 
+    /**
+     * 임시 저장 삭제
+     */
     @DeleteMapping("/{id}")
     public ApiResponseDto<Void> deleteDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -57,6 +69,9 @@ public class NestDraftController {
         return ApiResponseDto.success(null);
     }
 
+    /**
+     * 임시 저장 발행
+     */
     @PostMapping("/{id}/publish")
     public ApiResponseDto<NestSummaryResponseDto> publishDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
@@ -73,7 +73,7 @@ public class NestDraftController {
      * 임시 저장 발행
      */
     @PostMapping("/{id}/publish")
-    public ApiResponseDto<NestSummaryResponseDto> publishDraft(
+    public ApiResponseDto<NestSimpleResponseDto> publishDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id) {
         return ApiResponseDto.success(nestDraftService.publishDraft(userPrincipal.getId(), id));

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
@@ -21,7 +21,6 @@ public class NestDraftController {
 
     private final NestDraftService nestDraftService;
 
-    @Operation(summary = "임시 저장 생성", description = "현 위치 좌표를 기반으로 임시 저장을 생성합니다.")
     @PostMapping
     public ApiResponseDto<NestDraftResponseDto> createDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -29,14 +28,12 @@ public class NestDraftController {
         return ApiResponseDto.success(nestDraftService.createDraft(userPrincipal.getId(), requestDto));
     }
 
-    @Operation(summary = "내 임시 저장 목록 조회", description = "로그인한 사용자의 임시 저장 목록을 조회합니다.")
     @GetMapping
     public ApiResponseDto<List<NestDraftResponseDto>> getMyDrafts(
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         return ApiResponseDto.success(nestDraftService.getMyDrafts(userPrincipal.getId()));
     }
 
-    @Operation(summary = "임시 저장 상세 조회", description = "특정 임시 저장의 상세 내용을 조회합니다.")
     @GetMapping("/{id}")
     public ApiResponseDto<NestDraftResponseDto> getDraftDetail(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -44,7 +41,6 @@ public class NestDraftController {
         return ApiResponseDto.success(nestDraftService.getDraftDetail(userPrincipal.getId(), id));
     }
 
-    @Operation(summary = "임시 저장 수정", description = "임시 저장된 내용을 수정합니다.")
     @PatchMapping("/{id}")
     public ApiResponseDto<NestDraftResponseDto> updateDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -53,7 +49,6 @@ public class NestDraftController {
         return ApiResponseDto.success(nestDraftService.updateDraft(userPrincipal.getId(), id, requestDto));
     }
 
-    @Operation(summary = "임시 저장 삭제", description = "임시 저장된 데이터를 삭제합니다.")
     @DeleteMapping("/{id}")
     public ApiResponseDto<Void> deleteDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -62,7 +57,6 @@ public class NestDraftController {
         return ApiResponseDto.success(null);
     }
 
-    @Operation(summary = "임시 저장 발행", description = "임시 저장된 데이터를 기반으로 정식 둥지를 발행합니다.")
     @PostMapping("/{id}/publish")
     public ApiResponseDto<NestSummaryResponseDto> publishDraft(
             @AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestDraftController.java
@@ -1,0 +1,72 @@
+package com.dodo.dodoserver.domain.nest.controller;
+
+import com.dodo.dodoserver.domain.nest.dto.*;
+import com.dodo.dodoserver.domain.nest.service.NestDraftService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Nest Draft", description = "둥지 임시 저장 API")
+@RestController
+@RequestMapping("/api/v1/nests/drafts")
+@RequiredArgsConstructor
+public class NestDraftController {
+
+    private final NestDraftService nestDraftService;
+
+    @Operation(summary = "임시 저장 생성", description = "현 위치 좌표를 기반으로 임시 저장을 생성합니다.")
+    @PostMapping
+    public ApiResponseDto<NestDraftResponseDto> createDraft(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody NestDraftCreateRequestDto requestDto) {
+        return ApiResponseDto.success(nestDraftService.createDraft(userPrincipal.getId(), requestDto));
+    }
+
+    @Operation(summary = "내 임시 저장 목록 조회", description = "로그인한 사용자의 임시 저장 목록을 조회합니다.")
+    @GetMapping
+    public ApiResponseDto<List<NestDraftResponseDto>> getMyDrafts(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponseDto.success(nestDraftService.getMyDrafts(userPrincipal.getId()));
+    }
+
+    @Operation(summary = "임시 저장 상세 조회", description = "특정 임시 저장의 상세 내용을 조회합니다.")
+    @GetMapping("/{id}")
+    public ApiResponseDto<NestDraftResponseDto> getDraftDetail(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        return ApiResponseDto.success(nestDraftService.getDraftDetail(userPrincipal.getId(), id));
+    }
+
+    @Operation(summary = "임시 저장 수정", description = "임시 저장된 내용을 수정합니다.")
+    @PatchMapping("/{id}")
+    public ApiResponseDto<NestDraftResponseDto> updateDraft(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id,
+            @Valid @RequestBody NestDraftUpdateRequestDto requestDto) {
+        return ApiResponseDto.success(nestDraftService.updateDraft(userPrincipal.getId(), id, requestDto));
+    }
+
+    @Operation(summary = "임시 저장 삭제", description = "임시 저장된 데이터를 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ApiResponseDto<Void> deleteDraft(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        nestDraftService.deleteDraft(userPrincipal.getId(), id);
+        return ApiResponseDto.success(null);
+    }
+
+    @Operation(summary = "임시 저장 발행", description = "임시 저장된 데이터를 기반으로 정식 둥지를 발행합니다.")
+    @PostMapping("/{id}/publish")
+    public ApiResponseDto<NestSummaryResponseDto> publishDraft(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        return ApiResponseDto.success(nestDraftService.publishDraft(userPrincipal.getId(), id));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestPostController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestPostController.java
@@ -19,6 +19,7 @@ import com.dodo.dodoserver.domain.nest.dto.CommentResponseDto;
 import com.dodo.dodoserver.domain.nest.dto.CommentUpdateRequestDto;
 import com.dodo.dodoserver.domain.nest.dto.NestCreateRequestDto;
 import com.dodo.dodoserver.domain.nest.dto.NestDetailResponseDto;
+import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
 import com.dodo.dodoserver.domain.nest.dto.NestSummaryResponseDto;
 import com.dodo.dodoserver.domain.nest.dto.NestUpdateRequestDto;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
@@ -39,7 +40,7 @@ public class NestPostController {
 	 * 새로운 둥지(Nest) 생성
 	 */
 	@PostMapping
-	public ApiResponseDto<NestSummaryResponseDto> createNest(
+	public ApiResponseDto<NestSimpleResponseDto> createNest(
 		@AuthenticationPrincipal UserPrincipal principal,
 		@RequestBody @Valid NestCreateRequestDto requestDto) {
 
@@ -61,7 +62,7 @@ public class NestPostController {
 	 * 둥지 정보 수정 (작성자 전용)
 	 */
 	@PatchMapping("/{id}")
-	public ApiResponseDto<NestSummaryResponseDto> updateNest(
+	public ApiResponseDto<NestSimpleResponseDto> updateNest(
 		@AuthenticationPrincipal UserPrincipal principal,
 		@PathVariable Long id,
 		@RequestBody @Valid NestUpdateRequestDto requestDto) {

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestDraftRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestDraftRepository.java
@@ -1,0 +1,11 @@
+package com.dodo.dodoserver.domain.nest.dao;
+
+import com.dodo.dodoserver.domain.nest.entity.NestDraft;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NestDraftRepository extends JpaRepository<NestDraft, Long> {
+    List<NestDraft> findAllByCreatorOrderByCreatedAtDesc(User creator);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDraftCreateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDraftCreateRequestDto.java
@@ -1,0 +1,35 @@
+package com.dodo.dodoserver.domain.nest.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NestDraftCreateRequestDto {
+
+    @NotNull(message = "위도는 필수입니다.")
+    private Double latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private Double longitude;
+
+    @Size(max = 255, message = "제목은 255자 이내여야 합니다.")
+    private String title;
+
+    private String content;
+
+    @Min(value = 0, message = "해금 반경은 0 이상이어야 합니다.")
+    private Integer unlockRadius;
+
+    private List<Long> categoryIds;
+
+    @Size(max = 5, message = "이미지는 최대 5개까지 등록 가능합니다.")
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDraftResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDraftResponseDto.java
@@ -1,0 +1,38 @@
+package com.dodo.dodoserver.domain.nest.dto;
+
+import com.dodo.dodoserver.domain.nest.entity.NestDraft;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class NestDraftResponseDto {
+    private Long id;
+    private Double latitude;
+    private Double longitude;
+    private String title;
+    private String content;
+    private Integer unlockRadius;
+    private List<Long> categoryIds;
+    private List<String> imageUrls;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static NestDraftResponseDto from(NestDraft draft) {
+        return NestDraftResponseDto.builder()
+                .id(draft.getId())
+                .latitude(draft.getLatitude())
+                .longitude(draft.getLongitude())
+                .title(draft.getTitle())
+                .content(draft.getContent())
+                .unlockRadius(draft.getUnlockRadius())
+                .categoryIds(draft.getCategoryIds())
+                .imageUrls(draft.getImageUrls())
+                .createdAt(draft.getCreatedAt())
+                .updatedAt(draft.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDraftUpdateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDraftUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package com.dodo.dodoserver.domain.nest.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NestDraftUpdateRequestDto {
+
+    @Size(max = 255, message = "제목은 255자 이내여야 합니다.")
+    private String title;
+
+    private String content;
+
+    @Min(value = 0, message = "해금 반경은 0 이상이어야 합니다.")
+    private Integer unlockRadius;
+
+    private List<Long> categoryIds;
+
+    @Size(max = 5, message = "이미지는 최대 5개까지 등록 가능합니다.")
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestSimpleResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestSimpleResponseDto.java
@@ -11,11 +11,13 @@ import java.time.LocalDateTime;
 public class NestSimpleResponseDto {
     private Long id;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static NestSimpleResponseDto from(Nest nest) {
         return NestSimpleResponseDto.builder()
                 .id(nest.getId())
                 .createdAt(nest.getCreatedAt())
+                .updatedAt(nest.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestSimpleResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestSimpleResponseDto.java
@@ -1,0 +1,21 @@
+package com.dodo.dodoserver.domain.nest.dto;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NestSimpleResponseDto {
+    private Long id;
+    private LocalDateTime createdAt;
+
+    public static NestSimpleResponseDto from(Nest nest) {
+        return NestSimpleResponseDto.builder()
+                .id(nest.getId())
+                .createdAt(nest.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/entity/NestDraft.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/entity/NestDraft.java
@@ -1,0 +1,76 @@
+package com.dodo.dodoserver.domain.nest.entity;
+
+import com.dodo.dodoserver.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "nest_drafts")
+@EntityListeners(AuditingEntityListener.class)
+public class NestDraft {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User creator;
+
+    /**
+     * SRID 4326: GPS 좌표계 (WGS84)
+     * POINT(longitude, latitude) 순서 저장 주의
+     */
+    @Column(nullable = false, columnDefinition = "POINT SRID 4326")
+    private Point point;
+
+    @Column(length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Builder.Default
+    @Column(name = "unlock_radius")
+    private Integer unlockRadius = 100;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "image_urls", columnDefinition = "json")
+    private List<String> imageUrls;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "category_ids", columnDefinition = "json")
+    private List<Long> categoryIds;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // 위도 추출 편의 메서드
+    public Double getLatitude() {
+        return point != null ? point.getY() : null;
+    }
+
+    // 경도 추출 편의 메서드
+    public Double getLongitude() {
+        return point != null ? point.getX() : null;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
@@ -108,7 +108,7 @@ public class NestDraftService {
      * 임시 저장 데이터를 둥지로 정식 발행
      */
     @Transactional
-    public NestSummaryResponseDto publishDraft(Long userId, Long draftId) {
+    public NestSimpleResponseDto publishDraft(Long userId, Long draftId) {
         NestDraft draft = getDraftIfOwner(userId, draftId);
 
         // 발행 시 필수 값 검증
@@ -126,7 +126,7 @@ public class NestDraftService {
                 false // isAd 기본값
         );
 
-        NestSummaryResponseDto response = nestService.createNest(userId, nestCreateRequestDto);
+        NestSimpleResponseDto response = nestService.createNest(userId, nestCreateRequestDto);
 
         // 발행 성공 시 임시 저장 데이터 삭제
         nestDraftRepository.delete(draft);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
@@ -140,16 +140,16 @@ public class NestDraftService {
      */
     private void validatePublishable(NestDraft draft) {
         if (draft.getTitle() == null || draft.getTitle().isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.DRAFT_NOT_PUBLISHABLE);
         }
         if (draft.getContent() == null || draft.getContent().isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.DRAFT_NOT_PUBLISHABLE);
         }
         if (draft.getUnlockRadius() == null) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.DRAFT_NOT_PUBLISHABLE);
         }
         if (draft.getCategoryIds() == null || draft.getCategoryIds().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.DRAFT_NOT_PUBLISHABLE);
         }
     }
 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
@@ -111,10 +111,8 @@ public class NestDraftService {
     public NestSummaryResponseDto publishDraft(Long userId, Long draftId) {
         NestDraft draft = getDraftIfOwner(userId, draftId);
 
-        // 발행 시 필수 값 검증 (예: 제목)
-        if (draft.getTitle() == null || draft.getTitle().isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // 혹은 적절한 에러 코드
-        }
+        // 발행 시 필수 값 검증
+        validatePublishable(draft);
 
         // NestService의 createNest를 활용하기 위해 DTO 변환
         NestCreateRequestDto nestCreateRequestDto = new NestCreateRequestDto(
@@ -135,6 +133,24 @@ public class NestDraftService {
         log.info("임시 저장 발행 완료: DraftID={}, NestID={}", draftId, response.getId());
 
         return response;
+    }
+
+    /**
+     * 발행 가능 여부 검증 (필수값 체크)
+     */
+    private void validatePublishable(NestDraft draft) {
+        if (draft.getTitle() == null || draft.getTitle().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (draft.getContent() == null || draft.getContent().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (draft.getUnlockRadius() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (draft.getCategoryIds() == null || draft.getCategoryIds().isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 
     private NestDraft getDraftIfOwner(Long userId, Long draftId) {

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
@@ -1,0 +1,149 @@
+package com.dodo.dodoserver.domain.nest.service;
+
+import com.dodo.dodoserver.domain.nest.dao.NestDraftRepository;
+import com.dodo.dodoserver.domain.nest.dto.*;
+import com.dodo.dodoserver.domain.nest.entity.NestDraft;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NestDraftService {
+
+    private final NestDraftRepository nestDraftRepository;
+    private final UserRepository userRepository;
+    private final NestService nestService;
+
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    /**
+     * 임시 저장 생성
+     */
+    @Transactional
+    public NestDraftResponseDto createDraft(Long userId, NestDraftCreateRequestDto requestDto) {
+        User creator = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Point point = geometryFactory.createPoint(new Coordinate(requestDto.getLongitude(), requestDto.getLatitude()));
+
+        NestDraft draft = NestDraft.builder()
+                .creator(creator)
+                .point(point)
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .unlockRadius(requestDto.getUnlockRadius() != null ? requestDto.getUnlockRadius() : 100)
+                .imageUrls(requestDto.getImageUrls())
+                .categoryIds(requestDto.getCategoryIds())
+                .build();
+
+        NestDraft savedDraft = nestDraftRepository.save(draft);
+        log.info("임시 저장 생성 완료: ID={}, User={}", savedDraft.getId(), userId);
+        return NestDraftResponseDto.from(savedDraft);
+    }
+
+    /**
+     * 내 임시 저장 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NestDraftResponseDto> getMyDrafts(Long userId) {
+        User creator = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return nestDraftRepository.findAllByCreatorOrderByCreatedAtDesc(creator).stream()
+                .map(NestDraftResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 임시 저장 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public NestDraftResponseDto getDraftDetail(Long userId, Long draftId) {
+        NestDraft draft = getDraftIfOwner(userId, draftId);
+        return NestDraftResponseDto.from(draft);
+    }
+
+    /**
+     * 임시 저장 수정
+     */
+    @Transactional
+    public NestDraftResponseDto updateDraft(Long userId, Long draftId, NestDraftUpdateRequestDto requestDto) {
+        NestDraft draft = getDraftIfOwner(userId, draftId);
+
+        if (requestDto.getTitle() != null) draft.setTitle(requestDto.getTitle());
+        if (requestDto.getContent() != null) draft.setContent(requestDto.getContent());
+        if (requestDto.getUnlockRadius() != null) draft.setUnlockRadius(requestDto.getUnlockRadius());
+        if (requestDto.getImageUrls() != null) draft.setImageUrls(requestDto.getImageUrls());
+        if (requestDto.getCategoryIds() != null) draft.setCategoryIds(requestDto.getCategoryIds());
+
+        log.info("임시 저장 수정 완료: ID={}", draftId);
+        return NestDraftResponseDto.from(draft);
+    }
+
+    /**
+     * 임시 저장 삭제
+     */
+    @Transactional
+    public void deleteDraft(Long userId, Long draftId) {
+        NestDraft draft = getDraftIfOwner(userId, draftId);
+        nestDraftRepository.delete(draft);
+        log.info("임시 저장 삭제 완료: ID={}", draftId);
+    }
+
+    /**
+     * 임시 저장 데이터를 둥지로 정식 발행
+     */
+    @Transactional
+    public NestSummaryResponseDto publishDraft(Long userId, Long draftId) {
+        NestDraft draft = getDraftIfOwner(userId, draftId);
+
+        // 발행 시 필수 값 검증 (예: 제목)
+        if (draft.getTitle() == null || draft.getTitle().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // 혹은 적절한 에러 코드
+        }
+
+        // NestService의 createNest를 활용하기 위해 DTO 변환
+        NestCreateRequestDto nestCreateRequestDto = new NestCreateRequestDto(
+                draft.getTitle(),
+                draft.getContent(),
+                draft.getLatitude(),
+                draft.getLongitude(),
+                draft.getUnlockRadius(),
+                draft.getCategoryIds(),
+                draft.getImageUrls(),
+                false // isAd 기본값
+        );
+
+        NestSummaryResponseDto response = nestService.createNest(userId, nestCreateRequestDto);
+
+        // 발행 성공 시 임시 저장 데이터 삭제
+        nestDraftRepository.delete(draft);
+        log.info("임시 저장 발행 완료: DraftID={}, NestID={}", draftId, response.getId());
+
+        return response;
+    }
+
+    private NestDraft getDraftIfOwner(Long userId, Long draftId) {
+        NestDraft draft = nestDraftRepository.findById(draftId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+
+        if (!draft.getCreator().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+        return draft;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
@@ -139,7 +139,7 @@ public class NestDraftService {
 
     private NestDraft getDraftIfOwner(Long userId, Long draftId) {
         NestDraft draft = nestDraftRepository.findById(draftId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.DRAFT_NOT_FOUND));
 
         if (!draft.getCreator().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -1,5 +1,7 @@
 package com.dodo.dodoserver.domain.nest.service;
 
+import static com.dodo.dodoserver.global.common.constants.NestConstants.*;
+
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.*;
@@ -31,6 +33,7 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 @Slf4j
 public class NestService {
+
 
     private final NestRepository nestRepository;
     private final UserRepository userRepository;
@@ -437,7 +440,7 @@ public class NestService {
      */
     @Transactional(readOnly = true)
     public List<NestPinResponseDto> getNearbyPins(Double latitude, Double longitude, Double radiusMeter, List<Long> categoryIds) {
-        double radius = (radiusMeter != null) ? radiusMeter : 5000.0;
+        double radius = (radiusMeter != null) ? radiusMeter : DEFAULT_FIND_RADIUS_METER;
         Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude)); // (x,y)
         return nestRepository.findNearbyPins(point, radius, categoryIds);
     }
@@ -452,7 +455,7 @@ public class NestService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        double radius = (radiusMeter != null) ? radiusMeter : 5000.0;
+        double radius = (radiusMeter != null) ? radiusMeter : DEFAULT_FIND_RADIUS_METER;
         Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude));
 
         Page<NestQueryDto> nests = nestRepository.findNearbyNests(point, radius, categoryIds, pageable);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -52,7 +52,7 @@ public class NestService {
      * 새로운 둥지(Nest) 생성
      */
     @Transactional
-    public NestSummaryResponseDto createNest(Long userId, NestCreateRequestDto requestDto) {
+    public NestSimpleResponseDto createNest(Long userId, NestCreateRequestDto requestDto) {
         User creator = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -99,14 +99,14 @@ public class NestService {
         }
 
         log.info("새로운 둥지 생성 완료: ID={}, Title={}", savedNest.getId(), savedNest.getTitle());
-        return NestSummaryResponseDto.from(savedNest, true);
+        return NestSimpleResponseDto.from(savedNest);
     }
 
     /**
      * 둥지 정보 수정
      */
     @Transactional
-    public NestSummaryResponseDto updateNest(Long userId, Long nestId, NestUpdateRequestDto requestDto) {
+    public NestSimpleResponseDto updateNest(Long userId, Long nestId, NestUpdateRequestDto requestDto) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
@@ -155,7 +155,7 @@ public class NestService {
         }
 
         log.info("둥지 수정 완료: ID={}", nestId);
-        return NestSummaryResponseDto.from(nest, true);
+        return NestSimpleResponseDto.from(nest);
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -39,7 +39,8 @@ public enum ErrorCode {
     OUT_OF_UNLOCK_RADIUS(HttpStatus.BAD_REQUEST, "N002", "해당 위치에서 너무 멀어 해금할 수 없습니다."),
     ALREADY_UNLOCKED(HttpStatus.BAD_REQUEST, "N003", "이미 해금된 둥지입니다."),
     NOT_NEST_CREATOR(HttpStatus.FORBIDDEN, "N004", "둥지 작성자만 권한이 있습니다."),
-    DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "N005", "임시 저장된 둥지를 찾을 수 없습니다.");
+    DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "N005", "임시 저장된 둥지를 찾을 수 없습니다."),
+    DRAFT_NOT_PUBLISHABLE(HttpStatus.BAD_REQUEST, "N006", "필수 정보(제목, 내용, 반경, 카테고리)가 누락되어 발행할 수 없습니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -38,7 +38,8 @@ public enum ErrorCode {
     NEST_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "둥지를 찾을 수 없습니다."),
     OUT_OF_UNLOCK_RADIUS(HttpStatus.BAD_REQUEST, "N002", "해당 위치에서 너무 멀어 해금할 수 없습니다."),
     ALREADY_UNLOCKED(HttpStatus.BAD_REQUEST, "N003", "이미 해금된 둥지입니다."),
-    NOT_NEST_CREATOR(HttpStatus.FORBIDDEN, "N004", "둥지 작성자만 권한이 있습니다.");
+    NOT_NEST_CREATOR(HttpStatus.FORBIDDEN, "N004", "둥지 작성자만 권한이 있습니다."),
+    DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "N005", "임시 저장된 둥지를 찾을 수 없습니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NestConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NestConstants.java
@@ -1,0 +1,9 @@
+package com.dodo.dodoserver.global.common.constants;
+
+public final class NestConstants {
+
+	public static final double DEFAULT_FIND_RADIUS_METER = 2000.0;
+
+	private NestConstants() {
+	}
+}

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NestConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NestConstants.java
@@ -2,8 +2,8 @@ package com.dodo.dodoserver.global.common.constants;
 
 public final class NestConstants {
 
-	public static final double DEFAULT_FIND_RADIUS_METER = 2000.0;
+    public static final double DEFAULT_FIND_RADIUS_METER = 2000.0;
 
-	private NestConstants() {
-	}
+    private NestConstants() {
+    }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestDraftControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestDraftControllerTest.java
@@ -149,13 +149,13 @@ class NestDraftControllerTest {
     @WithMockUserPrincipal
     void publishDraft_success() throws Exception {
         Long draftId = 1L;
-        NestSummaryResponseDto responseDto = NestSummaryResponseDto.builder().id(100L).content("발행완료").build();
+        NestSimpleResponseDto responseDto = NestSimpleResponseDto.builder().id(100L).build();
 
         given(nestDraftService.publishDraft(any(), eq(draftId))).willReturn(responseDto);
 
         mockMvc.perform(post("/api/v1/nests/drafts/{id}/publish", draftId)
                         .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content").value("발행완료"));
+                .andExpect(jsonPath("$.data.id").value(100L));
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestDraftControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestDraftControllerTest.java
@@ -1,0 +1,161 @@
+package com.dodo.dodoserver.domain.nest.controller;
+
+import com.dodo.dodoserver.domain.nest.dto.*;
+import com.dodo.dodoserver.domain.nest.service.NestDraftService;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NestDraftController.class)
+@Import(SecurityConfig.class)
+class NestDraftControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private NestDraftService nestDraftService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("임시 저장 생성 성공")
+    @WithMockUserPrincipal
+    void createDraft_success() throws Exception {
+        NestDraftCreateRequestDto requestDto = new NestDraftCreateRequestDto(37.5, 127.0, "임시제목", "임시내용", 100, List.of(1L), List.of("url"));
+        NestDraftResponseDto responseDto = NestDraftResponseDto.builder().id(1L).title("임시제목").build();
+
+        given(nestDraftService.createDraft(any(), any())).willReturn(responseDto);
+
+        mockMvc.perform(post("/api/v1/nests/drafts")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("임시제목"));
+    }
+
+    @Test
+    @DisplayName("내 임시 저장 목록 조회 성공")
+    @WithMockUserPrincipal
+    void getMyDrafts_success() throws Exception {
+        NestDraftResponseDto responseDto = NestDraftResponseDto.builder().id(1L).title("임시목록").build();
+        given(nestDraftService.getMyDrafts(any())).willReturn(List.of(responseDto));
+
+        mockMvc.perform(get("/api/v1/nests/drafts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("임시목록"));
+    }
+
+    @Test
+    @DisplayName("임시 저장 상세 조회 성공")
+    @WithMockUserPrincipal
+    void getDraftDetail_success() throws Exception {
+        Long draftId = 1L;
+        NestDraftResponseDto responseDto = NestDraftResponseDto.builder().id(draftId).title("상세조회").build();
+
+        given(nestDraftService.getDraftDetail(any(), eq(draftId))).willReturn(responseDto);
+
+        mockMvc.perform(get("/api/v1/nests/drafts/{id}", draftId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("상세조회"));
+    }
+
+    @Test
+    @DisplayName("임시 저장 수정 성공")
+    @WithMockUserPrincipal
+    void updateDraft_success() throws Exception {
+        Long draftId = 1L;
+        NestDraftUpdateRequestDto requestDto = new NestDraftUpdateRequestDto("수정제목", null, null, null, null);
+        NestDraftResponseDto responseDto = NestDraftResponseDto.builder().id(draftId).title("수정제목").build();
+
+        given(nestDraftService.updateDraft(any(), eq(draftId), any())).willReturn(responseDto);
+
+        mockMvc.perform(patch("/api/v1/nests/drafts/{id}", draftId)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정제목"));
+    }
+
+    @Test
+    @DisplayName("임시 저장 삭제 성공")
+    @WithMockUserPrincipal
+    void deleteDraft_success() throws Exception {
+        Long draftId = 1L;
+
+        mockMvc.perform(delete("/api/v1/nests/drafts/{id}", draftId)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("임시 저장 발행 성공")
+    @WithMockUserPrincipal
+    void publishDraft_success() throws Exception {
+        Long draftId = 1L;
+        NestSummaryResponseDto responseDto = NestSummaryResponseDto.builder().id(100L).content("발행완료").build();
+
+        given(nestDraftService.publishDraft(any(), eq(draftId))).willReturn(responseDto);
+
+        mockMvc.perform(post("/api/v1/nests/drafts/{id}/publish", draftId)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").value("발행완료"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
@@ -78,7 +78,7 @@ class NestPostControllerTest {
     @WithMockUserPrincipal
     void createNest_success() throws Exception {
         NestCreateRequestDto requestDto = new NestCreateRequestDto("새둥지", "내용", 37.5, 127.0, 100, List.of(1L), List.of("url"), false);
-        NestSummaryResponseDto responseDto = NestSummaryResponseDto.builder().id(1L).content("새둥지").build();
+        NestSimpleResponseDto responseDto = NestSimpleResponseDto.builder().id(1L).build();
 
         given(nestService.createNest(any(), any())).willReturn(responseDto);
 
@@ -87,7 +87,7 @@ class NestPostControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content").value("새둥지"));
+                .andExpect(jsonPath("$.data.id").value(1L));
     }
 
     @Test
@@ -136,7 +136,7 @@ class NestPostControllerTest {
     void updateNest_success() throws Exception {
         Long nestId = 1L;
         NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", null, null, null, null);
-        NestSummaryResponseDto responseDto = NestSummaryResponseDto.builder().id(nestId).content("수정제목").build();
+        NestSimpleResponseDto responseDto = NestSimpleResponseDto.builder().id(nestId).build();
 
         given(nestService.updateNest(any(), eq(nestId), any())).willReturn(responseDto);
 
@@ -145,7 +145,7 @@ class NestPostControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content").value("수정제목"));
+                .andExpect(jsonPath("$.data.id").value(nestId));
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
@@ -1,0 +1,180 @@
+package com.dodo.dodoserver.domain.nest.service;
+
+import com.dodo.dodoserver.domain.nest.dao.NestDraftRepository;
+import com.dodo.dodoserver.domain.nest.dto.*;
+import com.dodo.dodoserver.domain.nest.entity.NestDraft;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NestDraftServiceTest {
+
+    @InjectMocks
+    private NestDraftService nestDraftService;
+
+    @Mock
+    private NestDraftRepository nestDraftRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NestService nestService;
+
+    @Spy
+    private GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    @Test
+    @DisplayName("임시 저장 생성 성공")
+    void createDraft_success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        NestDraftCreateRequestDto requestDto = new NestDraftCreateRequestDto(37.5, 127.0, "제목", "내용", 100, List.of(1L), List.of("url"));
+        
+        Point point = geometryFactory.createPoint(new Coordinate(127.0, 37.5));
+        NestDraft draft = NestDraft.builder()
+                .id(10L)
+                .creator(user)
+                .point(point)
+                .title("제목")
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(nestDraftRepository.save(any())).willReturn(draft);
+
+        // when
+        NestDraftResponseDto response = nestDraftService.createDraft(userId, requestDto);
+
+        // then
+        assertThat(response.getId()).isEqualTo(10L);
+        assertThat(response.getTitle()).isEqualTo("제목");
+        verify(nestDraftRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("내 임시 저장 목록 조회 성공")
+    void getMyDrafts_success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        NestDraft draft = NestDraft.builder().id(10L).creator(user).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(nestDraftRepository.findAllByCreatorOrderByCreatedAtDesc(user)).willReturn(List.of(draft));
+
+        // when
+        List<NestDraftResponseDto> response = nestDraftService.getMyDrafts(userId);
+
+        // then
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("임시 저장 상세 조회 실패 - 권한 없음")
+    void getDraftDetail_fail_notOwner() {
+        // given
+        Long userId = 1L;
+        Long otherUserId = 2L;
+        Long draftId = 10L;
+        User otherUser = User.builder().id(otherUserId).build();
+        NestDraft draft = NestDraft.builder().id(draftId).creator(otherUser).build();
+
+        given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
+
+        // when & then
+        assertThatThrownBy(() -> nestDraftService.getDraftDetail(userId, draftId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.HANDLE_ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("임시 저장 삭제 성공")
+    void deleteDraft_success() {
+        // given
+        Long userId = 1L;
+        Long draftId = 10L;
+        User user = User.builder().id(userId).build();
+        NestDraft draft = NestDraft.builder().id(draftId).creator(user).build();
+
+        given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
+
+        // when
+        nestDraftService.deleteDraft(userId, draftId);
+
+        // then
+        verify(nestDraftRepository, times(1)).delete(draft);
+    }
+
+    @Test
+    @DisplayName("임시 저장 발행 성공")
+    void publishDraft_success() {
+        // given
+        Long userId = 1L;
+        Long draftId = 10L;
+        User user = User.builder().id(userId).build();
+        Point point = geometryFactory.createPoint(new Coordinate(127.0, 37.5));
+        NestDraft draft = NestDraft.builder()
+                .id(draftId)
+                .creator(user)
+                .point(point)
+                .title("발행제목")
+                .unlockRadius(100)
+                .build();
+
+        given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
+        given(nestService.createNest(eq(userId), any())).willReturn(NestSummaryResponseDto.builder().id(100L).build());
+
+        // when
+        NestSummaryResponseDto response = nestDraftService.publishDraft(userId, draftId);
+
+        // then
+        assertThat(response.getId()).isEqualTo(100L);
+        verify(nestService, times(1)).createNest(eq(userId), any());
+        verify(nestDraftRepository, times(1)).delete(draft);
+    }
+
+    @Test
+    @DisplayName("임시 저장 발행 실패 - 제목 없음")
+    void publishDraft_fail_noTitle() {
+        // given
+        Long userId = 1L;
+        Long draftId = 10L;
+        User user = User.builder().id(userId).build();
+        NestDraft draft = NestDraft.builder()
+                .id(draftId)
+                .creator(user)
+                .title(null)
+                .build();
+
+        given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
+
+        // when & then
+        assertThatThrownBy(() -> nestDraftService.publishDraft(userId, draftId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
@@ -148,10 +148,10 @@ class NestDraftServiceTest {
                 .build();
 
         given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
-        given(nestService.createNest(eq(userId), any())).willReturn(NestSummaryResponseDto.builder().id(100L).build());
+        given(nestService.createNest(eq(userId), any())).willReturn(NestSimpleResponseDto.builder().id(100L).build());
 
         // when
-        NestSummaryResponseDto response = nestDraftService.publishDraft(userId, draftId);
+        NestSimpleResponseDto response = nestDraftService.publishDraft(userId, draftId);
 
         // then
         assertThat(response.getId()).isEqualTo(100L);

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
@@ -180,7 +180,7 @@ class NestDraftServiceTest {
         // when & then
         assertThatThrownBy(() -> nestDraftService.publishDraft(userId, draftId))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+                .hasMessageContaining(ErrorCode.DRAFT_NOT_PUBLISHABLE.getMessage());
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestDraftServiceTest.java
@@ -142,7 +142,9 @@ class NestDraftServiceTest {
                 .creator(user)
                 .point(point)
                 .title("발행제목")
+                .content("발행내용")
                 .unlockRadius(100)
+                .categoryIds(List.of(1L))
                 .build();
 
         given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
@@ -158,7 +160,7 @@ class NestDraftServiceTest {
     }
 
     @Test
-    @DisplayName("임시 저장 발행 실패 - 제목 없음")
+    @DisplayName("임시 저장 발행 실패 - 필수값(제목) 없음")
     void publishDraft_fail_noTitle() {
         // given
         Long userId = 1L;
@@ -168,6 +170,9 @@ class NestDraftServiceTest {
                 .id(draftId)
                 .creator(user)
                 .title(null)
+                .content("내용")
+                .unlockRadius(100)
+                .categoryIds(List.of(1L))
                 .build();
 
         given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
@@ -176,5 +181,51 @@ class NestDraftServiceTest {
         assertThatThrownBy(() -> nestDraftService.publishDraft(userId, draftId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+    }
+
+    @Test
+    @DisplayName("임시 저장 발행 실패 - 필수값(내용) 없음")
+    void publishDraft_fail_noContent() {
+        // given
+        Long userId = 1L;
+        Long draftId = 10L;
+        User user = User.builder().id(userId).build();
+        NestDraft draft = NestDraft.builder()
+                .id(draftId)
+                .creator(user)
+                .title("제목")
+                .content(null)
+                .unlockRadius(100)
+                .categoryIds(List.of(1L))
+                .build();
+
+        given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
+
+        // when & then
+        assertThatThrownBy(() -> nestDraftService.publishDraft(userId, draftId))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("임시 저장 발행 실패 - 필수값(카테고리) 없음")
+    void publishDraft_fail_noCategories() {
+        // given
+        Long userId = 1L;
+        Long draftId = 10L;
+        User user = User.builder().id(userId).build();
+        NestDraft draft = NestDraft.builder()
+                .id(draftId)
+                .creator(user)
+                .title("제목")
+                .content("내용")
+                .unlockRadius(100)
+                .categoryIds(null)
+                .build();
+
+        given(nestDraftRepository.findById(draftId)).willReturn(Optional.of(draft));
+
+        // when & then
+        assertThatThrownBy(() -> nestDraftService.publishDraft(userId, draftId))
+                .isInstanceOf(BusinessException.class);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -79,11 +79,15 @@ class NestServiceTest {
     void createNest_success() {
         NestCreateRequestDto requestDto = new NestCreateRequestDto("제목", "내용", 37.5, 127.0, 100, null, null, false);
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-        given(nestRepository.save(any(Nest.class))).willAnswer(inv -> (Nest) inv.getArgument(0));
+        given(nestRepository.save(any(Nest.class))).willAnswer(inv -> {
+            Nest nest = inv.getArgument(0);
+            nest.setId(100L);
+            return nest;
+        });
 
-        NestSummaryResponseDto response = nestService.createNest(user.getId(), requestDto);
+        NestSimpleResponseDto response = nestService.createNest(user.getId(), requestDto);
 
-        assertThat(response.getContent()).isEqualTo("내용");
+        assertThat(response.getId()).isEqualTo(100L);
         verify(nestRepository).save(any(Nest.class));
     }
 
@@ -97,9 +101,9 @@ class NestServiceTest {
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
-        NestSummaryResponseDto response = nestService.updateNest(user.getId(), nestId, requestDto);
+        NestSimpleResponseDto response = nestService.updateNest(user.getId(), nestId, requestDto);
 
-        assertThat(response.getContent()).isEqualTo("수정내용");
+        assertThat(response.getId()).isEqualTo(nestId);
         assertThat(nest.getContent()).isEqualTo("수정내용");
     }
 


### PR DESCRIPTION
## 📌 개요 (Overview)
현 위치 좌표를 먼저 선점하고 나중에 내용을 채워 발행할 수 있는 임시 저장 기능이 추가되었습니다. 또한, 생성/수정 직후 상세 페이지 리다이렉트를 위해 응답 데이터 규격을 간소화했습니다.
## 🛠️ 작업 내용 (Changes)
  1. 둥지 임시 저장 (Nest Draft) 도메인 구현
   - 현 위치에서 좌표를 먼저 선점하고 나중에 내용을 작성할 수 있는 NestDraft 엔티티 및 API 구현
   - 주요 필드: 좌표(POINT), 제목, 내용, 해금 반경, 이미지 URL 리스트(JSON), 카테고리 ID 리스트(JSON)
   - 발행(Publish) 로직: 임시 데이터를 정식 둥지(Nest)로 이관 후 원본 삭제. 발행 시 필수 데이터(제목, 내용, 반경, 카테고리) 검증 로직 포함.

  2. 응답 DTO 리팩토링 및 최적화
   - 생성/수정/발행 API의 응답을 리다이렉트 처리에 필요한 최소 정보만 담은 NestSimpleResponseDto로 변경
   - 적용 대상: createNest, updateNest, publishDraft
   - 반환 필드: id, createdAt, updatedAt

  3. 에러 핸들링 및 예외 코드 추가
   - DRAFT_NOT_FOUND (N005): 존재하지 않거나 권한 없는 임시 저장 접근 시
   - DRAFT_NOT_PUBLISHABLE (N006): 발행 시 필수 정보 누락 시

  4. 테스트 코드 작성 및 검증
   - NestDraftServiceTest: CRUD 및 발행 비즈니스 로직 검증 (총 6개 케이스)
   - NestDraftControllerTest: API 엔드포인트 동작 및 응답 규격 검증 (총 6개 케이스)
   - 기존 NestServiceTest, NestPostControllerTest를 변경된 응답 DTO에 맞춰 최신화




## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #35 

## 📝 추가 참고 사항 (Additional Notes)

  1. 둥지 임시 저장 (Nest Draft) API 추가
  좌표만 먼저 저장해두고, 나중에 원하는 시점에 상세 정보(제목, 내용 등)를 보완하여 발행할 수 있습니다.
   * POST /api/v1/nests/drafts : 임시 저장 생성 (위도/경도 필수)
   * GET /api/v1/nests/drafts : 내 임시 저장 목록 조회
   * GET /api/v1/nests/drafts/{id} : 임시 저장 상세 조회
   * PATCH /api/v1/nests/drafts/{id} : 임시 저장 내용 수정
   * DELETE /api/v1/nests/drafts/{id} : 임시 저장 삭제
   * POST /api/v1/nests/drafts/{id}/publish : 임시 저장 데이터를 정식 둥지로 발행 (성공 시 기존 Draft는 자동 삭제)

  > ⚠️ 발행(Publish) 주의사항
  > 발행 시점에는 제목, 내용, 해금 반경, 카테고리가 반드시 채워져 있어야 합니다. 누락 시 N006 (DRAFT_NOT_PUBLISHABLE) 에러가 발생합니다.

  2. 응답 DTO 변경 (Redirect용 최적화) 🚀
  기존에는 생성/수정 시 모든 정보를 포함한 무거운 DTO를 반환했으나, 클라이언트에서 id를 기반으로 즉시 리다이렉트하는 패턴에 맞춰 최소 정보만 반환하도록 변경되었습니다.

   * 대상 API:
       * POST /api/v1/nests (둥지 생성)
       * PATCH /api/v1/nests/{id} (둥지 수정)
       * POST /api/v1/nests/drafts/{id}/publish (임시 저장 발행)
   * 변경 후 응답 데이터 (NestSimpleResponseDto):

    1     {
    2       "status": "SUCCESS",
    3       "code": "200",
    4       "message": "...",
    5       "data": {
    6         "id": 123,
    7         "createdAt": "2024-04-25T...",
    8         "updatedAt": "2024-04-25T..."
    9       }
   10     }

  3. 신규 에러 코드
   * N005 (DRAFT_NOT_FOUND) : 임시 저장 데이터를 찾을 수 없거나 접근 권한이 없을 때
   * N006 (DRAFT_NOT_PUBLISHABLE) : 발행에 필요한 필수 정보가 누락되었을 때

