### PR TITLE
Feat/22/redis viewcount: Redis 기반 조회수 관리 및 중복 방지 로직 구현

### DIFF
--- a/src/main/java/com/dodo/dodoserver/DodoServerApplication.java
+++ b/src/main/java/com/dodo/dodoserver/DodoServerApplication.java
@@ -2,7 +2,9 @@ package com.dodo.dodoserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class DodoServerApplication {
 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
@@ -3,6 +3,13 @@ package com.dodo.dodoserver.domain.nest.dao;
 import com.dodo.dodoserver.domain.nest.dao.querydsl.NestRepositoryCustom;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NestRepository extends JpaRepository<Nest, Long>, NestRepositoryCustom {
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Nest n SET n.viewCount = n.viewCount + :increment WHERE n.id = :nestId")
+    void incrementViewCount(@Param("nestId") Long nestId, @Param("increment") Long increment);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -45,6 +45,7 @@ public class NestService {
     private final UserProfileRepository userProfileRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final NestNotificationService nestNotificationService;
+    private final RedisViewCountService redisViewCountService;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -291,7 +292,8 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        nest.setViewCount(nest.getViewCount() + 1);
+        // Redis 기반 조회수 증가 (중복 방지 포함)
+        redisViewCountService.incrementViewCount(nestId, userId);
 
         boolean isUnlocked = unlockHistoryRepository.existsByUserAndNest(user, nest) 
                 || nest.getCreator().equals(user); // 자기 자신일 경우 해금
@@ -309,7 +311,7 @@ public class NestService {
                 .title(nest.getTitle())
                 .content(nest.getContent())
                 .unlockRadius(nest.getUnlockRadius())
-                .viewCount(nest.getViewCount())
+                .viewCount(nest.getViewCount() + redisViewCountService.getCachedViewCount(nestId))
                 .isAd(nest.isAd())
                 .createdAt(nest.getCreatedAt())
                 .creatorNickname(nest.getCreator().getNickname())

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
@@ -1,0 +1,84 @@
+package com.dodo.dodoserver.domain.nest.service;
+
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisViewCountService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final NestRepository nestRepository;
+
+    private static final String VIEW_USER_KEY = "nest:view:%d:user:%d";
+    private static final String VIEW_COUNT_KEY = "nest:viewCount:%d";
+    private static final String UPDATED_NESTS_KEY = "nest:updatedViews";
+
+    /**
+     * 조회수 증가 로직 (중복 방지 포함)
+     */
+    public void incrementViewCount(Long nestId, Long userId) {
+        String userKey = String.format(VIEW_USER_KEY, nestId, userId);
+        
+        // 해당 유저가 이 둥지를 24시간 내에 조회한 적이 있는지 확인
+        Boolean isFirstView = redisTemplate.opsForValue().setIfAbsent(userKey, "v", Duration.ofDays(1));
+
+        if (Boolean.TRUE.equals(isFirstView)) {
+            // 중복이 아닐 경우 조회수 카운터 증가
+            String countKey = String.format(VIEW_COUNT_KEY, nestId);
+            redisTemplate.opsForValue().increment(countKey);
+            // 업데이트 대상 둥지 목록(Set)에 추가
+            redisTemplate.opsForSet().add(UPDATED_NESTS_KEY, String.valueOf(nestId));
+        }
+    }
+
+    /**
+     * Redis의 현재 증가분 조회
+     */
+    public Long getCachedViewCount(Long nestId) {
+        String countKey = String.format(VIEW_COUNT_KEY, nestId);
+        String count = redisTemplate.opsForValue().get(countKey);
+        return count != null ? Long.parseLong(count) : 0L;
+    }
+
+    /**
+     * 10분마다 Redis의 조회수 증가분을 DB에 반영
+     */
+    @Scheduled(cron = "0 0/10 * * * *")
+    @Transactional
+    public void syncViewCountToDb() {
+        Set<String> updatedNestIds = redisTemplate.opsForSet().members(UPDATED_NESTS_KEY);
+        if (updatedNestIds == null || updatedNestIds.isEmpty()) {
+            return;
+        }
+
+        log.info("Redis 조회수 DB 동기화 시작: {} 건", updatedNestIds.size());
+
+        for (String nestIdStr : updatedNestIds) {
+            Long nestId = Long.parseLong(nestIdStr);
+            String countKey = String.format(VIEW_COUNT_KEY, nestId);
+            
+            // 값을 가져오는 동시에 삭제하여 원자성 확보 시도 (getAndDelete는 Spring Data Redis 2.6+ 지원)
+            String countStr = redisTemplate.opsForValue().getAndDelete(countKey);
+            
+            if (countStr != null) {
+                Long increment = Long.parseLong(countStr);
+                nestRepository.incrementViewCount(nestId, increment);
+            }
+            
+            // 동기화 완료된 nestId를 Set에서 제거
+            redisTemplate.opsForSet().remove(UPDATED_NESTS_KEY, nestIdStr);
+        }
+        
+        log.info("Redis 조회수 DB 동기화 완료");
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
@@ -33,10 +33,8 @@ public class RedisViewCountService {
         Boolean isFirstView = redisTemplate.opsForValue().setIfAbsent(userKey, "v", Duration.ofDays(1));
 
         if (Boolean.TRUE.equals(isFirstView)) {
-            // 중복이 아닐 경우 조회수 카운터 증가
             String countKey = String.format(VIEW_COUNT_KEY, nestId);
             redisTemplate.opsForValue().increment(countKey);
-            // 업데이트 대상 둥지 목록(Set)에 추가
             redisTemplate.opsForSet().add(UPDATED_NESTS_KEY, String.valueOf(nestId));
         }
     }
@@ -67,7 +65,6 @@ public class RedisViewCountService {
             Long nestId = Long.parseLong(nestIdStr);
             String countKey = String.format(VIEW_COUNT_KEY, nestId);
             
-            // 값을 가져오는 동시에 삭제하여 원자성 확보 시도 (getAndDelete는 Spring Data Redis 2.6+ 지원)
             String countStr = redisTemplate.opsForValue().getAndDelete(countKey);
             
             if (countStr != null) {
@@ -75,7 +72,6 @@ public class RedisViewCountService {
                 nestRepository.incrementViewCount(nestId, increment);
             }
             
-            // 동기화 완료된 nestId를 Set에서 제거
             redisTemplate.opsForSet().remove(UPDATED_NESTS_KEY, nestIdStr);
         }
         

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -58,6 +58,8 @@ class NestServiceTest {
     private CommentLikeRepository commentLikeRepository;
     @Mock
     private NestNotificationService nestNotificationService;
+    @Mock
+    private RedisViewCountService redisViewCountService;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
     private User user;
@@ -216,11 +218,13 @@ class NestServiceTest {
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(false);
         given(userProfileRepository.findByUser(creator)).willReturn(Optional.empty());
         given(nestCategoryRepository.findAllByNest(nest)).willReturn(new ArrayList<>());
+        given(redisViewCountService.getCachedViewCount(nestId)).willReturn(5L);
 
         NestDetailResponseDto response = nestService.getNestDetail(user.getId(), nestId);
 
         assertThat(response.getContent()).isEqualTo("내용");
         assertThat(response.isUnlocked()).isFalse();
+        verify(redisViewCountService).incrementViewCount(nestId, user.getId());
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
 둥지(Nest) 상세 조회 시 발생하는 중복 조회수 증가 문제를 해결하고, DB 부하를 줄이기 위해 Redis를 활용한 조회수 캐싱 및 스케줄링 업데이트 로직을 구현했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - [x] 스케줄링 활성화: DodoServerApplication에 @EnableScheduling 추가하여 주기적인 DB 동기화 기반 마련
   - [x] NestRepository 업데이트: Redis 데이터를 DB에 한꺼번에 반영하기 위한 @Modifying 벌크 업데이트 쿼리 incrementViewCount 구현
   - [x] RedisViewCountService 구현:
       - 동일 유저 중복 조회 방지 (Redis Set 활용, 24시간 TTL 적용)
       - Redis increment 원자적 연산을 통한 정확한 카운팅 보장
       - 10분 주기(@Scheduled)로 Redis에 쌓인 조회수를 DB에 벌크 반영하는 로직 구현
   - [x] NestService 리팩토링:
       - getNestDetail 호출 시 Redis를 거쳐 조회수를 관리하도록 변경
       - 상세 조회 응답 시 DB의 기존 값과 Redis의 최신 카운트를 합산하여 반환함으로써 실시간성 유지
   - [x] 테스트 코드 작성: Mock Redis 설정을 통해 NestService와 RedisViewCountService 간의 연동 로직 검증 완료



## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #22 

## 📝 추가 참고 사항 (Additional Notes)
  - Redis 조회수 데이터는 10분 주기로 DB에 동기화되며, 동기화 완료 후 Redis의 임시 카운트 정보는 삭제됩니다.
