### PR TITLE
Feat/38/like notification

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestNotificationService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestNotificationService.java
@@ -56,10 +56,7 @@ public class NestNotificationService {
         }
 
         // 수신자의 FCM 토큰 목록 조회
-        List<String> fcmTokens = userDeviceRepository.findByUserId(targetUser.getId()).stream()
-                .map(UserDevice::getFcmToken)
-                .filter(Objects::nonNull)
-                .toList();
+        List<String> fcmTokens = getFcmTokens(targetUser);
 
         if (fcmTokens.isEmpty()) {
             return;
@@ -74,5 +71,62 @@ public class NestNotificationService {
         // 이벤트 발행
         eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
         log.info("댓글 알림 이벤트 발행 완료: TargetUser={}, Type={}", targetUser.getEmail(), type);
+    }
+
+    /**
+     * 둥지 좋아요 알림 발행
+     */
+    public void sendNestLikeNotification(User reactor, Nest nest) {
+        User targetUser = nest.getCreator();
+
+        if (reactor.getId().equals(targetUser.getId())) {
+            return;
+        }
+
+        List<String> fcmTokens = getFcmTokens(targetUser);
+        if (fcmTokens.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> data = new HashMap<>();
+        data.put(KEY_TYPE, TYPE_NEST_LIKE);
+        data.put(KEY_NEST_ID, nest.getId().toString());
+
+        eventPublisher.publishEvent(new NotificationEvent(fcmTokens, TITLE_NEST_LIKE,
+                String.format(BODY_NEST_LIKE, reactor.getNickname()), data));
+        log.info("둥지 좋아요 알림 이벤트 발행 완료: TargetUser={}, Reactor={}", targetUser.getEmail(), reactor.getNickname());
+    }
+
+    /**
+     * 댓글 좋아요 알림 발행
+     */
+    public void sendCommentLikeNotification(User reactor, NestComment comment) {
+        User targetUser = comment.getUser();
+        Nest nest = comment.getNest();
+
+        if (reactor.getId().equals(targetUser.getId())) {
+            return;
+        }
+
+        List<String> fcmTokens = getFcmTokens(targetUser);
+        if (fcmTokens.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> data = new HashMap<>();
+        data.put(KEY_TYPE, TYPE_COMMENT_LIKE);
+        data.put(KEY_NEST_ID, nest.getId().toString());
+        data.put(KEY_COMMENT_ID, comment.getId().toString());
+
+        eventPublisher.publishEvent(new NotificationEvent(fcmTokens, TITLE_COMMENT_LIKE,
+                String.format(BODY_COMMENT_LIKE, reactor.getNickname()), data));
+        log.info("댓글 좋아요 알림 이벤트 발행 완료: TargetUser={}, Reactor={}", targetUser.getEmail(), reactor.getNickname());
+    }
+
+    private List<String> getFcmTokens(User targetUser) {
+        return userDeviceRepository.findByUserId(targetUser.getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -539,9 +539,7 @@ public class NestService {
                 // 다른 타입이면 수정
                 reaction.setReactionType(type);
                 log.info("리액션 수정 완료: User={}, Nest={}, Type={}", userId, nestId, type);
-                if (type == ReactionType.LIKE) {
-                    nestNotificationService.sendNestLikeNotification(user, nest);
-                }
+                sendReactionNotification(type, user, nest);
             }
         } else {
             // 없으면 신규 등록
@@ -552,9 +550,13 @@ public class NestService {
                     .build();
             nestReactionRepository.save(reaction);
             log.info("리액션 등록 완료: User={}, Nest={}, Type={}", userId, nestId, type);
-            if (type == ReactionType.LIKE) {
-                nestNotificationService.sendNestLikeNotification(user, nest);
-            }
+            sendReactionNotification(type, user, nest);
+        }
+    }
+
+    private void sendReactionNotification(ReactionType type, User user, Nest nest) {
+        if (type == ReactionType.LIKE) {
+            nestNotificationService.sendNestLikeNotification(user, nest);
         }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -431,6 +431,7 @@ public class NestService {
             commentLikeRepository.save(like);
             comment.increaseLikeCount();
             log.info("댓글 좋아요 등록: User={}, Comment={}", userId, commentId);
+            nestNotificationService.sendCommentLikeNotification(user, comment);
         }
     }
 
@@ -538,6 +539,9 @@ public class NestService {
                 // 다른 타입이면 수정
                 reaction.setReactionType(type);
                 log.info("리액션 수정 완료: User={}, Nest={}, Type={}", userId, nestId, type);
+                if (type == ReactionType.LIKE) {
+                    nestNotificationService.sendNestLikeNotification(user, nest);
+                }
             }
         } else {
             // 없으면 신규 등록
@@ -548,6 +552,9 @@ public class NestService {
                     .build();
             nestReactionRepository.save(reaction);
             log.info("리액션 등록 완료: User={}, Nest={}, Type={}", userId, nestId, type);
+            if (type == ReactionType.LIKE) {
+                nestNotificationService.sendNestLikeNotification(user, nest);
+            }
         }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -11,12 +11,18 @@ public final class NotificationConstants {
     // Type Values
     public static final String TYPE_COMMENT = "COMMENT";
     public static final String TYPE_REPLY = "REPLY";
+    public static final String TYPE_NEST_LIKE = "NEST_LIKE";
+    public static final String TYPE_COMMENT_LIKE = "COMMENT_LIKE";
 
     // Message Templates
     public static final String TITLE_NEW_COMMENT = "둥지에 새 댓글이 달렸습니다!";
     public static final String BODY_NEW_COMMENT = "%s님이 댓글을 남겼습니다.";
     public static final String TITLE_NEW_REPLY = "내 댓글에 답글이 달렸습니다!";
     public static final String BODY_NEW_REPLY = "%s님이 답글을 남겼습니다.";
+    public static final String TITLE_NEST_LIKE = "내 둥지에 좋아요가 달렸어요!";
+    public static final String BODY_NEST_LIKE = "%s님이 회원님의 둥지를 좋아합니다.";
+    public static final String TITLE_COMMENT_LIKE = "내 댓글에 좋아요가 달렸어요!";
+    public static final String BODY_COMMENT_LIKE = "%s님이 회원님의 댓글을 좋아합니다.";
 
     private NotificationConstants() {
     }

--- a/src/main/java/com/dodo/dodoserver/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/CustomOAuth2UserService.java
@@ -54,7 +54,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private User saveOrUpdate(String provider, String providerId, String email, String nickname) {
         User user = userRepository.findByProviderAndProviderId(provider, providerId)
                 .map(entity -> {
-                    entity.setNickname(nickname); // 이름이 변경되었을 수 있으므로 업데이트
+                    if (!entity.isOnboarded()) {
+                        entity.setNickname(nickname);
+                    }
                     return entity;
                 })
                 .orElse(User.builder()

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestNotificationServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestNotificationServiceTest.java
@@ -119,4 +119,61 @@ class NestNotificationServiceTest {
         // then
         verify(eventPublisher, never()).publishEvent(any());
     }
+
+    @Test
+    @DisplayName("둥지 좋아요 시 둥지 제작자에게 알림 발행")
+    void sendNestLikeNotification_success() {
+        // given
+        User reactor = User.builder().id(1L).nickname("좋아요누른사람").build();
+        UserDevice device = UserDevice.builder().fcmToken("token-like").build();
+        given(userDeviceRepository.findByUserId(nest.getCreator().getId())).willReturn(List.of(device));
+
+        // when
+        nestNotificationService.sendNestLikeNotification(reactor, nest);
+
+        // then
+        ArgumentCaptor<NotificationEvent> captor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(captor.capture());
+
+        NotificationEvent event = captor.getValue();
+        assertThat(event.title()).isEqualTo(NotificationConstants.TITLE_NEST_LIKE);
+        assertThat(event.data().get(NotificationConstants.KEY_TYPE)).isEqualTo(NotificationConstants.TYPE_NEST_LIKE);
+        assertThat(event.data().get(NotificationConstants.KEY_NEST_ID)).isEqualTo(nest.getId().toString());
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 시 댓글 작성자에게 알림 발행")
+    void sendCommentLikeNotification_success() {
+        // given
+        User reactor = User.builder().id(1L).nickname("좋아요누른사람").build();
+        User commentAuthor = User.builder().id(3L).nickname("댓글작성자").build();
+        NestComment comment = NestComment.builder().id(50L).user(commentAuthor).nest(nest).build();
+        UserDevice device = UserDevice.builder().fcmToken("token-comment-like").build();
+        given(userDeviceRepository.findByUserId(commentAuthor.getId())).willReturn(List.of(device));
+
+        // when
+        nestNotificationService.sendCommentLikeNotification(reactor, comment);
+
+        // then
+        ArgumentCaptor<NotificationEvent> captor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(captor.capture());
+
+        NotificationEvent event = captor.getValue();
+        assertThat(event.title()).isEqualTo(NotificationConstants.TITLE_COMMENT_LIKE);
+        assertThat(event.data().get(NotificationConstants.KEY_TYPE)).isEqualTo(NotificationConstants.TYPE_COMMENT_LIKE);
+        assertThat(event.data().get(NotificationConstants.KEY_COMMENT_ID)).isEqualTo(comment.getId().toString());
+    }
+
+    @Test
+    @DisplayName("본인 글에 본인이 좋아요를 누르면 알림이 발행되지 않음")
+    void sendNestLikeNotification_SelfAction() {
+        // given
+        User nestCreator = nest.getCreator();
+
+        // when
+        nestNotificationService.sendNestLikeNotification(nestCreator, nest);
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any());
+    }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -256,6 +256,7 @@ class NestServiceTest {
 
         assertThat(comment.getLikeCount()).isEqualTo(1L);
         verify(commentLikeRepository).save(any(CommentLike.class));
+        verify(nestNotificationService).sendCommentLikeNotification(eq(user), eq(comment));
     }
 
     @Test
@@ -373,6 +374,7 @@ class NestServiceTest {
         nestService.handleReaction(user.getId(), nestId, ReactionType.LIKE);
 
         verify(nestReactionRepository).save(any(NestReaction.class));
+        verify(nestNotificationService).sendNestLikeNotification(eq(user), eq(nest));
     }
 
     @Test
@@ -389,6 +391,23 @@ class NestServiceTest {
         nestService.handleReaction(user.getId(), nestId, ReactionType.LIKE);
 
         verify(nestReactionRepository).delete(reaction);
+    }
+
+    @Test
+    @DisplayName("리액션 수정(DISLIKE -> LIKE) 시 알림 발송 성공")
+    void handleReaction_update_to_like() {
+        Long nestId = 1L;
+        Nest nest = Nest.builder().id(nestId).creator(user).build();
+        NestReaction existingReaction = NestReaction.builder().user(user).nest(nest).reactionType(ReactionType.DISLIKE).build();
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
+        given(nestReactionRepository.findByUserAndNest(user, nest)).willReturn(Optional.of(existingReaction));
+
+        nestService.handleReaction(user.getId(), nestId, ReactionType.LIKE);
+
+        assertThat(existingReaction.getReactionType()).isEqualTo(ReactionType.LIKE);
+        verify(nestNotificationService).sendNestLikeNotification(eq(user), eq(nest));
     }
 
     // --- 조회 (Search) 테스트 ---


### PR DESCRIPTION
## 📌 개요 (Overview)
 둥지 및 댓글에 좋아요(리액션)가 발생했을 때 작성자에게 실시간 FCM 알림을 전송하는 기능을 구현했습니다.


## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - 알림 관련 상수 추가 (NotificationConstants)
     - NEST_LIKE, COMMENT_LIKE 타입 정의
     - 각 상황에 맞는 제목 및 메시지 템플릿(닉네임 포함) 추가

   - 비즈니스 로직 연동 (NestService)
     - handleReaction: 좋아요(LIKE)로 등록되거나 변경될 때 둥지 알림 발송 연동
     - handleCommentLike: 댓글 좋아요 신규 등록 시 알림 발송 연동
   - 테스트 코드 작성 및 업데이트
     - NestServiceTest: 좋아요 처리 시 알림 서비스 호출 여부 검증
     - NestNotificationServiceTest: 좋아요 알림 이벤트 발행 및 본인 제외 로직 검증



## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #38 

