### PR TITLE
Feat/41/postcard domain implementation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --default-authentication-plugin=mysql_native_password
+      - --sort-buffer-size=1M
 
   redis:
     image: redis:7.0-alpine

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestCreateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestCreateRequestDto.java
@@ -27,6 +27,8 @@ public class NestCreateRequestDto {
     @Min(value = 0, message = "해금 반경은 0 이상이어야 합니다.")
     private Integer unlockRadius;
 
+    private Long postcardId;
+
     private List<Long> categoryIds;
 
     @Size(max = 5, message = "이미지는 최대 5개까지 등록 가능합니다.")

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDetailResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDetailResponseDto.java
@@ -30,4 +30,8 @@ public class NestDetailResponseDto {
     private long likeCount;
     private long dislikeCount;
     private boolean isUnlocked;
+
+    // 엽서 정보
+    private boolean hasPostcard;
+    private Long postcardId;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestSummaryResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestSummaryResponseDto.java
@@ -19,11 +19,13 @@ public class NestSummaryResponseDto {
     private List<String> categoryNames;
     private boolean isAd;
     private boolean isUnlocked;
+    private boolean hasPostcard;
+    private Long postcardId;
 
-    public static NestSummaryResponseDto from(Nest nest, boolean isUnlocked, Long likeCount, Double distance, List<String> categoryNames) {
+    public static NestSummaryResponseDto from(Nest nest, boolean isUnlocked, Long likeCount, Double distance, List<String> categoryNames, Long postcardId) {
         String thumbnail = nest.getImages().isEmpty() ? null : nest.getImages().get(0).getImageUrl();
 
-        String displayContent = nest.getContent();
+        String displayContent = nest.getContent(); // 해금 전 콘텐츠 필터링
         if (displayContent != null) {
             int newlineIndex = displayContent.indexOf('\n');
             if (newlineIndex != -1) {
@@ -40,11 +42,13 @@ public class NestSummaryResponseDto {
                 .categoryNames(categoryNames)
                 .isAd(nest.isAd())
                 .isUnlocked(isUnlocked)
+                .hasPostcard(postcardId != null)
+                .postcardId(postcardId)
                 .build();
     }
 
     public static NestSummaryResponseDto from(Nest nest, boolean isUnlocked) {
-        return from(nest, isUnlocked, 0L, null, Collections.emptyList());
+        return from(nest, isUnlocked, 0L, null, Collections.emptyList(), null);
     }
 }
 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestUpdateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestUpdateRequestDto.java
@@ -25,4 +25,6 @@ public class NestUpdateRequestDto {
 
     @Size(max = 5, message = "이미지는 최대 5개까지 등록 가능합니다.")
     private List<String> imageUrls;
+
+    private Long postcardId;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestDraftService.java
@@ -121,6 +121,7 @@ public class NestDraftService {
                 draft.getLatitude(),
                 draft.getLongitude(),
                 draft.getUnlockRadius(),
+                null, // postcardId
                 draft.getCategoryIds(),
                 draft.getImageUrls(),
                 false // isAd 기본값

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -176,6 +176,29 @@ public class NestService {
             });
         }
 
+        // 엽서 추가/변경 로직
+        if (requestDto.getPostcardId() != null) {
+            Postcard newPostcard = postcardRepository.findById(requestDto.getPostcardId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+
+            if (!newPostcard.getCurrentOwner().getId().equals(userId)) {
+                throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
+            }
+            if (newPostcard.isShared()) {
+                throw new BusinessException(ErrorCode.ALREADY_SHARED);
+            }
+            if (newPostcard.isExchanged()) {
+                throw new BusinessException(ErrorCode.ALREADY_EXCHANGED);
+            }
+
+            // 이미 둥지에 공유된 엽서가 있는지 확인
+            postcardRepository.findSharedPostcardByNest(nest).ifPresent(p -> {
+                throw new BusinessException(ErrorCode.ALREADY_SHARED); // 둥지당 엽서는 하나만 가능
+            });
+
+            newPostcard.shareToNest(nest);
+        }
+
         log.info("둥지 수정 완료: ID={}", nestId);
         return NestSimpleResponseDto.from(nest);
     }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -94,7 +94,7 @@ public class NestService {
             Postcard postcard = postcardRepository.findById(requestDto.getPostcardId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
-            if (!postcard.getCurrentOwner().getId().equals(userId)) {
+            if (postcard.getCurrentOwner() == null || !postcard.getCurrentOwner().getId().equals(userId)) {
                 throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
             }
             if (postcard.isShared()) {
@@ -181,7 +181,7 @@ public class NestService {
             Postcard newPostcard = postcardRepository.findById(requestDto.getPostcardId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
-            if (!newPostcard.getCurrentOwner().getId().equals(userId)) {
+            if (newPostcard.getCurrentOwner() == null || !newPostcard.getCurrentOwner().getId().equals(userId)) {
                 throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
             }
             if (newPostcard.isShared()) {

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -295,10 +295,14 @@ public class NestService {
                 .map(uh -> uh.getNest().getId())
                 .collect(Collectors.toSet());
 
+        // 엽서 정보 일괄 조회
+        Map<Long, Long> nestPostcardMap = postcardRepository.findAllByNestInAndIsSharedTrue(nestEntities).stream()
+                .collect(Collectors.toMap(p -> p.getNest().getId(), Postcard::getId));
+
         return nestDtos.stream().map(dto -> {
             Nest nest = dto.getNest();
             boolean isUnlocked = nest.getCreator().equals(user) || unlockedNestIds.contains(nest.getId());
-            return NestSummaryResponseDto.from(nest, isUnlocked, dto.getLikeCount(), dto.getDistance(), dto.getCategoryNames());
+            return NestSummaryResponseDto.from(nest, isUnlocked, dto.getLikeCount(), dto.getDistance(), dto.getCategoryNames(), nestPostcardMap.get(nest.getId()));
         }).collect(Collectors.toList());
     }
 
@@ -495,10 +499,14 @@ public class NestService {
                 .map(uh -> uh.getNest().getId())
                 .collect(Collectors.toSet());
 
+        // 현재 페이지의 엽서 정보 일괄 조회
+        Map<Long, Long> nestPostcardMap = postcardRepository.findAllByNestInAndIsSharedTrue(nestEntities).stream()
+                .collect(Collectors.toMap(p -> p.getNest().getId(), Postcard::getId));
+
         return nests.map(dto -> {
             Nest nestEntity = dto.getNest();
             boolean isUnlocked = nestEntity.getCreator().equals(user) || unlockedNestIds.contains(nestEntity.getId());
-            return NestSummaryResponseDto.from(nestEntity, isUnlocked, dto.getLikeCount(), dto.getDistance(), dto.getCategoryNames());
+            return NestSummaryResponseDto.from(nestEntity, isUnlocked, dto.getLikeCount(), dto.getDistance(), dto.getCategoryNames(), nestPostcardMap.get(nestEntity.getId()));
         });
     }
 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -331,6 +331,9 @@ public class NestService {
                 .map(nc -> nc.getCategory().getName())
                 .collect(Collectors.toList());
 
+        // 엽서 정보 조회
+        Postcard sharedPostcard = postcardRepository.findSharedPostcardByNest(nest).orElse(null);
+
         return NestDetailResponseDto.builder()
                 .id(nest.getId())
                 .title(nest.getTitle())
@@ -346,6 +349,8 @@ public class NestService {
                 .likeCount(likeCount)
                 .dislikeCount(dislikeCount)
                 .isUnlocked(isUnlocked)
+                .hasPostcard(sharedPostcard != null)
+                .postcardId(sharedPostcard != null ? sharedPostcard.getId() : null)
                 .build();
     }
 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -7,6 +7,8 @@ import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.*;
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.*;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.user.dao.UserProfileRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
@@ -46,6 +48,7 @@ public class NestService {
     private final CommentLikeRepository commentLikeRepository;
     private final NestNotificationService nestNotificationService;
     private final RedisViewCountService redisViewCountService;
+    private final PostcardRepository postcardRepository;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -85,6 +88,24 @@ public class NestService {
         }
 
         Nest savedNest = nestRepository.save(nest);
+
+        // 초기 엽서 등록 처리
+        if (requestDto.getPostcardId() != null) {
+            Postcard postcard = postcardRepository.findById(requestDto.getPostcardId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+
+            if (!postcard.getCurrentOwner().getId().equals(userId)) {
+                throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
+            }
+            if (postcard.isShared()) {
+                throw new BusinessException(ErrorCode.ALREADY_SHARED);
+            }
+            if (postcard.isExchanged()) {
+                throw new BusinessException(ErrorCode.ALREADY_EXCHANGED);
+            }
+
+            postcard.shareToNest(savedNest);
+        }
 
         if (requestDto.getCategoryIds() != null) {
             requestDto.getCategoryIds().forEach(categoryId -> {

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -3,7 +3,10 @@ package com.dodo.dodoserver.domain.postcard.controller;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
 import com.dodo.dodoserver.domain.postcard.dto.*;
 import com.dodo.dodoserver.domain.postcard.service.PostcardService;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostcardController {
 
     private final PostcardService postcardService;
+    private final UserRepository userRepository;
 
     /**
      * 엽서 등록 (생성)
@@ -24,7 +28,7 @@ public class PostcardController {
     public ApiResponseDto<PostcardResponseDto> createPostcard(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestBody PostcardCreateRequestDto requestDto) {
-        User user = userPrincipal.getUser();
+        User user = getUser(userPrincipal);
         return ApiResponseDto.success(postcardService.createPostcard(user, requestDto));
     }
 
@@ -35,7 +39,7 @@ public class PostcardController {
     public ApiResponseDto<PostcardResponseDto> getPostcardDetail(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id) {
-        User user = userPrincipal.getUser();
+        User user = getUser(userPrincipal);
         return ApiResponseDto.success(postcardService.getPostcardDetail(user, id));
     }
 
@@ -47,7 +51,7 @@ public class PostcardController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id,
             @RequestBody PostcardCreateRequestDto requestDto) {
-        User user = userPrincipal.getUser();
+        User user = getUser(userPrincipal);
         return ApiResponseDto.success(postcardService.updatePostcard(user, id, requestDto));
     }
 
@@ -58,7 +62,7 @@ public class PostcardController {
     public ApiResponseDto<Void> deletePostcard(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id) {
-        User user = userPrincipal.getUser();
+        User user = getUser(userPrincipal);
         postcardService.deletePostcard(user, id);
         return ApiResponseDto.success(null);
     }
@@ -69,7 +73,7 @@ public class PostcardController {
     @GetMapping("/postcards/exchange-check")
     public ApiResponseDto<PostcardExchangeCheckResponseDto> checkExchangeAvailability(
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        User user = userPrincipal.getUser();
+        User user = getUser(userPrincipal);
         return ApiResponseDto.success(postcardService.checkExchangeAvailability(user));
     }
 
@@ -81,7 +85,7 @@ public class PostcardController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable(name = "id") Long nestId,
             @RequestBody PostcardExchangeRequestDto requestDto) {
-        User user = userPrincipal.getUser();
+        User user = getUser(userPrincipal);
         return ApiResponseDto.success(postcardService.exchangePostcard(user, nestId, requestDto));
     }
 
@@ -93,8 +97,13 @@ public class PostcardController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id,
             @RequestParam ReactionType type) {
-        User user = userPrincipal.getUser();
+        User user = getUser(userPrincipal);
         postcardService.addReaction(user, id, type);
         return ApiResponseDto.success(null);
+    }
+
+    private User getUser(UserPrincipal userPrincipal) {
+        return userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import com.dodo.dodoserver.domain.postcard.service.PostcardService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.UserPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +29,7 @@ public class PostcardController {
     @PostMapping("/postcards")
     public ApiResponseDto<PostcardResponseDto> createPostcard(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestBody PostcardCreateRequestDto requestDto) {
+            @Valid @RequestBody PostcardCreateRequestDto requestDto) {
         return ApiResponseDto.success(postcardService.createPostcard(userPrincipal.getId(), requestDto));
     }
 
@@ -49,7 +50,7 @@ public class PostcardController {
     public ApiResponseDto<PostcardResponseDto> updatePostcard(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id,
-            @RequestBody PostcardCreateRequestDto requestDto) {
+            @Valid @RequestBody PostcardCreateRequestDto requestDto) {
         return ApiResponseDto.success(postcardService.updatePostcard(userPrincipal.getId(), id, requestDto));
     }
 
@@ -91,7 +92,7 @@ public class PostcardController {
     public ApiResponseDto<PostcardResponseDto> exchangePostcard(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable(name = "id") Long nestId,
-            @RequestBody PostcardExchangeRequestDto requestDto) {
+            @Valid @RequestBody PostcardExchangeRequestDto requestDto) {
         return ApiResponseDto.success(postcardService.exchangePostcard(userPrincipal.getId(), nestId, requestDto));
     }
 

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -1,12 +1,8 @@
 package com.dodo.dodoserver.domain.postcard.controller;
 
-import com.dodo.dodoserver.domain.nest.entity.ReactionType;
 import com.dodo.dodoserver.domain.postcard.dto.*;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import com.dodo.dodoserver.domain.postcard.service.PostcardService;
-import com.dodo.dodoserver.domain.user.dao.UserRepository;
-import com.dodo.dodoserver.domain.user.entity.User;
-import com.dodo.dodoserver.error.ErrorCode;
-import com.dodo.dodoserver.error.exception.BusinessException;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -83,13 +79,13 @@ public class PostcardController {
     }
 
     /**
-     * 엽서 이모지 반응
+     * 엽서 리액션 반응
      */
     @PostMapping("/postcards/{id}/reactions")
     public ApiResponseDto<Void> addReaction(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id,
-            @RequestParam ReactionType type) {
+            @RequestParam PostcardReactionType type) {
         postcardService.addReaction(userPrincipal.getId(), id, type);
         return ApiResponseDto.success(null);
     }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -70,8 +70,9 @@ public class PostcardController {
     @GetMapping("/postcards/inventory")
     public ApiResponseDto<Page<PostcardResponseDto>> getPostcardInventory(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(required = false, defaultValue = "ALL") String filter,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponseDto.success(postcardService.getPostcardInventory(userPrincipal.getId(), pageable));
+        return ApiResponseDto.success(postcardService.getPostcardInventory(userPrincipal.getId(), filter, pageable));
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 public class PostcardController {
 
     private final PostcardService postcardService;
-    private final UserRepository userRepository;
 
     /**
      * 엽서 등록 (생성)
@@ -28,8 +27,7 @@ public class PostcardController {
     public ApiResponseDto<PostcardResponseDto> createPostcard(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestBody PostcardCreateRequestDto requestDto) {
-        User user = getUser(userPrincipal);
-        return ApiResponseDto.success(postcardService.createPostcard(user, requestDto));
+        return ApiResponseDto.success(postcardService.createPostcard(userPrincipal.getId(), requestDto));
     }
 
     /**
@@ -39,8 +37,7 @@ public class PostcardController {
     public ApiResponseDto<PostcardResponseDto> getPostcardDetail(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id) {
-        User user = getUser(userPrincipal);
-        return ApiResponseDto.success(postcardService.getPostcardDetail(user, id));
+        return ApiResponseDto.success(postcardService.getPostcardDetail(userPrincipal.getId(), id));
     }
 
     /**
@@ -51,8 +48,7 @@ public class PostcardController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id,
             @RequestBody PostcardCreateRequestDto requestDto) {
-        User user = getUser(userPrincipal);
-        return ApiResponseDto.success(postcardService.updatePostcard(user, id, requestDto));
+        return ApiResponseDto.success(postcardService.updatePostcard(userPrincipal.getId(), id, requestDto));
     }
 
     /**
@@ -62,8 +58,7 @@ public class PostcardController {
     public ApiResponseDto<Void> deletePostcard(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id) {
-        User user = getUser(userPrincipal);
-        postcardService.deletePostcard(user, id);
+        postcardService.deletePostcard(userPrincipal.getId(), id);
         return ApiResponseDto.success(null);
     }
 
@@ -73,8 +68,7 @@ public class PostcardController {
     @GetMapping("/postcards/exchange-check")
     public ApiResponseDto<PostcardExchangeCheckResponseDto> checkExchangeAvailability(
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        User user = getUser(userPrincipal);
-        return ApiResponseDto.success(postcardService.checkExchangeAvailability(user));
+        return ApiResponseDto.success(postcardService.checkExchangeAvailability(userPrincipal.getId()));
     }
 
     /**
@@ -85,8 +79,7 @@ public class PostcardController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable(name = "id") Long nestId,
             @RequestBody PostcardExchangeRequestDto requestDto) {
-        User user = getUser(userPrincipal);
-        return ApiResponseDto.success(postcardService.exchangePostcard(user, nestId, requestDto));
+        return ApiResponseDto.success(postcardService.exchangePostcard(userPrincipal.getId(), nestId, requestDto));
     }
 
     /**
@@ -97,13 +90,7 @@ public class PostcardController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id,
             @RequestParam ReactionType type) {
-        User user = getUser(userPrincipal);
-        postcardService.addReaction(user, id, type);
+        postcardService.addReaction(userPrincipal.getId(), id, type);
         return ApiResponseDto.success(null);
-    }
-
-    private User getUser(UserPrincipal userPrincipal) {
-        return userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -56,6 +58,15 @@ public class PostcardController {
             @PathVariable Long id) {
         postcardService.deletePostcard(userPrincipal.getId(), id);
         return ApiResponseDto.success(null);
+    }
+
+    /**
+     * 엽서 인벤토리 조회 (내가 만든 엽서 + 내가 가져온 엽서)
+     */
+    @GetMapping("/postcards/inventory")
+    public ApiResponseDto<List<PostcardResponseDto>> getPostcardInventory(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponseDto.success(postcardService.getPostcardInventory(userPrincipal.getId()));
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -1,0 +1,100 @@
+package com.dodo.dodoserver.domain.postcard.controller;
+
+import com.dodo.dodoserver.domain.nest.entity.ReactionType;
+import com.dodo.dodoserver.domain.postcard.dto.*;
+import com.dodo.dodoserver.domain.postcard.service.PostcardService;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PostcardController {
+
+    private final PostcardService postcardService;
+
+    /**
+     * 엽서 등록 (생성)
+     */
+    @PostMapping("/postcards")
+    public ApiResponseDto<PostcardResponseDto> createPostcard(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody PostcardCreateRequestDto requestDto) {
+        User user = userPrincipal.getUser();
+        return ApiResponseDto.success(postcardService.createPostcard(user, requestDto));
+    }
+
+    /**
+     * 엽서 상세 조회
+     */
+    @GetMapping("/postcards/{id}")
+    public ApiResponseDto<PostcardResponseDto> getPostcardDetail(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        User user = userPrincipal.getUser();
+        return ApiResponseDto.success(postcardService.getPostcardDetail(user, id));
+    }
+
+    /**
+     * 엽서 수정
+     */
+    @PutMapping("/postcards/{id}")
+    public ApiResponseDto<PostcardResponseDto> updatePostcard(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id,
+            @RequestBody PostcardCreateRequestDto requestDto) {
+        User user = userPrincipal.getUser();
+        return ApiResponseDto.success(postcardService.updatePostcard(user, id, requestDto));
+    }
+
+    /**
+     * 엽서 삭제
+     */
+    @DeleteMapping("/postcards/{id}")
+    public ApiResponseDto<Void> deletePostcard(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        User user = userPrincipal.getUser();
+        postcardService.deletePostcard(user, id);
+        return ApiResponseDto.success(null);
+    }
+
+    /**
+     * 엽서 교환 가능 여부 확인
+     */
+    @GetMapping("/postcards/exchange-check")
+    public ApiResponseDto<PostcardExchangeCheckResponseDto> checkExchangeAvailability(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        User user = userPrincipal.getUser();
+        return ApiResponseDto.success(postcardService.checkExchangeAvailability(user));
+    }
+
+    /**
+     * 엽서 교환
+     */
+    @PostMapping("/nests/{id}/exchange")
+    public ApiResponseDto<PostcardResponseDto> exchangePostcard(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable(name = "id") Long nestId,
+            @RequestBody PostcardExchangeRequestDto requestDto) {
+        User user = userPrincipal.getUser();
+        return ApiResponseDto.success(postcardService.exchangePostcard(user, nestId, requestDto));
+    }
+
+    /**
+     * 엽서 이모지 반응
+     */
+    @PostMapping("/postcards/{id}/reactions")
+    public ApiResponseDto<Void> addReaction(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id,
+            @RequestParam ReactionType type) {
+        User user = userPrincipal.getUser();
+        postcardService.addReaction(user, id, type);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/controller/PostcardController.java
@@ -6,6 +6,10 @@ import com.dodo.dodoserver.domain.postcard.service.PostcardService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -64,9 +68,10 @@ public class PostcardController {
      * 엽서 인벤토리 조회 (내가 만든 엽서 + 내가 가져온 엽서)
      */
     @GetMapping("/postcards/inventory")
-    public ApiResponseDto<List<PostcardResponseDto>> getPostcardInventory(
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        return ApiResponseDto.success(postcardService.getPostcardInventory(userPrincipal.getId()));
+    public ApiResponseDto<Page<PostcardResponseDto>> getPostcardInventory(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(postcardService.getPostcardInventory(userPrincipal.getId(), pageable));
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardReactionRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardReactionRepository.java
@@ -1,0 +1,12 @@
+package com.dodo.dodoserver.domain.postcard.dao;
+
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReaction;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostcardReactionRepository extends JpaRepository<PostcardReaction, Long> {
+    Optional<PostcardReaction> findByPostcardAndUser(Postcard postcard, User user);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardReactionRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardReactionRepository.java
@@ -5,8 +5,13 @@ import com.dodo.dodoserver.domain.postcard.entity.PostcardReaction;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostcardReactionRepository extends JpaRepository<PostcardReaction, Long> {
     Optional<PostcardReaction> findByPostcardAndUser(Postcard postcard, User user);
+
+    List<PostcardReaction> findAllByPostcardIn(List<Postcard> postcards);
+
+    Optional<PostcardReaction> findByPostcard(Postcard postcard);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostcardRepository extends JpaRepository<Postcard, Long> {
@@ -22,4 +23,7 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
 
     @Query("SELECT p FROM Postcard p WHERE p.nest = :nest AND p.isShared = true")
     Optional<Postcard> findSharedPostcardByNest(@Param("nest") Nest nest);
+
+    @Query("SELECT p FROM Postcard p WHERE p.nest IN :nests AND p.isShared = true")
+    List<Postcard> findAllByNestInAndIsSharedTrue(@Param("nests") java.util.Collection<Nest> nests);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -4,7 +4,8 @@ import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.user.entity.User;
 import jakarta.persistence.LockModeType;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -30,5 +31,5 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
     List<Postcard> findAllByNestInAndIsSharedTrue(@Param("nests") java.util.Collection<Nest> nests);
 
     @Query("SELECT p FROM Postcard p WHERE p.originalAuthor = :user OR p.currentOwner = :user")
-    List<Postcard> findInventoryByUser(@Param("user") User user, Sort sort);
+    Page<Postcard> findInventoryByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -1,0 +1,25 @@
+package com.dodo.dodoserver.domain.postcard.dao;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface PostcardRepository extends JpaRepository<Postcard, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Postcard p WHERE p.id = :id")
+    Optional<Postcard> findByIdForUpdate(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Postcard p WHERE p.nest = :nest AND p.isShared = true")
+    Optional<Postcard> findSharedPostcardByNestForUpdate(@Param("nest") Nest nest);
+
+    @Query("SELECT p FROM Postcard p WHERE p.nest = :nest AND p.isShared = true")
+    Optional<Postcard> findSharedPostcardByNest(@Param("nest") Nest nest);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -2,7 +2,9 @@ package com.dodo.dodoserver.domain.postcard.dao;
 
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.user.entity.User;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +28,7 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
 
     @Query("SELECT p FROM Postcard p WHERE p.nest IN :nests AND p.isShared = true")
     List<Postcard> findAllByNestInAndIsSharedTrue(@Param("nests") java.util.Collection<Nest> nests);
+
+    @Query("SELECT p FROM Postcard p WHERE p.originalAuthor = :user OR p.currentOwner = :user")
+    List<Postcard> findInventoryByUser(@Param("user") User user, Sort sort);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -32,4 +32,10 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
 
     @Query("SELECT p FROM Postcard p WHERE p.originalAuthor = :user OR p.currentOwner = :user")
     Page<Postcard> findInventoryByUser(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT p FROM Postcard p WHERE p.originalAuthor = :user")
+    Page<Postcard> findCreatedByUser(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT p FROM Postcard p WHERE p.currentOwner = :user AND p.originalAuthor != :user")
+    Page<Postcard> findAcquiredByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardCreateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.postcard.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostcardCreateRequestDto {
+
+    @NotBlank(message = "이미지 url은 필수입니다.")
     private String imageUrl;
+
+    @NotBlank(message = "엽서 내용은 필수입니다.")
     private String content;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardCreateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardCreateRequestDto.java
@@ -1,0 +1,15 @@
+package com.dodo.dodoserver.domain.postcard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostcardCreateRequestDto {
+    private String imageUrl;
+    private String content;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardExchangeCheckResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardExchangeCheckResponseDto.java
@@ -1,0 +1,16 @@
+package com.dodo.dodoserver.domain.postcard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostcardExchangeCheckResponseDto {
+    private boolean canExchange;
+    private int remainingCount;
+    private String reason;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardExchangeRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardExchangeRequestDto.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.postcard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostcardExchangeRequestDto {
+    private Long myPostcardId;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardExchangeRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardExchangeRequestDto.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.postcard.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostcardExchangeRequestDto {
+    @NotNull(message = "교환할 내 엽서 ID는 필수입니다.")
     private Long myPostcardId;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardResponseDto.java
@@ -1,6 +1,7 @@
 package com.dodo.dodoserver.domain.postcard.dto;
 
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +22,7 @@ public class PostcardResponseDto {
     private boolean isShared;
     private boolean isExchanged;
     private LocalDateTime createdAt;
+    private PostcardReactionType reactionType;
 
     public static PostcardResponseDto from(Postcard postcard) {
         return PostcardResponseDto.builder()
@@ -32,6 +34,20 @@ public class PostcardResponseDto {
                 .isShared(postcard.isShared())
                 .isExchanged(postcard.isExchanged())
                 .createdAt(postcard.getCreatedAt())
+                .build();
+    }
+
+    public static PostcardResponseDto from(Postcard postcard, PostcardReactionType reactionType) {
+        return PostcardResponseDto.builder()
+                .id(postcard.getId())
+                .originalAuthorId(postcard.getOriginalAuthor().getId())
+                .originalAuthorNickname(postcard.getOriginalAuthor().getNickname())
+                .imageUrl(postcard.getImageUrl())
+                .content(postcard.getContent())
+                .isShared(postcard.isShared())
+                .isExchanged(postcard.isExchanged())
+                .createdAt(postcard.getCreatedAt())
+                .reactionType(reactionType)
                 .build();
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardResponseDto.java
@@ -1,0 +1,37 @@
+package com.dodo.dodoserver.domain.postcard.dto;
+
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostcardResponseDto {
+    private Long id;
+    private Long originalAuthorId;
+    private String originalAuthorNickname;
+    private String imageUrl;
+    private String content;
+    private boolean isShared;
+    private boolean isExchanged;
+    private LocalDateTime createdAt;
+
+    public static PostcardResponseDto from(Postcard postcard) {
+        return PostcardResponseDto.builder()
+                .id(postcard.getId())
+                .originalAuthorId(postcard.getOriginalAuthor().getId())
+                .originalAuthorNickname(postcard.getOriginalAuthor().getNickname())
+                .imageUrl(postcard.getImageUrl())
+                .content(postcard.getContent())
+                .isShared(postcard.isShared())
+                .isExchanged(postcard.isExchanged())
+                .createdAt(postcard.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dto/PostcardResponseDto.java
@@ -21,10 +21,11 @@ public class PostcardResponseDto {
     private String content;
     private boolean isShared;
     private boolean isExchanged;
+    private boolean isMine; // 내가 원작자인지 여부
     private LocalDateTime createdAt;
     private PostcardReactionType reactionType;
 
-    public static PostcardResponseDto from(Postcard postcard) {
+    public static PostcardResponseDto from(Postcard postcard, Long currentUserId) {
         return PostcardResponseDto.builder()
                 .id(postcard.getId())
                 .originalAuthorId(postcard.getOriginalAuthor().getId())
@@ -33,11 +34,12 @@ public class PostcardResponseDto {
                 .content(postcard.getContent())
                 .isShared(postcard.isShared())
                 .isExchanged(postcard.isExchanged())
+                .isMine(postcard.getOriginalAuthor().getId().equals(currentUserId))
                 .createdAt(postcard.getCreatedAt())
                 .build();
     }
 
-    public static PostcardResponseDto from(Postcard postcard, PostcardReactionType reactionType) {
+    public static PostcardResponseDto from(Postcard postcard, PostcardReactionType reactionType, Long currentUserId) {
         return PostcardResponseDto.builder()
                 .id(postcard.getId())
                 .originalAuthorId(postcard.getOriginalAuthor().getId())
@@ -46,6 +48,7 @@ public class PostcardResponseDto {
                 .content(postcard.getContent())
                 .isShared(postcard.isShared())
                 .isExchanged(postcard.isExchanged())
+                .isMine(postcard.getOriginalAuthor().getId().equals(currentUserId))
                 .createdAt(postcard.getCreatedAt())
                 .reactionType(reactionType)
                 .build();

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/entity/Postcard.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/entity/Postcard.java
@@ -43,7 +43,7 @@ public class Postcard {
     @Column(nullable = false)
     private String imageUrl;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Builder.Default

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/entity/Postcard.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/entity/Postcard.java
@@ -1,0 +1,86 @@
+package com.dodo.dodoserver.domain.postcard.entity;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "postcards")
+@EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE postcards SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Postcard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "original_author_id", nullable = false)
+    private User originalAuthor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_owner_id")
+    private User currentOwner;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "nest_id")
+    private Nest nest;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Builder.Default
+    @Column(name = "is_shared", nullable = false)
+    private boolean isShared = false;
+
+    @Builder.Default
+    @Column(name = "is_exchanged", nullable = false)
+    private boolean isExchanged = false;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    /**
+     * 엽서 교환 시 상태 변경 (둥지 -> 유저)
+     */
+    public void exchangeToUser(User newOwner) {
+        this.currentOwner = newOwner;
+        this.nest = null;
+        this.isShared = false;
+        this.isExchanged = true;
+    }
+
+    /**
+     * 엽서 등록 시 상태 변경 (유저 -> 둥지)
+     */
+    public void shareToNest(Nest nest) {
+        this.currentOwner = null;
+        this.nest = nest;
+        this.isShared = true;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/entity/PostcardReaction.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/entity/PostcardReaction.java
@@ -1,0 +1,44 @@
+package com.dodo.dodoserver.domain.postcard.entity;
+
+import com.dodo.dodoserver.domain.nest.entity.ReactionType;
+import com.dodo.dodoserver.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "postcard_reactions", 
+       uniqueConstraints = {
+           @UniqueConstraint(columnNames = {"postcard_id", "user_id"})
+       })
+@EntityListeners(AuditingEntityListener.class)
+public class PostcardReaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postcard_id", nullable = false)
+    private Postcard postcard;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReactionType reactionType;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/entity/PostcardReaction.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/entity/PostcardReaction.java
@@ -1,6 +1,5 @@
 package com.dodo.dodoserver.domain.postcard.entity;
 
-import com.dodo.dodoserver.domain.nest.entity.ReactionType;
 import com.dodo.dodoserver.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -36,7 +35,7 @@ public class PostcardReaction {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private ReactionType reactionType;
+    private PostcardReactionType reactionType;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/entity/PostcardReactionType.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/entity/PostcardReactionType.java
@@ -1,0 +1,15 @@
+package com.dodo.dodoserver.domain.postcard.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostcardReactionType {
+    TOUCHED("감동이에요"),
+    AWESOME("멋져요"),
+    HAPPY("기뻐요"),
+    BEST("최고에요");
+
+    private final String value;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardNotificationService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardNotificationService.java
@@ -49,6 +49,33 @@ public class PostcardNotificationService {
         log.info("엽서 교환 알림 이벤트 발행 완료: TargetUser={}, Nest={}", targetUser.getEmail(), nest.getTitle());
     }
 
+    /**
+     * 엽서 좋아요 알림 발행
+     */
+    public void sendPostcardLikeNotification(User reactor, Postcard postcard) {
+        User targetUser = postcard.getOriginalAuthor();
+
+        // 본인 엽서에 본인이 반응을 한 경우 알림 미발행
+        if (reactor.getId().equals(targetUser.getId())) {
+            return;
+        }
+
+        List<String> fcmTokens = getFcmTokens(targetUser);
+        if (fcmTokens.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> data = new HashMap<>();
+        data.put(KEY_TYPE, TYPE_POSTCARD_LIKE);
+        data.put(KEY_POSTCARD_ID, postcard.getId().toString());
+
+        String title = TITLE_POSTCARD_LIKE;
+        String body = String.format(BODY_POSTCARD_LIKE, reactor.getNickname());
+
+        eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
+        log.info("엽서 좋아요 알림 이벤트 발행 완료: TargetUser={}, Reactor={}", targetUser.getEmail(), reactor.getNickname());
+    }
+
     private List<String> getFcmTokens(User targetUser) {
         return userDeviceRepository.findByUserId(targetUser.getId()).stream()
                 .map(UserDevice::getFcmToken)

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardNotificationService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardNotificationService.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.postcard.service;
 
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.domain.user.entity.UserDevice;
@@ -50,9 +51,9 @@ public class PostcardNotificationService {
     }
 
     /**
-     * 엽서 좋아요 알림 발행
+     * 엽서 리액션 알림 발행
      */
-    public void sendPostcardLikeNotification(User reactor, Postcard postcard) {
+    public void sendPostcardReactionNotification(User reactor, Postcard postcard, PostcardReactionType reactionType) {
         User targetUser = postcard.getOriginalAuthor();
 
         // 본인 엽서에 본인이 반응을 한 경우 알림 미발행
@@ -70,10 +71,11 @@ public class PostcardNotificationService {
         data.put(KEY_POSTCARD_ID, postcard.getId().toString());
 
         String title = TITLE_POSTCARD_LIKE;
-        String body = String.format(BODY_POSTCARD_LIKE, reactor.getNickname());
+        String body = String.format(BODY_POSTCARD_LIKE, reactor.getNickname(), reactionType.getValue());
 
         eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
-        log.info("엽서 좋아요 알림 이벤트 발행 완료: TargetUser={}, Reactor={}", targetUser.getEmail(), reactor.getNickname());
+        log.info("엽서 리액션 알림 이벤트 발행 완료: TargetUser={}, Reactor={}, Type={}", 
+                targetUser.getEmail(), reactor.getNickname(), reactionType.name());
     }
 
     private List<String> getFcmTokens(User targetUser) {

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardNotificationService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardNotificationService.java
@@ -1,0 +1,58 @@
+package com.dodo.dodoserver.domain.postcard.service;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostcardNotificationService {
+
+    private final UserDeviceRepository userDeviceRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 엽서 교환 알림 발행
+     */
+    public void sendPostcardExchangedNotification(Postcard targetPostcard, Nest nest) {
+        User targetUser = targetPostcard.getOriginalAuthor();
+
+        List<String> fcmTokens = getFcmTokens(targetUser);
+        if (fcmTokens.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> data = new HashMap<>();
+        data.put(KEY_TYPE, TYPE_POSTCARD_EXCHANGED);
+        data.put(KEY_NEST_ID, nest.getId().toString());
+        data.put(KEY_POSTCARD_ID, targetPostcard.getId().toString());
+
+        String title = TITLE_POSTCARD_EXCHANGED;
+        String body = String.format(BODY_POSTCARD_EXCHANGED, nest.getTitle());
+
+        eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
+        log.info("엽서 교환 알림 이벤트 발행 완료: TargetUser={}, Nest={}", targetUser.getEmail(), nest.getTitle());
+    }
+
+    private List<String> getFcmTokens(User targetUser) {
+        return userDeviceRepository.findByUserId(targetUser.getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardRedisService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardRedisService.java
@@ -1,0 +1,54 @@
+package com.dodo.dodoserver.domain.postcard.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class PostcardRedisService {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String KEY_PREFIX = "postcard_exchange:date:";
+    private static final int MAX_EXCHANGE_COUNT = 3;
+
+    public void checkAndIncrementExchangeCount(Long userId) {
+        String key = generateKey(userId);
+        Long count = redisTemplate.opsForValue().increment(key);
+
+        if (count == 1) {
+            // 처음 생성된 키인 경우 자정까지의 TTL 설정
+            redisTemplate.expire(key, getDurationUntilMidnight());
+        }
+
+        if (count > MAX_EXCHANGE_COUNT) {
+            // 롤백은 따로 하지 않음 (이미 3을 넘었으므로)
+            throw new com.dodo.dodoserver.error.exception.BusinessException(com.dodo.dodoserver.error.ErrorCode.EXCHANGE_LIMIT_EXCEEDED);
+        }
+    }
+
+    public int getRemainingExchangeCount(Long userId) {
+        String key = generateKey(userId);
+        String countStr = redisTemplate.opsForValue().get(key);
+        if (countStr == null) {
+            return MAX_EXCHANGE_COUNT;
+        }
+        return Math.max(0, MAX_EXCHANGE_COUNT - Integer.parseInt(countStr));
+    }
+
+    private String generateKey(Long userId) {
+        String date = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        return KEY_PREFIX + date + ":user:" + userId;
+    }
+
+    private Duration getDurationUntilMidnight() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime midnight = now.toLocalDate().atTime(LocalTime.MAX);
+        return Duration.between(now, midnight);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -8,6 +8,7 @@ import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.dto.*;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.postcard.entity.PostcardReaction;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
@@ -25,9 +26,11 @@ public class PostcardService {
     private final UnlockHistoryRepository unlockHistoryRepository;
     private final PostcardNotificationService postcardNotificationService;
     private final PostcardReactionRepository postcardReactionRepository;
+    private final UserRepository userRepository;
 
     @Transactional
-    public PostcardResponseDto createPostcard(User user, PostcardCreateRequestDto requestDto) {
+    public PostcardResponseDto createPostcard(Long userId, PostcardCreateRequestDto requestDto) {
+        User user = getUser(userId);
         Postcard postcard = Postcard.builder()
                 .originalAuthor(user)
                 .currentOwner(user)
@@ -41,8 +44,8 @@ public class PostcardService {
     }
 
     @Transactional(readOnly = true)
-    public PostcardExchangeCheckResponseDto checkExchangeAvailability(User user) {
-        int remainingCount = postcardRedisService.getRemainingExchangeCount(user.getId());
+    public PostcardExchangeCheckResponseDto checkExchangeAvailability(Long userId) {
+        int remainingCount = postcardRedisService.getRemainingExchangeCount(userId);
         
         if (remainingCount <= 0) {
             return PostcardExchangeCheckResponseDto.builder()
@@ -59,7 +62,8 @@ public class PostcardService {
     }
 
     @Transactional
-    public PostcardResponseDto exchangePostcard(User user, Long nestId, PostcardExchangeRequestDto requestDto) {
+    public PostcardResponseDto exchangePostcard(Long userId, Long nestId, PostcardExchangeRequestDto requestDto) {
+        User user = getUser(userId);
         // 1. 둥지 및 해금 여부 확인
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
@@ -69,7 +73,7 @@ public class PostcardService {
         }
 
         // 2. 일일 교환 횟수 제한 확인 및 증가 (Atomic INCR)
-        postcardRedisService.checkAndIncrementExchangeCount(user.getId());
+        postcardRedisService.checkAndIncrementExchangeCount(userId);
 
         // 3. 내 엽서 락 획득 및 검증
         Postcard myPostcard = postcardRepository.findByIdForUpdate(requestDto.getMyPostcardId())
@@ -82,7 +86,7 @@ public class PostcardService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_AVAILABLE_POSTCARD_IN_NEST));
 
         // 5. 본인 엽서 교환 차단
-        if (targetPostcard.getOriginalAuthor().getId().equals(user.getId())) {
+        if (targetPostcard.getOriginalAuthor().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.CANNOT_EXCHANGE_OWN_POSTCARD);
         }
 
@@ -97,18 +101,18 @@ public class PostcardService {
     }
 
     @Transactional(readOnly = true)
-    public PostcardResponseDto getPostcardDetail(User user, Long postcardId) {
+    public PostcardResponseDto getPostcardDetail(Long userId, Long postcardId) {
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
         return PostcardResponseDto.from(postcard);
     }
 
     @Transactional
-    public PostcardResponseDto updatePostcard(User user, Long postcardId, PostcardCreateRequestDto requestDto) {
+    public PostcardResponseDto updatePostcard(Long userId, Long postcardId, PostcardCreateRequestDto requestDto) {
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
-        if (!postcard.getCurrentOwner().getId().equals(user.getId())) {
+        if (!postcard.getCurrentOwner().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
         }
 
@@ -123,11 +127,11 @@ public class PostcardService {
     }
 
     @Transactional
-    public void deletePostcard(User user, Long postcardId) {
+    public void deletePostcard(Long userId, Long postcardId) {
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
-        if (!postcard.getCurrentOwner().getId().equals(user.getId())) {
+        if (!postcard.getCurrentOwner().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
         }
 
@@ -139,7 +143,8 @@ public class PostcardService {
     }
 
     @Transactional
-    public void addReaction(User user, Long postcardId, com.dodo.dodoserver.domain.nest.entity.ReactionType reactionType) {
+    public void addReaction(Long userId, Long postcardId, com.dodo.dodoserver.domain.nest.entity.ReactionType reactionType) {
+        User user = getUser(userId);
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
@@ -161,6 +166,11 @@ public class PostcardService {
                             postcardReactionRepository.save(reaction);
                         }
                 );
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     private void validateMyPostcard(User user, Postcard myPostcard) {

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -8,6 +8,7 @@ import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.dto.*;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.postcard.entity.PostcardReaction;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -94,7 +95,7 @@ public class PostcardService {
         targetPostcard.exchangeToUser(user);
         myPostcard.shareToNest(nest);
 
-        // 7. 알림 발행 (FCM 토큰 조회 등이 포함되므로 커밋 후 비동기 처리가 권장되나, 현재는 서비스 내에서 호출)
+        // 7. 알림 발행
         postcardNotificationService.sendPostcardExchangedNotification(targetPostcard, nest);
 
         return PostcardResponseDto.from(targetPostcard);
@@ -143,7 +144,7 @@ public class PostcardService {
     }
 
     @Transactional
-    public void addReaction(Long userId, Long postcardId, com.dodo.dodoserver.domain.nest.entity.ReactionType reactionType) {
+    public void addReaction(Long userId, Long postcardId, PostcardReactionType reactionType) {
         User user = getUser(userId);
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
@@ -155,6 +156,7 @@ public class PostcardService {
                                 postcardReactionRepository.delete(reaction);
                             } else {
                                 reaction.setReactionType(reactionType);
+                                postcardNotificationService.sendPostcardReactionNotification(user, postcard, reactionType);
                             }
                         },
                         () -> {
@@ -164,11 +166,7 @@ public class PostcardService {
                                     .reactionType(reactionType)
                                     .build();
                             postcardReactionRepository.save(reaction);
-                            
-                            // 좋아요 반응인 경우 알림 발송
-                            if (reactionType == com.dodo.dodoserver.domain.nest.entity.ReactionType.LIKE) {
-                                postcardNotificationService.sendPostcardLikeNotification(user, postcard);
-                            }
+                            postcardNotificationService.sendPostcardReactionNotification(user, postcard, reactionType);
                         }
                 );
     }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -155,7 +155,7 @@ public class PostcardService {
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
-        if (!postcard.getCurrentOwner().getId().equals(userId)) {
+        if (postcard.getCurrentOwner() == null || !postcard.getCurrentOwner().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
         }
 

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -1,0 +1,177 @@
+package com.dodo.dodoserver.domain.postcard.service;
+
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.dao.UnlockHistoryRepository;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardReactionRepository;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.dto.*;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReaction;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostcardService {
+
+    private final PostcardRepository postcardRepository;
+    private final PostcardRedisService postcardRedisService;
+    private final NestRepository nestRepository;
+    private final UnlockHistoryRepository unlockHistoryRepository;
+    private final PostcardNotificationService postcardNotificationService;
+    private final PostcardReactionRepository postcardReactionRepository;
+
+    @Transactional
+    public PostcardResponseDto createPostcard(User user, PostcardCreateRequestDto requestDto) {
+        Postcard postcard = Postcard.builder()
+                .originalAuthor(user)
+                .currentOwner(user)
+                .imageUrl(requestDto.getImageUrl())
+                .content(requestDto.getContent())
+                .isShared(false)
+                .isExchanged(false)
+                .build();
+
+        return PostcardResponseDto.from(postcardRepository.save(postcard));
+    }
+
+    @Transactional(readOnly = true)
+    public PostcardExchangeCheckResponseDto checkExchangeAvailability(User user) {
+        int remainingCount = postcardRedisService.getRemainingExchangeCount(user.getId());
+        
+        if (remainingCount <= 0) {
+            return PostcardExchangeCheckResponseDto.builder()
+                    .canExchange(false)
+                    .remainingCount(0)
+                    .reason(ErrorCode.EXCHANGE_LIMIT_EXCEEDED.getMessage())
+                    .build();
+        }
+
+        return PostcardExchangeCheckResponseDto.builder()
+                .canExchange(true)
+                .remainingCount(remainingCount)
+                .build();
+    }
+
+    @Transactional
+    public PostcardResponseDto exchangePostcard(User user, Long nestId, PostcardExchangeRequestDto requestDto) {
+        // 1. 둥지 및 해금 여부 확인
+        Nest nest = nestRepository.findById(nestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
+
+        if (!unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+            throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
+        }
+
+        // 2. 일일 교환 횟수 제한 확인 및 증가 (Atomic INCR)
+        postcardRedisService.checkAndIncrementExchangeCount(user.getId());
+
+        // 3. 내 엽서 락 획득 및 검증
+        Postcard myPostcard = postcardRepository.findByIdForUpdate(requestDto.getMyPostcardId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+
+        validateMyPostcard(user, myPostcard);
+
+        // 4. 둥지의 유일한 엽서 락 획득 및 검증
+        Postcard targetPostcard = postcardRepository.findSharedPostcardByNestForUpdate(nest)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_AVAILABLE_POSTCARD_IN_NEST));
+
+        // 5. 본인 엽서 교환 차단
+        if (targetPostcard.getOriginalAuthor().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.CANNOT_EXCHANGE_OWN_POSTCARD);
+        }
+
+        // 6. Atomic Swap
+        targetPostcard.exchangeToUser(user);
+        myPostcard.shareToNest(nest);
+
+        // 7. 알림 발행 (FCM 토큰 조회 등이 포함되므로 커밋 후 비동기 처리가 권장되나, 현재는 서비스 내에서 호출)
+        postcardNotificationService.sendPostcardExchangedNotification(targetPostcard, nest);
+
+        return PostcardResponseDto.from(targetPostcard);
+    }
+
+    @Transactional(readOnly = true)
+    public PostcardResponseDto getPostcardDetail(User user, Long postcardId) {
+        Postcard postcard = postcardRepository.findById(postcardId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+        return PostcardResponseDto.from(postcard);
+    }
+
+    @Transactional
+    public PostcardResponseDto updatePostcard(User user, Long postcardId, PostcardCreateRequestDto requestDto) {
+        Postcard postcard = postcardRepository.findById(postcardId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+
+        if (!postcard.getCurrentOwner().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
+        }
+
+        if (postcard.isExchanged() || postcard.isShared()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        postcard.setImageUrl(requestDto.getImageUrl());
+        postcard.setContent(requestDto.getContent());
+
+        return PostcardResponseDto.from(postcard);
+    }
+
+    @Transactional
+    public void deletePostcard(User user, Long postcardId) {
+        Postcard postcard = postcardRepository.findById(postcardId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+
+        if (!postcard.getCurrentOwner().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
+        }
+
+        if (postcard.isShared()) {
+            throw new BusinessException(ErrorCode.ALREADY_SHARED);
+        }
+
+        postcardRepository.delete(postcard);
+    }
+
+    @Transactional
+    public void addReaction(User user, Long postcardId, com.dodo.dodoserver.domain.nest.entity.ReactionType reactionType) {
+        Postcard postcard = postcardRepository.findById(postcardId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+
+        postcardReactionRepository.findByPostcardAndUser(postcard, user)
+                .ifPresentOrElse(
+                        reaction -> {
+                            if (reaction.getReactionType() == reactionType) {
+                                postcardReactionRepository.delete(reaction);
+                            } else {
+                                reaction.setReactionType(reactionType);
+                            }
+                        },
+                        () -> {
+                            PostcardReaction reaction = PostcardReaction.builder()
+                                    .postcard(postcard)
+                                    .user(user)
+                                    .reactionType(reactionType)
+                                    .build();
+                            postcardReactionRepository.save(reaction);
+                        }
+                );
+    }
+
+    private void validateMyPostcard(User user, Postcard myPostcard) {
+        if (!myPostcard.getCurrentOwner().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
+        }
+        if (myPostcard.isShared()) {
+            throw new BusinessException(ErrorCode.ALREADY_SHARED);
+        }
+        if (myPostcard.isExchanged()) {
+            throw new BusinessException(ErrorCode.ALREADY_EXCHANGED);
+        }
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -186,6 +186,10 @@ public class PostcardService {
             throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
         }
 
+        if (postcard.getOriginalAuthor().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.CANNOT_REACTION_OWN_POSTCARD);
+        }
+
         postcardReactionRepository.findByPostcardAndUser(postcard, user)
                 .ifPresentOrElse(
                         reaction -> {

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -14,8 +14,13 @@ import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -105,7 +110,34 @@ public class PostcardService {
     public PostcardResponseDto getPostcardDetail(Long userId, Long postcardId) {
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
-        return PostcardResponseDto.from(postcard);
+        
+        PostcardReactionType reactionType = postcardReactionRepository.findByPostcard(postcard)
+                .map(PostcardReaction::getReactionType)
+                .orElse(null);
+                
+        return PostcardResponseDto.from(postcard, reactionType);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostcardResponseDto> getPostcardInventory(Long userId) {
+        User user = getUser(userId);
+        List<Postcard> inventory = postcardRepository.findInventoryByUser(user, Sort.by(Sort.Direction.DESC, "createdAt"));
+        
+        if (inventory.isEmpty()) {
+            return List.of();
+        }
+
+        // 리액션 일괄 조회 (N+1 방지)
+        Map<Long, PostcardReactionType> reactionMap = postcardReactionRepository.findAllByPostcardIn(inventory)
+                .stream()
+                .collect(Collectors.toMap(
+                        r -> r.getPostcard().getId(),
+                        PostcardReaction::getReactionType
+                ));
+
+        return inventory.stream()
+                .map(p -> PostcardResponseDto.from(p, reactionMap.get(p.getId())))
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -47,7 +47,7 @@ public class PostcardService {
                 .isExchanged(false)
                 .build();
 
-        return PostcardResponseDto.from(postcardRepository.save(postcard));
+        return PostcardResponseDto.from(postcardRepository.save(postcard), userId);
     }
 
     @Transactional(readOnly = true)
@@ -104,7 +104,7 @@ public class PostcardService {
         // 7. 알림 발행
         postcardNotificationService.sendPostcardExchangedNotification(targetPostcard, nest);
 
-        return PostcardResponseDto.from(targetPostcard);
+        return PostcardResponseDto.from(targetPostcard, userId);
     }
 
     @Transactional(readOnly = true)
@@ -116,7 +116,7 @@ public class PostcardService {
                 .map(PostcardReaction::getReactionType)
                 .orElse(null);
                 
-        return PostcardResponseDto.from(postcard, reactionType);
+        return PostcardResponseDto.from(postcard, reactionType, userId);
     }
 
     @Transactional(readOnly = true)
@@ -138,8 +138,8 @@ public class PostcardService {
                         PostcardReaction::getReactionType
                 ));
 
-        return inventory.map(p -> PostcardResponseDto.from(p, reactionMap.get(p.getId())));
-    }
+        return inventory.map(p -> PostcardResponseDto.from(p, reactionMap.get(p.getId()), userId));
+        }
 
     @Transactional
     public PostcardResponseDto updatePostcard(Long userId, Long postcardId, PostcardCreateRequestDto requestDto) {
@@ -157,7 +157,7 @@ public class PostcardService {
         postcard.setImageUrl(requestDto.getImageUrl());
         postcard.setContent(requestDto.getContent());
 
-        return PostcardResponseDto.from(postcard);
+        return PostcardResponseDto.from(postcard, userId);
     }
 
     @Transactional

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -71,7 +71,7 @@ public class PostcardService {
     @Transactional
     public PostcardResponseDto exchangePostcard(Long userId, Long nestId, PostcardExchangeRequestDto requestDto) {
         User user = getUser(userId);
-        // 1. 둥지 및 해금 여부 확인
+        // 둥지 및 해금 여부 확인
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
@@ -79,29 +79,30 @@ public class PostcardService {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 
-        // 2. 일일 교환 횟수 제한 확인 및 증가 (Atomic INCR)
-        postcardRedisService.checkAndIncrementExchangeCount(userId);
 
-        // 3. 내 엽서 락 획득 및 검증
+        // 내 엽서 락 획득 및 검증
         Postcard myPostcard = postcardRepository.findByIdForUpdate(requestDto.getMyPostcardId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
         validateMyPostcard(user, myPostcard);
 
-        // 4. 둥지의 유일한 엽서 락 획득 및 검증
+        // 둥지의 유일한 엽서 락 획득 및 검증
         Postcard targetPostcard = postcardRepository.findSharedPostcardByNestForUpdate(nest)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_AVAILABLE_POSTCARD_IN_NEST));
 
-        // 5. 본인 엽서 교환 차단
+        // 본인 엽서 교환 차단
         if (targetPostcard.getOriginalAuthor().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.CANNOT_EXCHANGE_OWN_POSTCARD);
         }
 
-        // 6. Atomic Swap
+        // 일일 교환 횟수 제한 
+        postcardRedisService.checkAndIncrementExchangeCount(userId);
+
+        // Atomic Swap
         targetPostcard.exchangeToUser(user);
         myPostcard.shareToNest(nest);
 
-        // 7. 알림 발행
+        // 알림 발행
         postcardNotificationService.sendPostcardExchangedNotification(targetPostcard, nest);
 
         return PostcardResponseDto.from(targetPostcard, userId);

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -14,7 +14,8 @@ import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -119,25 +120,25 @@ public class PostcardService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostcardResponseDto> getPostcardInventory(Long userId) {
+    public Page<PostcardResponseDto> getPostcardInventory(Long userId, Pageable pageable) {
         User user = getUser(userId);
-        List<Postcard> inventory = postcardRepository.findInventoryByUser(user, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Postcard> inventory = postcardRepository.findInventoryByUser(user, pageable);
         
         if (inventory.isEmpty()) {
-            return List.of();
+            return Page.empty(pageable);
         }
 
+        List<Postcard> postcardList = inventory.getContent();
+
         // 리액션 일괄 조회 (N+1 방지)
-        Map<Long, PostcardReactionType> reactionMap = postcardReactionRepository.findAllByPostcardIn(inventory)
+        Map<Long, PostcardReactionType> reactionMap = postcardReactionRepository.findAllByPostcardIn(postcardList)
                 .stream()
                 .collect(Collectors.toMap(
                         r -> r.getPostcard().getId(),
                         PostcardReaction::getReactionType
                 ));
 
-        return inventory.stream()
-                .map(p -> PostcardResponseDto.from(p, reactionMap.get(p.getId())))
-                .collect(Collectors.toList());
+        return inventory.map(p -> PostcardResponseDto.from(p, reactionMap.get(p.getId())));
     }
 
     @Transactional

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -120,9 +120,17 @@ public class PostcardService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostcardResponseDto> getPostcardInventory(Long userId, Pageable pageable) {
+    public Page<PostcardResponseDto> getPostcardInventory(Long userId, String filter, Pageable pageable) {
         User user = getUser(userId);
-        Page<Postcard> inventory = postcardRepository.findInventoryByUser(user, pageable);
+        
+        Page<Postcard> inventory;
+        if ("CREATED".equalsIgnoreCase(filter)) {
+            inventory = postcardRepository.findCreatedByUser(user, pageable);
+        } else if ("ACQUIRED".equalsIgnoreCase(filter)) {
+            inventory = postcardRepository.findAcquiredByUser(user, pageable);
+        } else {
+            inventory = postcardRepository.findInventoryByUser(user, pageable);
+        }
         
         if (inventory.isEmpty()) {
             return Page.empty(pageable);

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -164,6 +164,11 @@ public class PostcardService {
                                     .reactionType(reactionType)
                                     .build();
                             postcardReactionRepository.save(reaction);
+                            
+                            // 좋아요 반응인 경우 알림 발송
+                            if (reactionType == com.dodo.dodoserver.domain.nest.entity.ReactionType.LIKE) {
+                                postcardNotificationService.sendPostcardLikeNotification(user, postcard);
+                            }
                         }
                 );
     }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -149,6 +149,10 @@ public class PostcardService {
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
 
+        if (postcard.getCurrentOwner() == null || !postcard.getCurrentOwner().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOT_POSTCARD_OWNER);
+        }
+
         postcardReactionRepository.findByPostcardAndUser(postcard, user)
                 .ifPresentOrElse(
                         reaction -> {

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
     NOT_SHARED(HttpStatus.BAD_REQUEST, "PC005", "현재 공유 중인 상태가 아닙니다."),
     EXCHANGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PC006", "오늘의 엽서 교환 횟수를 모두 사용했습니다. (일일 3회)"),
     NO_AVAILABLE_POSTCARD_IN_NEST(HttpStatus.BAD_REQUEST, "PC007", "현재 둥지에 교환 가능한 엽서가 없습니다."),
-    CANNOT_EXCHANGE_OWN_POSTCARD(HttpStatus.BAD_REQUEST, "PC008", "자신이 등록한 엽서는 교환할 수 없습니다.");
+    CANNOT_EXCHANGE_OWN_POSTCARD(HttpStatus.BAD_REQUEST, "PC008", "자신이 등록한 엽서는 교환할 수 없습니다."),
+    CANNOT_REACTION_OWN_POSTCARD(HttpStatus.BAD_REQUEST, "PC009", "자신이 만든 엽서에는 반응을 남길 수 없습니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -41,7 +41,17 @@ public enum ErrorCode {
     NOT_NEST_CREATOR(HttpStatus.FORBIDDEN, "N004", "둥지 작성자만 권한이 있습니다."),
     DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "N005", "임시 저장된 둥지를 찾을 수 없습니다."),
     DRAFT_NOT_PUBLISHABLE(HttpStatus.BAD_REQUEST, "N006", "필수 정보(제목, 내용, 반경, 카테고리)가 누락되어 발행할 수 없습니다."),
-    NEST_NOT_UNLOCKED(HttpStatus.FORBIDDEN, "N007", "해당 둥지의 상세 내용을 보려면 해금이 필요합니다.");
+    NEST_NOT_UNLOCKED(HttpStatus.FORBIDDEN, "N007", "해당 둥지의 상세 내용을 보려면 해금이 필요합니다."),
+
+    // Postcard (PC)
+    POSTCARD_NOT_FOUND(HttpStatus.NOT_FOUND, "PC001", "엽서를 찾을 수 없습니다."),
+    NOT_POSTCARD_OWNER(HttpStatus.FORBIDDEN, "PC002", "엽서의 소유자만 권한이 있습니다."),
+    ALREADY_EXCHANGED(HttpStatus.BAD_REQUEST, "PC003", "이미 교환된 엽서는 재등록할 수 없습니다."),
+    ALREADY_SHARED(HttpStatus.BAD_REQUEST, "PC004", "이미 둥지에 등록된 엽서입니다."),
+    NOT_SHARED(HttpStatus.BAD_REQUEST, "PC005", "현재 공유 중인 상태가 아닙니다."),
+    EXCHANGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PC006", "오늘의 엽서 교환 횟수를 모두 사용했습니다. (일일 3회)"),
+    NO_AVAILABLE_POSTCARD_IN_NEST(HttpStatus.BAD_REQUEST, "PC007", "현재 둥지에 교환 가능한 엽서가 없습니다."),
+    CANNOT_EXCHANGE_OWN_POSTCARD(HttpStatus.BAD_REQUEST, "PC008", "자신이 등록한 엽서는 교환할 수 없습니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -28,8 +28,8 @@ public final class NotificationConstants {
     public static final String BODY_COMMENT_LIKE = "%s님이 회원님의 댓글을 좋아합니다.";
     public static final String TITLE_POSTCARD_EXCHANGED = "나의 엽서가 교환되었습니다!";
     public static final String BODY_POSTCARD_EXCHANGED = "누군가 %s둥지에서 당신의 엽서를 가져갔어요!";
-    public static final String TITLE_POSTCARD_LIKE = "내 엽서에 좋아요가 달렸어요!";
-    public static final String BODY_POSTCARD_LIKE = "%s님이 회원님의 엽서를 좋아합니다.";
+    public static final String TITLE_POSTCARD_LIKE = "내 엽서에 리액션이 달렸어요!";
+    public static final String BODY_POSTCARD_LIKE = "%s님이 회원님의 엽서에 '%s'라고 반응했습니다.";
 
     private NotificationConstants() {
     }

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -15,6 +15,7 @@ public final class NotificationConstants {
     public static final String TYPE_NEST_LIKE = "NEST_LIKE";
     public static final String TYPE_COMMENT_LIKE = "COMMENT_LIKE";
     public static final String TYPE_POSTCARD_EXCHANGED = "POSTCARD_EXCHANGED";
+    public static final String TYPE_POSTCARD_LIKE = "POSTCARD_LIKE";
 
     // Message Templates
     public static final String TITLE_NEW_COMMENT = "둥지에 새 댓글이 달렸습니다!";
@@ -27,6 +28,8 @@ public final class NotificationConstants {
     public static final String BODY_COMMENT_LIKE = "%s님이 회원님의 댓글을 좋아합니다.";
     public static final String TITLE_POSTCARD_EXCHANGED = "나의 엽서가 교환되었습니다!";
     public static final String BODY_POSTCARD_EXCHANGED = "누군가 %s둥지에서 당신의 엽서를 가져갔어요!";
+    public static final String TITLE_POSTCARD_LIKE = "내 엽서에 좋아요가 달렸어요!";
+    public static final String BODY_POSTCARD_LIKE = "%s님이 회원님의 엽서를 좋아합니다.";
 
     private NotificationConstants() {
     }

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -7,12 +7,14 @@ public final class NotificationConstants {
     public static final String KEY_TYPE = "type";
     public static final String KEY_NEST_ID = "nestId";
     public static final String KEY_COMMENT_ID = "commentId";
+    public static final String KEY_POSTCARD_ID = "postcardId";
 
     // Type Values
     public static final String TYPE_COMMENT = "COMMENT";
     public static final String TYPE_REPLY = "REPLY";
     public static final String TYPE_NEST_LIKE = "NEST_LIKE";
     public static final String TYPE_COMMENT_LIKE = "COMMENT_LIKE";
+    public static final String TYPE_POSTCARD_EXCHANGED = "POSTCARD_EXCHANGED";
 
     // Message Templates
     public static final String TITLE_NEW_COMMENT = "둥지에 새 댓글이 달렸습니다!";
@@ -23,6 +25,8 @@ public final class NotificationConstants {
     public static final String BODY_NEST_LIKE = "%s님이 회원님의 둥지를 좋아합니다.";
     public static final String TITLE_COMMENT_LIKE = "내 댓글에 좋아요가 달렸어요!";
     public static final String BODY_COMMENT_LIKE = "%s님이 회원님의 댓글을 좋아합니다.";
+    public static final String TITLE_POSTCARD_EXCHANGED = "나의 엽서가 교환되었습니다!";
+    public static final String BODY_POSTCARD_EXCHANGED = "누군가 %s둥지에서 당신의 엽서를 가져갔어요!";
 
     private NotificationConstants() {
     }

--- a/src/main/java/com/dodo/dodoserver/infrastructure/fcm/NotificationEventListener.java
+++ b/src/main/java/com/dodo/dodoserver/infrastructure/fcm/NotificationEventListener.java
@@ -15,7 +15,7 @@ public class NotificationEventListener {
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
 	public void handleNotification(NotificationEvent event) {
-		log.info("Notification event received: title={}, tokens={}", event.title(), event.tokens());
+		log.info("Notification event received: title={}, tokenCount={}", event.title(), event.tokens().size());
 		fcmService.sendNotification(event);
 	}
 }

--- a/src/main/java/com/dodo/dodoserver/infrastructure/fcm/NotificationEventListener.java
+++ b/src/main/java/com/dodo/dodoserver/infrastructure/fcm/NotificationEventListener.java
@@ -5,14 +5,17 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class NotificationEventListener {
 	private final FcmService fcmService;
 
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
 	public void handleNotification(NotificationEvent event) {
+		log.info("Notification event received: title={}, tokens={}", event.title(), event.tokens());
 		fcmService.sendNotification(event);
 	}
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
@@ -77,7 +77,7 @@ class NestPostControllerTest {
     @DisplayName("둥지 생성 성공")
     @WithMockUserPrincipal
     void createNest_success() throws Exception {
-        NestCreateRequestDto requestDto = new NestCreateRequestDto("새둥지", "내용", 37.5, 127.0, 100, List.of(1L), List.of("url"), false);
+        NestCreateRequestDto requestDto = new NestCreateRequestDto("새둥지", "내용", 37.5, 127.0, 100, null, List.of(1L), List.of("url"), false);
         NestSimpleResponseDto responseDto = NestSimpleResponseDto.builder().id(1L).build();
 
         given(nestService.createNest(any(), any())).willReturn(responseDto);

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
@@ -135,7 +135,7 @@ class NestPostControllerTest {
     @WithMockUserPrincipal
     void updateNest_success() throws Exception {
         Long nestId = 1L;
-        NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", null, null, null, null);
+        NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", null, null, null, null, null);
         NestSimpleResponseDto responseDto = NestSimpleResponseDto.builder().id(nestId).build();
 
         given(nestService.updateNest(any(), eq(nestId), any())).willReturn(responseDto);

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.nest.dao.*;
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.*;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.user.dao.UserProfileRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
@@ -101,7 +102,7 @@ class NestServiceTest {
     void createNest_withPostcard_success() {
         Long postcardId = 10L;
         NestCreateRequestDto requestDto = new NestCreateRequestDto("제목", "내용", 37.5, 127.0, 100, postcardId, null, null, false);
-        com.dodo.dodoserver.domain.postcard.entity.Postcard postcard = com.dodo.dodoserver.domain.postcard.entity.Postcard.builder()
+        Postcard postcard = Postcard.builder()
                 .id(postcardId)
                 .currentOwner(user)
                 .build();

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -127,7 +127,7 @@ class NestServiceTest {
     void updateNest_success() {
         Long nestId = 1L;
         Nest nest = Nest.builder().id(nestId).creator(user).title("기존제목").images(new ArrayList<>()).build();
-        NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", "수정내용", 200, null, null);
+        NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", "수정내용", 200, null, null, null);
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
@@ -144,7 +144,7 @@ class NestServiceTest {
         Long nestId = 1L;
         User other = User.builder().id(2L).email("other@example.com").build();
         Nest nest = Nest.builder().id(nestId).creator(other).build();
-        NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", null, null, null, null);
+        NestUpdateRequestDto requestDto = new NestUpdateRequestDto("수정제목", null, null, null, null, null);
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -4,6 +4,7 @@ import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.nest.dao.*;
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.*;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.user.dao.UserProfileRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
@@ -60,6 +61,8 @@ class NestServiceTest {
     private NestNotificationService nestNotificationService;
     @Mock
     private RedisViewCountService redisViewCountService;
+    @Mock
+    private PostcardRepository postcardRepository;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
     private User user;
@@ -79,7 +82,7 @@ class NestServiceTest {
     @Test
     @DisplayName("둥지 생성 성공")
     void createNest_success() {
-        NestCreateRequestDto requestDto = new NestCreateRequestDto("제목", "내용", 37.5, 127.0, 100, null, null, false);
+        NestCreateRequestDto requestDto = new NestCreateRequestDto("제목", "내용", 37.5, 127.0, 100, null, null, null, false);
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.save(any(Nest.class))).willAnswer(inv -> {
             Nest nest = inv.getArgument(0);
@@ -91,6 +94,31 @@ class NestServiceTest {
 
         assertThat(response.getId()).isEqualTo(100L);
         verify(nestRepository).save(any(Nest.class));
+    }
+
+    @Test
+    @DisplayName("둥지 생성 성공 - 초기 엽서 포함")
+    void createNest_withPostcard_success() {
+        Long postcardId = 10L;
+        NestCreateRequestDto requestDto = new NestCreateRequestDto("제목", "내용", 37.5, 127.0, 100, postcardId, null, null, false);
+        com.dodo.dodoserver.domain.postcard.entity.Postcard postcard = com.dodo.dodoserver.domain.postcard.entity.Postcard.builder()
+                .id(postcardId)
+                .currentOwner(user)
+                .build();
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(postcardRepository.findById(postcardId)).willReturn(Optional.of(postcard));
+        given(nestRepository.save(any(Nest.class))).willAnswer(inv -> {
+            Nest nest = inv.getArgument(0);
+            nest.setId(100L);
+            return nest;
+        });
+
+        NestSimpleResponseDto response = nestService.createNest(user.getId(), requestDto);
+
+        assertThat(response.getId()).isEqualTo(100L);
+        assertThat(postcard.isShared()).isTrue();
+        assertThat(postcard.getNest().getId()).isEqualTo(100L);
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -3,10 +3,13 @@ package com.dodo.dodoserver.domain.postcard.service;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import com.dodo.dodoserver.domain.nest.dao.UnlockHistoryRepository;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardReactionRepository;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.dto.PostcardExchangeRequestDto;
 import com.dodo.dodoserver.domain.postcard.dto.PostcardResponseDto;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReaction;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -18,12 +21,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -43,6 +49,8 @@ class PostcardServiceTest {
     private UnlockHistoryRepository unlockHistoryRepository;
     @Mock
     private PostcardNotificationService postcardNotificationService;
+    @Mock
+    private PostcardReactionRepository postcardReactionRepository;
     @Mock
     private UserRepository userRepository;
 
@@ -134,5 +142,51 @@ class PostcardServiceTest {
         assertThatThrownBy(() -> postcardService.exchangePostcard(user.getId(), nest.getId(), requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_SHARED.getMessage());
+    }
+
+    @Test
+    @DisplayName("엽서 인벤토리 조회 성공")
+    void getPostcardInventory_success() {
+        // given
+        List<Postcard> inventory = List.of(myPostcard, targetPostcard);
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(postcardRepository.findInventoryByUser(eq(user), any(Sort.class))).willReturn(inventory);
+        
+        PostcardReaction reaction = PostcardReaction.builder()
+                .postcard(targetPostcard)
+                .reactionType(PostcardReactionType.TOUCHED)
+                .build();
+        given(postcardReactionRepository.findAllByPostcardIn(inventory)).willReturn(List.of(reaction));
+
+        // when
+        List<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(myPostcard.getId());
+        assertThat(result.get(0).getReactionType()).isNull();
+        
+        assertThat(result.get(1).getId()).isEqualTo(targetPostcard.getId());
+        assertThat(result.get(1).getReactionType()).isEqualTo(PostcardReactionType.TOUCHED);
+    }
+
+    @Test
+    @DisplayName("엽서 상세 조회 시 리액션 정보 포함 확인")
+    void getPostcardDetail_withReaction() {
+        // given
+        given(postcardRepository.findById(targetPostcard.getId())).willReturn(Optional.of(targetPostcard));
+        
+        PostcardReaction reaction = PostcardReaction.builder()
+                .postcard(targetPostcard)
+                .reactionType(PostcardReactionType.BEST)
+                .build();
+        given(postcardReactionRepository.findByPostcard(targetPostcard)).willReturn(Optional.of(reaction));
+
+        // when
+        PostcardResponseDto response = postcardService.getPostcardDetail(user.getId(), targetPostcard.getId());
+
+        // then
+        assertThat(response.getId()).isEqualTo(targetPostcard.getId());
+        assertThat(response.getReactionType()).isEqualTo(PostcardReactionType.BEST);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -167,9 +167,11 @@ class PostcardServiceTest {
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).getId()).isEqualTo(myPostcard.getId());
+        assertThat(result.getContent().get(0).isMine()).isTrue(); // 내가 만든 엽서
         assertThat(result.getContent().get(0).getReactionType()).isNull();
         
         assertThat(result.getContent().get(1).getId()).isEqualTo(targetPostcard.getId());
+        assertThat(result.getContent().get(1).isMine()).isFalse(); // 남이 만든 엽서
         assertThat(result.getContent().get(1).getReactionType()).isEqualTo(PostcardReactionType.TOUCHED);
     }
 
@@ -190,6 +192,7 @@ class PostcardServiceTest {
 
         // then
         assertThat(response.getId()).isEqualTo(targetPostcard.getId());
+        assertThat(response.isMine()).isFalse();
         assertThat(response.getReactionType()).isEqualTo(PostcardReactionType.BEST);
     }
 

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -7,6 +7,7 @@ import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.dto.PostcardExchangeRequestDto;
 import com.dodo.dodoserver.domain.postcard.dto.PostcardResponseDto;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
@@ -42,6 +43,8 @@ class PostcardServiceTest {
     private UnlockHistoryRepository unlockHistoryRepository;
     @Mock
     private PostcardNotificationService postcardNotificationService;
+    @Mock
+    private UserRepository userRepository;
 
     private User user;
     private Nest nest;
@@ -76,13 +79,14 @@ class PostcardServiceTest {
         // given
         PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
 
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
         given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
 
         // when
-        PostcardResponseDto response = postcardService.exchangePostcard(user, nest.getId(), requestDto);
+        PostcardResponseDto response = postcardService.exchangePostcard(user.getId(), nest.getId(), requestDto);
 
         // then
         assertThat(response.getId()).isEqualTo(targetPostcard.getId());
@@ -102,13 +106,14 @@ class PostcardServiceTest {
         targetPostcard.setOriginalAuthor(user); // 둥지에 있는 엽서가 내가 쓴 것
         PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
 
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
         given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
 
         // when & then
-        assertThatThrownBy(() -> postcardService.exchangePostcard(user, nest.getId(), requestDto))
+        assertThatThrownBy(() -> postcardService.exchangePostcard(user.getId(), nest.getId(), requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.CANNOT_EXCHANGE_OWN_POSTCARD.getMessage());
     }
@@ -120,12 +125,13 @@ class PostcardServiceTest {
         myPostcard.setShared(true);
         PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
 
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
 
         // when & then
-        assertThatThrownBy(() -> postcardService.exchangePostcard(user, nest.getId(), requestDto))
+        assertThatThrownBy(() -> postcardService.exchangePostcard(user.getId(), nest.getId(), requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_SHARED.getMessage());
     }

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -192,4 +192,19 @@ class PostcardServiceTest {
         assertThat(response.getId()).isEqualTo(targetPostcard.getId());
         assertThat(response.getReactionType()).isEqualTo(PostcardReactionType.BEST);
     }
+
+    @Test
+    @DisplayName("리액션 추가 실패 - 원작자 본인인 경우")
+    void addReaction_fail_originalAuthor() {
+        // given
+        myPostcard.setOriginalAuthor(user);
+        myPostcard.setCurrentOwner(user);
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(postcardRepository.findById(myPostcard.getId())).willReturn(Optional.of(myPostcard));
+
+        // when & then
+        assertThatThrownBy(() -> postcardService.addReaction(user.getId(), myPostcard.getId(), PostcardReactionType.TOUCHED))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.CANNOT_REACTION_OWN_POSTCARD.getMessage());
+    }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -147,8 +147,8 @@ class PostcardServiceTest {
     }
 
     @Test
-    @DisplayName("엽서 인벤토리 조회 성공")
-    void getPostcardInventory_success() {
+    @DisplayName("엽서 인벤토리 조회 성공 - 전체 보기")
+    void getPostcardInventory_all_success() {
         // given
         List<Postcard> inventoryList = List.of(myPostcard, targetPostcard);
         Page<Postcard> inventoryPage = new PageImpl<>(inventoryList);
@@ -162,17 +162,48 @@ class PostcardServiceTest {
         given(postcardReactionRepository.findAllByPostcardIn(inventoryList)).willReturn(List.of(reaction));
 
         // when
-        Page<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId(), Pageable.unpaged());
+        Page<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId(), "ALL", Pageable.unpaged());
 
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).getId()).isEqualTo(myPostcard.getId());
-        assertThat(result.getContent().get(0).isMine()).isTrue(); // 내가 만든 엽서
-        assertThat(result.getContent().get(0).getReactionType()).isNull();
-        
         assertThat(result.getContent().get(1).getId()).isEqualTo(targetPostcard.getId());
-        assertThat(result.getContent().get(1).isMine()).isFalse(); // 남이 만든 엽서
-        assertThat(result.getContent().get(1).getReactionType()).isEqualTo(PostcardReactionType.TOUCHED);
+    }
+
+    @Test
+    @DisplayName("엽서 인벤토리 조회 성공 - 내가 생성한 엽서만")
+    void getPostcardInventory_created_success() {
+        // given
+        List<Postcard> createdList = List.of(myPostcard);
+        Page<Postcard> inventoryPage = new PageImpl<>(createdList);
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(postcardRepository.findCreatedByUser(eq(user), any(Pageable.class))).willReturn(inventoryPage);
+
+        // when
+        Page<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId(), "CREATED", Pageable.unpaged());
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(myPostcard.getId());
+        assertThat(result.getContent().get(0).isMine()).isTrue();
+    }
+
+    @Test
+    @DisplayName("엽서 인벤토리 조회 성공 - 내가 가져온 엽서만")
+    void getPostcardInventory_acquired_success() {
+        // given
+        List<Postcard> acquiredList = List.of(targetPostcard);
+        Page<Postcard> inventoryPage = new PageImpl<>(acquiredList);
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(postcardRepository.findAcquiredByUser(eq(user), any(Pageable.class))).willReturn(inventoryPage);
+
+        // when
+        Page<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId(), "ACQUIRED", Pageable.unpaged());
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(targetPostcard.getId());
+        assertThat(result.getContent().get(0).isMine()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -1,0 +1,132 @@
+package com.dodo.dodoserver.domain.postcard.service;
+
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.dao.UnlockHistoryRepository;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.dto.PostcardExchangeRequestDto;
+import com.dodo.dodoserver.domain.postcard.dto.PostcardResponseDto;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PostcardServiceTest {
+
+    @InjectMocks
+    private PostcardService postcardService;
+
+    @Mock
+    private PostcardRepository postcardRepository;
+    @Mock
+    private PostcardRedisService postcardRedisService;
+    @Mock
+    private NestRepository nestRepository;
+    @Mock
+    private UnlockHistoryRepository unlockHistoryRepository;
+    @Mock
+    private PostcardNotificationService postcardNotificationService;
+
+    private User user;
+    private Nest nest;
+    private Postcard myPostcard;
+    private Postcard targetPostcard;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().id(1L).nickname("나").build();
+        User author = User.builder().id(2L).nickname("작가").build();
+        nest = Nest.builder().id(1L).title("테스트 둥지").build();
+        
+        myPostcard = Postcard.builder()
+                .id(10L)
+                .originalAuthor(user)
+                .currentOwner(user)
+                .isShared(false)
+                .isExchanged(false)
+                .build();
+                
+        targetPostcard = Postcard.builder()
+                .id(20L)
+                .originalAuthor(author)
+                .isShared(true)
+                .isExchanged(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("엽서 교환 성공")
+    void exchangePostcard_success() {
+        // given
+        PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
+
+        given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
+        given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
+        given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
+        given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
+
+        // when
+        PostcardResponseDto response = postcardService.exchangePostcard(user, nest.getId(), requestDto);
+
+        // then
+        assertThat(response.getId()).isEqualTo(targetPostcard.getId());
+        assertThat(targetPostcard.getCurrentOwner()).isEqualTo(user);
+        assertThat(targetPostcard.isExchanged()).isTrue();
+        assertThat(myPostcard.isShared()).isTrue();
+        assertThat(myPostcard.getNest()).isEqualTo(nest);
+
+        verify(postcardRedisService).checkAndIncrementExchangeCount(user.getId());
+        verify(postcardNotificationService).sendPostcardExchangedNotification(targetPostcard, nest);
+    }
+
+    @Test
+    @DisplayName("엽서 교환 실패 - 본인 엽서인 경우")
+    void exchangePostcard_fail_ownPostcard() {
+        // given
+        targetPostcard.setOriginalAuthor(user); // 둥지에 있는 엽서가 내가 쓴 것
+        PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
+
+        given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
+        given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
+        given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
+        given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
+
+        // when & then
+        assertThatThrownBy(() -> postcardService.exchangePostcard(user, nest.getId(), requestDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.CANNOT_EXCHANGE_OWN_POSTCARD.getMessage());
+    }
+
+    @Test
+    @DisplayName("엽서 교환 실패 - 이미 공유 중인 내 엽서 제출")
+    void exchangePostcard_fail_alreadyShared() {
+        // given
+        myPostcard.setShared(true);
+        PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
+
+        given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
+        given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
+        given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
+
+        // when & then
+        assertThatThrownBy(() -> postcardService.exchangePostcard(user, nest.getId(), requestDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ALREADY_SHARED.getMessage());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -148,26 +150,27 @@ class PostcardServiceTest {
     @DisplayName("엽서 인벤토리 조회 성공")
     void getPostcardInventory_success() {
         // given
-        List<Postcard> inventory = List.of(myPostcard, targetPostcard);
+        List<Postcard> inventoryList = List.of(myPostcard, targetPostcard);
+        Page<Postcard> inventoryPage = new PageImpl<>(inventoryList);
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-        given(postcardRepository.findInventoryByUser(eq(user), any(Sort.class))).willReturn(inventory);
+        given(postcardRepository.findInventoryByUser(eq(user), any(Pageable.class))).willReturn(inventoryPage);
         
         PostcardReaction reaction = PostcardReaction.builder()
                 .postcard(targetPostcard)
                 .reactionType(PostcardReactionType.TOUCHED)
                 .build();
-        given(postcardReactionRepository.findAllByPostcardIn(inventory)).willReturn(List.of(reaction));
+        given(postcardReactionRepository.findAllByPostcardIn(inventoryList)).willReturn(List.of(reaction));
 
         // when
-        List<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId());
+        Page<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId(), Pageable.unpaged());
 
         // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getId()).isEqualTo(myPostcard.getId());
-        assertThat(result.get(0).getReactionType()).isNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(myPostcard.getId());
+        assertThat(result.getContent().get(0).getReactionType()).isNull();
         
-        assertThat(result.get(1).getId()).isEqualTo(targetPostcard.getId());
-        assertThat(result.get(1).getReactionType()).isEqualTo(PostcardReactionType.TOUCHED);
+        assertThat(result.getContent().get(1).getId()).isEqualTo(targetPostcard.getId());
+        assertThat(result.getContent().get(1).getReactionType()).isEqualTo(PostcardReactionType.TOUCHED);
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
 엽서(Postcard) 도메인의 핵심 기능을 구현하고, FCM 알림 시스템의 안정성을 개선했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
  1. 엽서(Postcard) 도메인 구현
   - Entity & Repository: Postcard, PostcardReaction 엔티티 정의 및 Querydsl 기반 검색/필터링 로직 구현.
   - Service: 엽서 생성, 조회, 교환 신청/수락, 반응(좋아요/싫어요) 처리 비즈니스 로직 구현.
   - Controller: 교환 신청, 상태 확인, 목록 조회 등 REST API 엔드포인트 구현.
   - Redis 연동: 교환 제한 및 중복 요청 방지를 위한 PostcardRedisService 추가.
   - 알림 기능: 엽서 교환 관련 알림 발송 로직 구현 (PostcardNotificationService).

  2. FCM 알림 시스템 개선
   - TransactionalEventListener 수정: fallbackExecution = true 설정을 추가하여 트랜잭션이 없는 환경(테스트 API
     등)에서도 알림이 누락되지 않도록 개선.


  3. 기타 수정 사항
   - NestService 및 관련 DTO 필드 보완 (isMine 등).
   - 공통 에러 코드(ErrorCode) 및 알림 상수(NotificationConstants) 추가.
   - PostcardServiceTest 등 단위 테스트를 통한 비즈니스 로직 검증 완료.




## 🔗 관련 이슈 (Related Issues)
- close #41 

## 📝 추가 참고 사항 (Additional Notes)
   - 엽서 교환 로직은 Redis를 활용하여 정책(예: 24시간 제한)을 관리합니다.
