### PR TITLE
Feat/43/mypage api: 마이페이지(MyPage) 도메인 API 구현 

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/controller/MyPageController.java
@@ -1,11 +1,7 @@
 package com.dodo.dodoserver.domain.mypage.controller;
 
-import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
+import com.dodo.dodoserver.domain.mypage.dto.*;
 import com.dodo.dodoserver.domain.mypage.service.MyPageService;
-import com.dodo.dodoserver.domain.nest.dto.NestCommentResponseDto;
-import com.dodo.dodoserver.domain.nest.dto.NestDraftResponseDto;
-import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
-import com.dodo.dodoserver.domain.postcard.dto.PostcardResponseDto;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +23,7 @@ public class MyPageController {
     private final MyPageService myPageService;
 
     @GetMapping("/nests")
-    public ApiResponseDto<Page<NestSimpleResponseDto>> getMyNests(
+    public ApiResponseDto<Page<MyPageNestResponseDto>> getMyNests(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(required = false) Long categoryId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -35,14 +31,14 @@ public class MyPageController {
     }
 
     @GetMapping("/comments")
-    public ApiResponseDto<Page<NestCommentResponseDto>> getMyComments(
+    public ApiResponseDto<Page<MyPageCommentResponseDto>> getMyComments(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ApiResponseDto.success(myPageService.getMyComments(userPrincipal.getId(), pageable));
     }
 
     @GetMapping("/drafts")
-    public ApiResponseDto<Page<NestDraftResponseDto>> getMyDrafts(
+    public ApiResponseDto<Page<MyPageDraftResponseDto>> getMyDrafts(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ApiResponseDto.success(myPageService.getMyDrafts(userPrincipal.getId(), pageable));
@@ -55,28 +51,28 @@ public class MyPageController {
     }
 
     @GetMapping("/unlocks")
-    public ApiResponseDto<Page<NestSimpleResponseDto>> getMyUnlockedNests(
+    public ApiResponseDto<Page<MyPageNestResponseDto>> getMyUnlockedNests(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ApiResponseDto.success(myPageService.getMyUnlockedNests(userPrincipal.getId(), pageable));
     }
 
     @GetMapping("/reactions")
-    public ApiResponseDto<Page<NestCommentResponseDto>> getReactionsOnMyNests(
+    public ApiResponseDto<Page<MyPageCommentResponseDto>> getReactionsOnMyNests(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ApiResponseDto.success(myPageService.getReactionsOnMyNests(userPrincipal.getId(), pageable));
     }
 
     @GetMapping("/likes")
-    public ApiResponseDto<Page<NestSimpleResponseDto>> getMyLikedNests(
+    public ApiResponseDto<Page<MyPageNestResponseDto>> getMyLikedNests(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ApiResponseDto.success(myPageService.getMyLikedNests(userPrincipal.getId(), pageable));
     }
 
     @GetMapping("/postcards")
-    public ApiResponseDto<Page<PostcardResponseDto>> getMyPostcards(
+    public ApiResponseDto<Page<MyPagePostcardResponseDto>> getMyPostcards(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(required = false, defaultValue = "ALL") String filter,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,85 @@
+package com.dodo.dodoserver.domain.mypage.controller;
+
+import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
+import com.dodo.dodoserver.domain.mypage.service.MyPageService;
+import com.dodo.dodoserver.domain.nest.dto.NestCommentResponseDto;
+import com.dodo.dodoserver.domain.nest.dto.NestDraftResponseDto;
+import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
+import com.dodo.dodoserver.domain.postcard.dto.PostcardResponseDto;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping("/nests")
+    public ApiResponseDto<Page<NestSimpleResponseDto>> getMyNests(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(required = false) Long categoryId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(myPageService.getMyNests(userPrincipal.getId(), categoryId, pageable));
+    }
+
+    @GetMapping("/comments")
+    public ApiResponseDto<Page<NestCommentResponseDto>> getMyComments(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(myPageService.getMyComments(userPrincipal.getId(), pageable));
+    }
+
+    @GetMapping("/drafts")
+    public ApiResponseDto<Page<NestDraftResponseDto>> getMyDrafts(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(myPageService.getMyDrafts(userPrincipal.getId(), pageable));
+    }
+
+    @GetMapping("/statistics")
+    public ApiResponseDto<MyPageStatisticsResponseDto> getMyStatistics(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponseDto.success(myPageService.getMyStatistics(userPrincipal.getId()));
+    }
+
+    @GetMapping("/unlocks")
+    public ApiResponseDto<Page<NestSimpleResponseDto>> getMyUnlockedNests(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(myPageService.getMyUnlockedNests(userPrincipal.getId(), pageable));
+    }
+
+    @GetMapping("/reactions")
+    public ApiResponseDto<Page<NestCommentResponseDto>> getReactionsOnMyNests(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(myPageService.getReactionsOnMyNests(userPrincipal.getId(), pageable));
+    }
+
+    @GetMapping("/likes")
+    public ApiResponseDto<Page<NestSimpleResponseDto>> getMyLikedNests(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(myPageService.getMyLikedNests(userPrincipal.getId(), pageable));
+    }
+
+    @GetMapping("/postcards")
+    public ApiResponseDto<Page<PostcardResponseDto>> getMyPostcards(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(required = false, defaultValue = "ALL") String filter,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponseDto.success(myPageService.getMyPostcards(userPrincipal.getId(), filter, pageable));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/controller/MyPageController.java
@@ -58,10 +58,10 @@ public class MyPageController {
     }
 
     @GetMapping("/reactions")
-    public ApiResponseDto<Page<MyPageCommentResponseDto>> getReactionsOnMyNests(
+    public ApiResponseDto<Page<MyPageCommentResponseDto>> getCommentsOnMyNests(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponseDto.success(myPageService.getReactionsOnMyNests(userPrincipal.getId(), pageable));
+        return ApiResponseDto.success(myPageService.getCommentsOnMyNests(userPrincipal.getId(), pageable));
     }
 
     @GetMapping("/likes")

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepository.java
@@ -1,0 +1,21 @@
+package com.dodo.dodoserver.domain.mypage.dao;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import com.dodo.dodoserver.domain.nest.entity.NestDraft;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MyPageRepository {
+    Page<Nest> findNestsByUserAndCategory(User user, Long categoryId, Pageable pageable);
+    Page<NestComment> findCommentsByUser(User user, Pageable pageable);
+    Page<NestDraft> findDraftsByUser(User user, Pageable pageable);
+    Page<Nest> findUnlockedNestsByUser(User user, Pageable pageable);
+    Page<NestComment> findCommentsOnUserNests(User user, Pageable pageable);
+    Page<Nest> findLikedNestsByUser(User user, Pageable pageable);
+
+    long countNestsByUser(User user);
+    long countCommentsByUser(User user);
+    long countPostcardsByUser(User user);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
@@ -41,23 +41,25 @@ public class MyPageRepositoryImpl implements MyPageRepository {
                 .selectFrom(nest)
                 .where(
                         nest.creator.eq(user),
-                        nest.deletedAt.isNull(),
-                        categoryIdEq(categoryId)
+                        nest.deletedAt.isNull()
+                );
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(nest.count())
+                .from(nest)
+                .where(
+                        nest.creator.eq(user),
+                        nest.deletedAt.isNull()
                 );
 
         if (categoryId != null) {
             query.join(nestCategory).on(nestCategory.nest.eq(nest))
                  .where(nestCategory.category.id.eq(categoryId));
+            countQuery.join(nestCategory).on(nestCategory.nest.eq(nest))
+                      .where(nestCategory.category.id.eq(categoryId));
         }
 
-        Long totalCount = queryFactory
-                .select(nest.count())
-                .from(nest)
-                .where(
-                        nest.creator.eq(user),
-                        nest.deletedAt.isNull(),
-                        categoryIdEq(categoryId)
-                ).fetchOne();
+        Long totalCount = countQuery.fetchOne();
         long total = Optional.ofNullable(totalCount).orElse(0L);
 
         List<Nest> content = query

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
@@ -1,0 +1,204 @@
+package com.dodo.dodoserver.domain.mypage.dao;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import com.dodo.dodoserver.domain.nest.entity.NestDraft;
+import com.dodo.dodoserver.domain.nest.entity.ReactionType;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.dodo.dodoserver.domain.nest.entity.QNest.nest;
+import static com.dodo.dodoserver.domain.nest.entity.QNestCategory.nestCategory;
+import static com.dodo.dodoserver.domain.nest.entity.QNestComment.nestComment;
+import static com.dodo.dodoserver.domain.nest.entity.QNestDraft.nestDraft;
+import static com.dodo.dodoserver.domain.nest.entity.QNestReaction.nestReaction;
+import static com.dodo.dodoserver.domain.nest.entity.QUnlockHistory.unlockHistory;
+import static com.dodo.dodoserver.domain.postcard.entity.QPostcard.postcard;
+
+@Repository
+@RequiredArgsConstructor
+public class MyPageRepositoryImpl implements MyPageRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Nest> findNestsByUserAndCategory(User user, Long categoryId, Pageable pageable) {
+        JPAQuery<Nest> query = queryFactory
+                .selectFrom(nest)
+                .where(
+                        nest.creator.eq(user),
+                        nest.deletedAt.isNull(),
+                        categoryIdEq(categoryId)
+                );
+
+        if (categoryId != null) {
+            query.join(nestCategory).on(nestCategory.nest.eq(nest))
+                 .where(nestCategory.category.id.eq(categoryId));
+        }
+
+        long total = query.fetchCount();
+
+        List<Nest> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort(), Nest.class, "nest"))
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<NestComment> findCommentsByUser(User user, Pageable pageable) {
+        JPAQuery<NestComment> query = queryFactory
+                .selectFrom(nestComment)
+                .where(
+                        nestComment.user.eq(user),
+                        nestComment.deletedAt.isNull()
+                );
+
+        long total = query.fetchCount();
+
+        List<NestComment> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort(), NestComment.class, "nestComment"))
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<NestDraft> findDraftsByUser(User user, Pageable pageable) {
+        JPAQuery<NestDraft> query = queryFactory
+                .selectFrom(nestDraft)
+                .where(nestDraft.creator.eq(user));
+
+        long total = query.fetchCount();
+
+        List<NestDraft> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort(), NestDraft.class, "nestDraft"))
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<Nest> findUnlockedNestsByUser(User user, Pageable pageable) {
+        JPAQuery<Nest> query = queryFactory
+                .select(nest)
+                .from(unlockHistory)
+                .join(unlockHistory.nest, nest)
+                .where(
+                        unlockHistory.user.eq(user),
+                        nest.deletedAt.isNull()
+                );
+
+        long total = query.fetchCount();
+
+        List<Nest> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort(), Nest.class, "nest"))
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<NestComment> findCommentsOnUserNests(User user, Pageable pageable) {
+        JPAQuery<NestComment> query = queryFactory
+                .selectFrom(nestComment)
+                .join(nestComment.nest, nest)
+                .where(
+                        nest.creator.eq(user),
+                        nestComment.user.ne(user), // Optional: exclude user's own comments on their own nests
+                        nestComment.deletedAt.isNull()
+                );
+
+        long total = query.fetchCount();
+
+        List<NestComment> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort(), NestComment.class, "nestComment"))
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<Nest> findLikedNestsByUser(User user, Pageable pageable) {
+        JPAQuery<Nest> query = queryFactory
+                .select(nest)
+                .from(nestReaction)
+                .join(nestReaction.nest, nest)
+                .where(
+                        nestReaction.user.eq(user),
+                        nestReaction.reactionType.eq(ReactionType.LIKE),
+                        nest.deletedAt.isNull()
+                );
+
+        long total = query.fetchCount();
+
+        List<Nest> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort(), Nest.class, "nest"))
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public long countNestsByUser(User user) {
+        return queryFactory
+                .selectFrom(nest)
+                .where(nest.creator.eq(user), nest.deletedAt.isNull())
+                .fetchCount();
+    }
+
+    @Override
+    public long countCommentsByUser(User user) {
+        return queryFactory
+                .selectFrom(nestComment)
+                .where(nestComment.user.eq(user), nestComment.deletedAt.isNull())
+                .fetchCount();
+    }
+
+    @Override
+    public long countPostcardsByUser(User user) {
+        return queryFactory
+                .selectFrom(postcard)
+                .where(postcard.currentOwner.eq(user), postcard.deletedAt.isNull())
+                .fetchCount();
+    }
+
+    private BooleanExpression categoryIdEq(Long categoryId) {
+        return categoryId != null ? nestCategory.category.id.eq(categoryId) : null;
+    }
+
+    private <T> OrderSpecifier<?>[] getOrderSpecifier(Sort sort, Class<T> clazz, String variable) {
+        return sort.stream()
+                .map(order -> {
+                    Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                    PathBuilder<T> pathBuilder = new PathBuilder<>(clazz, variable);
+                    return new OrderSpecifier(direction, pathBuilder.get(order.getProperty()));
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.dodo.dodoserver.domain.nest.entity.QNest.nest;
 import static com.dodo.dodoserver.domain.nest.entity.QNestCategory.nestCategory;
@@ -49,7 +50,15 @@ public class MyPageRepositoryImpl implements MyPageRepository {
                  .where(nestCategory.category.id.eq(categoryId));
         }
 
-        long total = query.fetchCount();
+        Long totalCount = queryFactory
+                .select(nest.count())
+                .from(nest)
+                .where(
+                        nest.creator.eq(user),
+                        nest.deletedAt.isNull(),
+                        categoryIdEq(categoryId)
+                ).fetchOne();
+        long total = Optional.ofNullable(totalCount).orElse(0L);
 
         List<Nest> content = query
                 .offset(pageable.getOffset())
@@ -69,7 +78,14 @@ public class MyPageRepositoryImpl implements MyPageRepository {
                         nestComment.deletedAt.isNull()
                 );
 
-        long total = query.fetchCount();
+        Long totalCount = queryFactory
+                .select(nestComment.count())
+                .from(nestComment)
+                .where(
+                        nestComment.user.eq(user),
+                        nestComment.deletedAt.isNull()
+                ).fetchOne();
+        long total = Optional.ofNullable(totalCount).orElse(0L);
 
         List<NestComment> content = query
                 .offset(pageable.getOffset())
@@ -86,7 +102,12 @@ public class MyPageRepositoryImpl implements MyPageRepository {
                 .selectFrom(nestDraft)
                 .where(nestDraft.creator.eq(user));
 
-        long total = query.fetchCount();
+        Long totalCount = queryFactory
+                .select(nestDraft.count())
+                .from(nestDraft)
+                .where(nestDraft.creator.eq(user))
+                .fetchOne();
+        long total = Optional.ofNullable(totalCount).orElse(0L);
 
         List<NestDraft> content = query
                 .offset(pageable.getOffset())
@@ -108,7 +129,15 @@ public class MyPageRepositoryImpl implements MyPageRepository {
                         nest.deletedAt.isNull()
                 );
 
-        long total = query.fetchCount();
+        Long totalCount = queryFactory
+                .select(nest.count())
+                .from(unlockHistory)
+                .join(unlockHistory.nest, nest)
+                .where(
+                        unlockHistory.user.eq(user),
+                        nest.deletedAt.isNull()
+                ).fetchOne();
+        long total = Optional.ofNullable(totalCount).orElse(0L);
 
         List<Nest> content = query
                 .offset(pageable.getOffset())
@@ -126,11 +155,20 @@ public class MyPageRepositoryImpl implements MyPageRepository {
                 .join(nestComment.nest, nest)
                 .where(
                         nest.creator.eq(user),
-                        nestComment.user.ne(user), // Optional: exclude user's own comments on their own nests
+                        nestComment.user.ne(user),
                         nestComment.deletedAt.isNull()
                 );
 
-        long total = query.fetchCount();
+        Long totalCount = queryFactory
+                .select(nestComment.count())
+                .from(nestComment)
+                .join(nestComment.nest, nest)
+                .where(
+                        nest.creator.eq(user),
+                        nestComment.user.ne(user),
+                        nestComment.deletedAt.isNull()
+                ).fetchOne();
+        long total = Optional.ofNullable(totalCount).orElse(0L);
 
         List<NestComment> content = query
                 .offset(pageable.getOffset())
@@ -153,7 +191,16 @@ public class MyPageRepositoryImpl implements MyPageRepository {
                         nest.deletedAt.isNull()
                 );
 
-        long total = query.fetchCount();
+        Long totalCount = queryFactory
+                .select(nest.count())
+                .from(nestReaction)
+                .join(nestReaction.nest, nest)
+                .where(
+                        nestReaction.user.eq(user),
+                        nestReaction.reactionType.eq(ReactionType.LIKE),
+                        nest.deletedAt.isNull()
+                ).fetchOne();
+        long total = Optional.ofNullable(totalCount).orElse(0L);
 
         List<Nest> content = query
                 .offset(pageable.getOffset())
@@ -166,26 +213,32 @@ public class MyPageRepositoryImpl implements MyPageRepository {
 
     @Override
     public long countNestsByUser(User user) {
-        return queryFactory
-                .selectFrom(nest)
+        Long count = queryFactory
+                .select(nest.count())
+                .from(nest)
                 .where(nest.creator.eq(user), nest.deletedAt.isNull())
-                .fetchCount();
+                .fetchOne();
+        return Optional.ofNullable(count).orElse(0L);
     }
 
     @Override
     public long countCommentsByUser(User user) {
-        return queryFactory
-                .selectFrom(nestComment)
+        Long count = queryFactory
+                .select(nestComment.count())
+                .from(nestComment)
                 .where(nestComment.user.eq(user), nestComment.deletedAt.isNull())
-                .fetchCount();
+                .fetchOne();
+        return Optional.ofNullable(count).orElse(0L);
     }
 
     @Override
     public long countPostcardsByUser(User user) {
-        return queryFactory
-                .selectFrom(postcard)
+        Long count = queryFactory
+                .select(postcard.count())
+                .from(postcard)
                 .where(postcard.currentOwner.eq(user), postcard.deletedAt.isNull())
-                .fetchCount();
+                .fetchOne();
+        return Optional.ofNullable(count).orElse(0L);
     }
 
     private BooleanExpression categoryIdEq(Long categoryId) {

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.dodo.dodoserver.domain.user.entity.QUser;
+
 import static com.dodo.dodoserver.domain.nest.entity.QNest.nest;
 import static com.dodo.dodoserver.domain.nest.entity.QNestCategory.nestCategory;
 import static com.dodo.dodoserver.domain.nest.entity.QNestComment.nestComment;
@@ -28,6 +30,7 @@ import static com.dodo.dodoserver.domain.nest.entity.QNestDraft.nestDraft;
 import static com.dodo.dodoserver.domain.nest.entity.QNestReaction.nestReaction;
 import static com.dodo.dodoserver.domain.nest.entity.QUnlockHistory.unlockHistory;
 import static com.dodo.dodoserver.domain.postcard.entity.QPostcard.postcard;
+import static com.dodo.dodoserver.domain.user.entity.QUser.user;
 
 @Repository
 @RequiredArgsConstructor
@@ -75,6 +78,8 @@ public class MyPageRepositoryImpl implements MyPageRepository {
     public Page<NestComment> findCommentsByUser(User user, Pageable pageable) {
         JPAQuery<NestComment> query = queryFactory
                 .selectFrom(nestComment)
+                .join(nestComment.nest, nest).fetchJoin()
+                .join(nestComment.user, QUser.user).fetchJoin()
                 .where(
                         nestComment.user.eq(user),
                         nestComment.deletedAt.isNull()
@@ -154,7 +159,8 @@ public class MyPageRepositoryImpl implements MyPageRepository {
     public Page<NestComment> findCommentsOnUserNests(User user, Pageable pageable) {
         JPAQuery<NestComment> query = queryFactory
                 .selectFrom(nestComment)
-                .join(nestComment.nest, nest)
+                .join(nestComment.nest, nest).fetchJoin()
+                .join(nestComment.user, QUser.user).fetchJoin()
                 .where(
                         nest.creator.eq(user),
                         nestComment.user.ne(user),

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageCommentResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageCommentResponseDto.java
@@ -1,0 +1,33 @@
+package com.dodo.dodoserver.domain.mypage.dto;
+
+import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyPageCommentResponseDto {
+    private Long id;
+    private Long nestId;
+    private String nestTitle;
+    private String content;
+    private String authorNickname;
+    private LocalDateTime createdAt;
+
+    public static MyPageCommentResponseDto from(NestComment comment) {
+        return MyPageCommentResponseDto.builder()
+                .id(comment.getId())
+                .nestId(comment.getNest().getId())
+                .nestTitle(comment.getNest().getTitle())
+                .content(comment.getContent())
+                .authorNickname(comment.getUser().getNickname())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageDraftResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageDraftResponseDto.java
@@ -1,0 +1,31 @@
+package com.dodo.dodoserver.domain.mypage.dto;
+
+import com.dodo.dodoserver.domain.nest.entity.NestDraft;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyPageDraftResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MyPageDraftResponseDto from(NestDraft draft) {
+        return MyPageDraftResponseDto.builder()
+                .id(draft.getId())
+                .title(draft.getTitle())
+                .content(draft.getContent())
+                .createdAt(draft.getCreatedAt())
+                .updatedAt(draft.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageNestResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageNestResponseDto.java
@@ -19,11 +19,10 @@ public class MyPageNestResponseDto {
     private String content;
     private String thumbnailUrl;
     private boolean isUnlocked;
-    private ReactionType myReaction;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static MyPageNestResponseDto from(Nest nest, boolean isUnlocked, ReactionType myReaction) {
+    public static MyPageNestResponseDto from(Nest nest, boolean isUnlocked) {
         String thumbnail = nest.getImages().isEmpty() ? null : nest.getImages().get(0).getImageUrl();
         
         return MyPageNestResponseDto.builder()
@@ -32,7 +31,6 @@ public class MyPageNestResponseDto {
                 .content(nest.getContent())
                 .thumbnailUrl(thumbnail)
                 .isUnlocked(isUnlocked)
-                .myReaction(myReaction)
                 .createdAt(nest.getCreatedAt())
                 .updatedAt(nest.getUpdatedAt())
                 .build();

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageNestResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageNestResponseDto.java
@@ -1,0 +1,40 @@
+package com.dodo.dodoserver.domain.mypage.dto;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.ReactionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyPageNestResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private String thumbnailUrl;
+    private boolean isUnlocked;
+    private ReactionType myReaction;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MyPageNestResponseDto from(Nest nest, boolean isUnlocked, ReactionType myReaction) {
+        String thumbnail = nest.getImages().isEmpty() ? null : nest.getImages().get(0).getImageUrl();
+        
+        return MyPageNestResponseDto.builder()
+                .id(nest.getId())
+                .title(nest.getTitle())
+                .content(nest.getContent())
+                .thumbnailUrl(thumbnail)
+                .isUnlocked(isUnlocked)
+                .myReaction(myReaction)
+                .createdAt(nest.getCreatedAt())
+                .updatedAt(nest.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPagePostcardResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPagePostcardResponseDto.java
@@ -1,0 +1,33 @@
+package com.dodo.dodoserver.domain.mypage.dto;
+
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyPagePostcardResponseDto {
+    private Long id;
+    private String imageUrl;
+    private String content;
+    private String authorNickname;
+    private boolean isMine;
+    private LocalDateTime createdAt;
+
+    public static MyPagePostcardResponseDto from(Postcard postcard, Long currentUserId) {
+        return MyPagePostcardResponseDto.builder()
+                .id(postcard.getId())
+                .imageUrl(postcard.getImageUrl())
+                .content(postcard.getContent())
+                .authorNickname(postcard.getOriginalAuthor().getNickname())
+                .isMine(postcard.getOriginalAuthor().getId().equals(currentUserId))
+                .createdAt(postcard.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPagePostcardResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPagePostcardResponseDto.java
@@ -1,6 +1,7 @@
 package com.dodo.dodoserver.domain.mypage.dto;
 
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,15 +19,21 @@ public class MyPagePostcardResponseDto {
     private String content;
     private String authorNickname;
     private boolean isMine;
+    private PostcardReactionType reactionType;
     private LocalDateTime createdAt;
 
     public static MyPagePostcardResponseDto from(Postcard postcard, Long currentUserId) {
+        return from(postcard, null, currentUserId);
+    }
+
+    public static MyPagePostcardResponseDto from(Postcard postcard, PostcardReactionType reactionType, Long currentUserId) {
         return MyPagePostcardResponseDto.builder()
                 .id(postcard.getId())
                 .imageUrl(postcard.getImageUrl())
                 .content(postcard.getContent())
                 .authorNickname(postcard.getOriginalAuthor().getNickname())
                 .isMine(postcard.getOriginalAuthor().getId().equals(currentUserId))
+                .reactionType(reactionType)
                 .createdAt(postcard.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageStatisticsResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dto/MyPageStatisticsResponseDto.java
@@ -1,0 +1,24 @@
+package com.dodo.dodoserver.domain.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyPageStatisticsResponseDto {
+    private long nestCount;
+    private long commentCount;
+    private long postcardCount;
+
+    public static MyPageStatisticsResponseDto of(long nestCount, long commentCount, long postcardCount) {
+        return MyPageStatisticsResponseDto.builder()
+                .nestCount(nestCount)
+                .commentCount(commentCount)
+                .postcardCount(postcardCount)
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
@@ -4,6 +4,7 @@ import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
 import com.dodo.dodoserver.domain.mypage.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -82,7 +83,7 @@ public class MyPageService {
     public Page<MyPagePostcardResponseDto> getMyPostcards(Long userId, String filter, Pageable pageable) {
         User user = getUser(userId);
         
-        Page<com.dodo.dodoserver.domain.postcard.entity.Postcard> postcards;
+        Page<Postcard> postcards;
         if ("CREATED".equalsIgnoreCase(filter)) {
             postcards = postcardRepository.findCreatedByUser(user, pageable);
         } else if ("ACQUIRED".equalsIgnoreCase(filter)) {

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
@@ -3,7 +3,10 @@ package com.dodo.dodoserver.domain.mypage.service;
 import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
 import com.dodo.dodoserver.domain.mypage.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardReactionRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReaction;
+import com.dodo.dodoserver.domain.postcard.entity.PostcardReactionType;
 import com.dodo.dodoserver.domain.postcard.service.PostcardService;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
@@ -15,6 +18,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
@@ -22,6 +29,7 @@ public class MyPageService {
     private final UserRepository userRepository;
     private final MyPageRepository myPageRepository;
     private final PostcardService postcardService;
+    private final PostcardReactionRepository postcardReactionRepository;
 
     private User getUser(Long userId) {
         return userRepository.findById(userId)
@@ -82,6 +90,22 @@ public class MyPageService {
     @Transactional(readOnly = true)
     public Page<MyPagePostcardResponseDto> getMyPostcards(Long userId, String filter, Pageable pageable) {
         Page<Postcard> postcards = postcardService.getPostcardEntitiesByFilter(userId, filter, pageable);
-        return postcards.map(postcard -> MyPagePostcardResponseDto.from(postcard, userId));
+
+        if (postcards.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Postcard> postcardList = postcards.getContent();
+
+        // 리액션 일괄 조회 (N+1 방지)
+        Map<Long, PostcardReactionType> reactionMap = postcardReactionRepository.findAllByPostcardIn(postcardList)
+                .stream()
+                .collect(Collectors.toMap(
+                        r -> r.getPostcard().getId(),
+                        PostcardReaction::getReactionType
+                ));
+
+        return postcards.map(postcard ->
+                MyPagePostcardResponseDto.from(postcard, reactionMap.get(postcard.getId()), userId));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
@@ -3,8 +3,8 @@ package com.dodo.dodoserver.domain.mypage.service;
 import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
 import com.dodo.dodoserver.domain.mypage.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
-import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.service.PostcardService;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -21,7 +21,7 @@ public class MyPageService {
 
     private final UserRepository userRepository;
     private final MyPageRepository myPageRepository;
-    private final PostcardRepository postcardRepository;
+    private final PostcardService postcardService;
 
     private User getUser(Long userId) {
         return userRepository.findById(userId)
@@ -81,17 +81,7 @@ public class MyPageService {
 
     @Transactional(readOnly = true)
     public Page<MyPagePostcardResponseDto> getMyPostcards(Long userId, String filter, Pageable pageable) {
-        User user = getUser(userId);
-        
-        Page<Postcard> postcards;
-        if ("CREATED".equalsIgnoreCase(filter)) {
-            postcards = postcardRepository.findCreatedByUser(user, pageable);
-        } else if ("ACQUIRED".equalsIgnoreCase(filter)) {
-            postcards = postcardRepository.findAcquiredByUser(user, pageable);
-        } else {
-            postcards = postcardRepository.findInventoryByUser(user, pageable);
-        }
-
+        Page<Postcard> postcards = postcardService.getPostcardEntitiesByFilter(userId, filter, pageable);
         return postcards.map(postcard -> MyPagePostcardResponseDto.from(postcard, userId));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
@@ -1,13 +1,9 @@
 package com.dodo.dodoserver.domain.mypage.service;
 
 import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
-import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
-import com.dodo.dodoserver.domain.nest.dto.NestCommentResponseDto;
-import com.dodo.dodoserver.domain.nest.dto.NestDraftResponseDto;
-import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
+import com.dodo.dodoserver.domain.mypage.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
-import com.dodo.dodoserver.domain.postcard.dto.PostcardResponseDto;
-import com.dodo.dodoserver.domain.postcard.service.PostcardService;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.global.error.ErrorCode;
@@ -24,7 +20,7 @@ public class MyPageService {
 
     private final UserRepository userRepository;
     private final MyPageRepository myPageRepository;
-    private final PostcardService postcardService;
+    private final PostcardRepository postcardRepository;
 
     private User getUser(Long userId) {
         return userRepository.findById(userId)
@@ -32,24 +28,24 @@ public class MyPageService {
     }
 
     @Transactional(readOnly = true)
-    public Page<NestSimpleResponseDto> getMyNests(Long userId, Long categoryId, Pageable pageable) {
+    public Page<MyPageNestResponseDto> getMyNests(Long userId, Long categoryId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findNestsByUserAndCategory(user, categoryId, pageable)
-                .map(nest -> NestSimpleResponseDto.from(nest, true, null));
+                .map(nest -> MyPageNestResponseDto.from(nest, true, null));
     }
 
     @Transactional(readOnly = true)
-    public Page<NestCommentResponseDto> getMyComments(Long userId, Pageable pageable) {
+    public Page<MyPageCommentResponseDto> getMyComments(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findCommentsByUser(user, pageable)
-                .map(NestCommentResponseDto::from);
+                .map(MyPageCommentResponseDto::from);
     }
 
     @Transactional(readOnly = true)
-    public Page<NestDraftResponseDto> getMyDrafts(Long userId, Pageable pageable) {
+    public Page<MyPageDraftResponseDto> getMyDrafts(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findDraftsByUser(user, pageable)
-                .map(NestDraftResponseDto::from);
+                .map(MyPageDraftResponseDto::from);
     }
 
     @Transactional(readOnly = true)
@@ -62,28 +58,39 @@ public class MyPageService {
     }
 
     @Transactional(readOnly = true)
-    public Page<NestSimpleResponseDto> getMyUnlockedNests(Long userId, Pageable pageable) {
+    public Page<MyPageNestResponseDto> getMyUnlockedNests(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findUnlockedNestsByUser(user, pageable)
-                .map(nest -> NestSimpleResponseDto.from(nest, true, null));
+                .map(nest -> MyPageNestResponseDto.from(nest, true, null));
     }
 
     @Transactional(readOnly = true)
-    public Page<NestCommentResponseDto> getReactionsOnMyNests(Long userId, Pageable pageable) {
+    public Page<MyPageCommentResponseDto> getReactionsOnMyNests(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findCommentsOnUserNests(user, pageable)
-                .map(NestCommentResponseDto::from);
+                .map(MyPageCommentResponseDto::from);
     }
 
     @Transactional(readOnly = true)
-    public Page<NestSimpleResponseDto> getMyLikedNests(Long userId, Pageable pageable) {
+    public Page<MyPageNestResponseDto> getMyLikedNests(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findLikedNestsByUser(user, pageable)
-                .map(nest -> NestSimpleResponseDto.from(nest, true, ReactionType.LIKE));
+                .map(nest -> MyPageNestResponseDto.from(nest, true, ReactionType.LIKE));
     }
 
     @Transactional(readOnly = true)
-    public Page<PostcardResponseDto> getMyPostcards(Long userId, String filter, Pageable pageable) {
-        return postcardService.getPostcardInventory(userId, filter, pageable);
+    public Page<MyPagePostcardResponseDto> getMyPostcards(Long userId, String filter, Pageable pageable) {
+        User user = getUser(userId);
+        
+        Page<com.dodo.dodoserver.domain.postcard.entity.Postcard> postcards;
+        if ("CREATED".equalsIgnoreCase(filter)) {
+            postcards = postcardRepository.findCreatedByUser(user, pageable);
+        } else if ("ACQUIRED".equalsIgnoreCase(filter)) {
+            postcards = postcardRepository.findAcquiredByUser(user, pageable);
+        } else {
+            postcards = postcardRepository.findInventoryByUser(user, pageable);
+        }
+
+        return postcards.map(postcard -> MyPagePostcardResponseDto.from(postcard, userId));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
@@ -1,0 +1,89 @@
+package com.dodo.dodoserver.domain.mypage.service;
+
+import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
+import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
+import com.dodo.dodoserver.domain.nest.dto.NestCommentResponseDto;
+import com.dodo.dodoserver.domain.nest.dto.NestDraftResponseDto;
+import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
+import com.dodo.dodoserver.domain.nest.entity.ReactionType;
+import com.dodo.dodoserver.domain.postcard.dto.PostcardResponseDto;
+import com.dodo.dodoserver.domain.postcard.service.PostcardService;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.global.error.ErrorCode;
+import com.dodo.dodoserver.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final MyPageRepository myPageRepository;
+    private final PostcardService postcardService;
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NestSimpleResponseDto> getMyNests(Long userId, Long categoryId, Pageable pageable) {
+        User user = getUser(userId);
+        return myPageRepository.findNestsByUserAndCategory(user, categoryId, pageable)
+                .map(nest -> NestSimpleResponseDto.from(nest, true, null));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NestCommentResponseDto> getMyComments(Long userId, Pageable pageable) {
+        User user = getUser(userId);
+        return myPageRepository.findCommentsByUser(user, pageable)
+                .map(NestCommentResponseDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NestDraftResponseDto> getMyDrafts(Long userId, Pageable pageable) {
+        User user = getUser(userId);
+        return myPageRepository.findDraftsByUser(user, pageable)
+                .map(NestDraftResponseDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public MyPageStatisticsResponseDto getMyStatistics(Long userId) {
+        User user = getUser(userId);
+        long nestCount = myPageRepository.countNestsByUser(user);
+        long commentCount = myPageRepository.countCommentsByUser(user);
+        long postcardCount = myPageRepository.countPostcardsByUser(user);
+        return MyPageStatisticsResponseDto.of(nestCount, commentCount, postcardCount);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NestSimpleResponseDto> getMyUnlockedNests(Long userId, Pageable pageable) {
+        User user = getUser(userId);
+        return myPageRepository.findUnlockedNestsByUser(user, pageable)
+                .map(nest -> NestSimpleResponseDto.from(nest, true, null));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NestCommentResponseDto> getReactionsOnMyNests(Long userId, Pageable pageable) {
+        User user = getUser(userId);
+        return myPageRepository.findCommentsOnUserNests(user, pageable)
+                .map(NestCommentResponseDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NestSimpleResponseDto> getMyLikedNests(Long userId, Pageable pageable) {
+        User user = getUser(userId);
+        return myPageRepository.findLikedNestsByUser(user, pageable)
+                .map(nest -> NestSimpleResponseDto.from(nest, true, ReactionType.LIKE));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostcardResponseDto> getMyPostcards(Long userId, String filter, Pageable pageable) {
+        return postcardService.getPostcardInventory(userId, filter, pageable);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/service/MyPageService.java
@@ -6,8 +6,8 @@ import com.dodo.dodoserver.domain.nest.entity.ReactionType;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
-import com.dodo.dodoserver.global.error.ErrorCode;
-import com.dodo.dodoserver.global.error.exception.BusinessException;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +31,7 @@ public class MyPageService {
     public Page<MyPageNestResponseDto> getMyNests(Long userId, Long categoryId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findNestsByUserAndCategory(user, categoryId, pageable)
-                .map(nest -> MyPageNestResponseDto.from(nest, true, null));
+                .map(nest -> MyPageNestResponseDto.from(nest, true));
     }
 
     @Transactional(readOnly = true)
@@ -61,11 +61,11 @@ public class MyPageService {
     public Page<MyPageNestResponseDto> getMyUnlockedNests(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findUnlockedNestsByUser(user, pageable)
-                .map(nest -> MyPageNestResponseDto.from(nest, true, null));
+                .map(nest -> MyPageNestResponseDto.from(nest, true));
     }
 
     @Transactional(readOnly = true)
-    public Page<MyPageCommentResponseDto> getReactionsOnMyNests(Long userId, Pageable pageable) {
+    public Page<MyPageCommentResponseDto> getCommentsOnMyNests(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findCommentsOnUserNests(user, pageable)
                 .map(MyPageCommentResponseDto::from);
@@ -75,7 +75,7 @@ public class MyPageService {
     public Page<MyPageNestResponseDto> getMyLikedNests(Long userId, Pageable pageable) {
         User user = getUser(userId);
         return myPageRepository.findLikedNestsByUser(user, pageable)
-                .map(nest -> MyPageNestResponseDto.from(nest, true, ReactionType.LIKE));
+                .map(nest -> MyPageNestResponseDto.from(nest, true));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dodo/dodoserver/domain/nest/entity/Nest.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/entity/Nest.java
@@ -56,6 +56,7 @@ public class Nest {
 
     @Builder.Default
     @OneToMany(mappedBy = "nest", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
     private List<NestImage> images = new ArrayList<>();
 
     @CreatedDate

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -30,12 +30,12 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
     @Query("SELECT p FROM Postcard p WHERE p.nest IN :nests AND p.isShared = true")
     List<Postcard> findAllByNestInAndIsSharedTrue(@Param("nests") java.util.Collection<Nest> nests);
 
-    @Query("SELECT p FROM Postcard p WHERE p.originalAuthor = :user OR p.currentOwner = :user")
+    @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.originalAuthor = :user OR p.currentOwner = :user")
     Page<Postcard> findInventoryByUser(@Param("user") User user, Pageable pageable);
 
-    @Query("SELECT p FROM Postcard p WHERE p.originalAuthor = :user")
+    @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.originalAuthor = :user")
     Page<Postcard> findCreatedByUser(@Param("user") User user, Pageable pageable);
 
-    @Query("SELECT p FROM Postcard p WHERE p.currentOwner = :user AND p.originalAuthor != :user")
+    @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.currentOwner = :user AND p.originalAuthor != :user")
     Page<Postcard> findAcquiredByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -122,16 +122,7 @@ public class PostcardService {
 
     @Transactional(readOnly = true)
     public Page<PostcardResponseDto> getPostcardInventory(Long userId, String filter, Pageable pageable) {
-        User user = getUser(userId);
-        
-        Page<Postcard> inventory;
-        if ("CREATED".equalsIgnoreCase(filter)) {
-            inventory = postcardRepository.findCreatedByUser(user, pageable);
-        } else if ("ACQUIRED".equalsIgnoreCase(filter)) {
-            inventory = postcardRepository.findAcquiredByUser(user, pageable);
-        } else {
-            inventory = postcardRepository.findInventoryByUser(user, pageable);
-        }
+        Page<Postcard> inventory = getPostcardEntitiesByFilter(userId, filter, pageable);
         
         if (inventory.isEmpty()) {
             return Page.empty(pageable);
@@ -148,7 +139,21 @@ public class PostcardService {
                 ));
 
         return inventory.map(p -> PostcardResponseDto.from(p, reactionMap.get(p.getId()), userId));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Postcard> getPostcardEntitiesByFilter(Long userId, String filter, Pageable pageable) {
+        User user = getUser(userId);
+
+        if ("CREATED".equalsIgnoreCase(filter)) {
+            return postcardRepository.findCreatedByUser(user, pageable);
+        } else if ("ACQUIRED".equalsIgnoreCase(filter)) {
+            return postcardRepository.findAcquiredByUser(user, pageable);
+        } else {
+            return postcardRepository.findInventoryByUser(user, pageable);
         }
+    }
+
 
     @Transactional
     public PostcardResponseDto updatePostcard(Long userId, Long postcardId, PostcardCreateRequestDto requestDto) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+        default_batch_fetch_size: 100
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/java/com/dodo/dodoserver/domain/mypage/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/mypage/controller/MyPageControllerTest.java
@@ -1,0 +1,118 @@
+package com.dodo.dodoserver.domain.mypage.controller;
+
+import com.dodo.dodoserver.domain.mypage.dto.*;
+import com.dodo.dodoserver.domain.mypage.service.MyPageService;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MyPageController.class)
+@Import(SecurityConfig.class)
+class MyPageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MyPageService myPageService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("나의 작성 둥지 목록 조회 성공")
+    @WithMockUserPrincipal
+    void getMyNests_success() throws Exception {
+        MyPageNestResponseDto responseDto = MyPageNestResponseDto.builder().id(1L).title("제목").build();
+        Page<MyPageNestResponseDto> page = new PageImpl<>(List.of(responseDto));
+
+        given(myPageService.getMyNests(anyLong(), any(), any())).willReturn(page);
+
+        mockMvc.perform(get("/api/v1/mypage/nests"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].title").value("제목"));
+    }
+
+    @Test
+    @DisplayName("활동 통계 조회 성공")
+    @WithMockUserPrincipal
+    void getMyStatistics_success() throws Exception {
+        MyPageStatisticsResponseDto responseDto = MyPageStatisticsResponseDto.builder()
+                .nestCount(5)
+                .commentCount(10)
+                .postcardCount(3)
+                .build();
+
+        given(myPageService.getMyStatistics(anyLong())).willReturn(responseDto);
+
+        mockMvc.perform(get("/api/v1/mypage/statistics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nestCount").value(5))
+                .andExpect(jsonPath("$.data.commentCount").value(10));
+    }
+
+    @Test
+    @DisplayName("보유 엽서 목록 조회 성공")
+    @WithMockUserPrincipal
+    void getMyPostcards_success() throws Exception {
+        MyPagePostcardResponseDto responseDto = MyPagePostcardResponseDto.builder().id(1L).content("엽서내용").build();
+        Page<MyPagePostcardResponseDto> page = new PageImpl<>(List.of(responseDto));
+
+        given(myPageService.getMyPostcards(anyLong(), anyString(), any())).willReturn(page);
+
+        mockMvc.perform(get("/api/v1/mypage/postcards")
+                        .param("filter", "ALL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].content").value("엽서내용"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
@@ -1,8 +1,10 @@
 package com.dodo.dodoserver.domain.mypage.service;
 
 import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
+import com.dodo.dodoserver.domain.mypage.dto.MyPagePostcardResponseDto;
 import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -13,13 +15,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class MyPageServiceTest {
@@ -60,5 +69,57 @@ class MyPageServiceTest {
         assertThat(result.getNestCount()).isEqualTo(5);
         assertThat(result.getCommentCount()).isEqualTo(10);
         assertThat(result.getPostcardCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("엽서 인벤토리 조회 - ALL 필터")
+    void getMyPostcards_all() {
+        // given
+        User user = User.builder().id(1L).build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(postcardRepository.findInventoryByUser(user, pageable)).willReturn(new PageImpl<>(List.of(postcard)));
+
+        // when
+        Page<MyPagePostcardResponseDto> result = myPageService.getMyPostcards(1L, "ALL", pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        verify(postcardRepository).findInventoryByUser(user, pageable);
+    }
+
+    @Test
+    @DisplayName("엽서 인벤토리 조회 - CREATED 필터")
+    void getMyPostcards_created() {
+        // given
+        User user = User.builder().id(1L).build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(postcardRepository.findCreatedByUser(user, pageable)).willReturn(new PageImpl<>(List.of(postcard)));
+
+        // when
+        myPageService.getMyPostcards(1L, "CREATED", pageable);
+
+        // then
+        verify(postcardRepository).findCreatedByUser(user, pageable);
+    }
+
+    @Test
+    @DisplayName("엽서 인벤토리 조회 - ACQUIRED 필터")
+    void getMyPostcards_acquired() {
+        // given
+        User user = User.builder().id(1L).build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(postcardRepository.findAcquiredByUser(user, pageable)).willReturn(new PageImpl<>(List.of(postcard)));
+
+        // when
+        myPageService.getMyPostcards(1L, "ACQUIRED", pageable);
+
+        // then
+        verify(postcardRepository).findAcquiredByUser(user, pageable);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
@@ -3,8 +3,8 @@ package com.dodo.dodoserver.domain.mypage.service;
 import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
 import com.dodo.dodoserver.domain.mypage.dto.MyPagePostcardResponseDto;
 import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
-import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.postcard.service.PostcardService;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -43,7 +43,7 @@ class MyPageServiceTest {
     private MyPageRepository myPageRepository;
 
     @Mock
-    private PostcardRepository postcardRepository;
+    private PostcardService postcardService;
 
     @Test
     @DisplayName("유저가 없는 경우 예외 발생")
@@ -78,15 +78,14 @@ class MyPageServiceTest {
         User user = User.builder().id(1L).build();
         Pageable pageable = PageRequest.of(0, 10);
         Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(postcardRepository.findInventoryByUser(user, pageable)).willReturn(new PageImpl<>(List.of(postcard)));
+        given(postcardService.getPostcardEntitiesByFilter(anyLong(), any(), any())).willReturn(new PageImpl<>(List.of(postcard)));
 
         // when
         Page<MyPagePostcardResponseDto> result = myPageService.getMyPostcards(1L, "ALL", pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);
-        verify(postcardRepository).findInventoryByUser(user, pageable);
+        verify(postcardService).getPostcardEntitiesByFilter(1L, "ALL", pageable);
     }
 
     @Test
@@ -96,14 +95,13 @@ class MyPageServiceTest {
         User user = User.builder().id(1L).build();
         Pageable pageable = PageRequest.of(0, 10);
         Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(postcardRepository.findCreatedByUser(user, pageable)).willReturn(new PageImpl<>(List.of(postcard)));
+        given(postcardService.getPostcardEntitiesByFilter(anyLong(), any(), any())).willReturn(new PageImpl<>(List.of(postcard)));
 
         // when
         myPageService.getMyPostcards(1L, "CREATED", pageable);
 
         // then
-        verify(postcardRepository).findCreatedByUser(user, pageable);
+        verify(postcardService).getPostcardEntitiesByFilter(1L, "CREATED", pageable);
     }
 
     @Test
@@ -113,13 +111,12 @@ class MyPageServiceTest {
         User user = User.builder().id(1L).build();
         Pageable pageable = PageRequest.of(0, 10);
         Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(postcardRepository.findAcquiredByUser(user, pageable)).willReturn(new PageImpl<>(List.of(postcard)));
+        given(postcardService.getPostcardEntitiesByFilter(anyLong(), any(), any())).willReturn(new PageImpl<>(List.of(postcard)));
 
         // when
         myPageService.getMyPostcards(1L, "ACQUIRED", pageable);
 
         // then
-        verify(postcardRepository).findAcquiredByUser(user, pageable);
+        verify(postcardService).getPostcardEntitiesByFilter(1L, "ACQUIRED", pageable);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
@@ -1,0 +1,64 @@
+package com.dodo.dodoserver.domain.mypage.service;
+
+import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
+import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MyPageServiceTest {
+
+    @InjectMocks
+    private MyPageService myPageService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MyPageRepository myPageRepository;
+
+    @Mock
+    private PostcardRepository postcardRepository;
+
+    @Test
+    @DisplayName("유저가 없는 경우 예외 발생")
+    void getUser_fail() {
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.getMyStatistics(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("마이페이지 통계 조회 성공")
+    void getMyStatistics_success() {
+        User user = User.builder().id(1L).build();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(myPageRepository.countNestsByUser(user)).willReturn(5L);
+        given(myPageRepository.countCommentsByUser(user)).willReturn(10L);
+        given(myPageRepository.countPostcardsByUser(user)).willReturn(3L);
+
+        MyPageStatisticsResponseDto result = myPageService.getMyStatistics(1L);
+
+        assertThat(result.getNestCount()).isEqualTo(5);
+        assertThat(result.getCommentCount()).isEqualTo(10);
+        assertThat(result.getPostcardCount()).isEqualTo(3);
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.mypage.service;
 import com.dodo.dodoserver.domain.mypage.dao.MyPageRepository;
 import com.dodo.dodoserver.domain.mypage.dto.MyPagePostcardResponseDto;
 import com.dodo.dodoserver.domain.mypage.dto.MyPageStatisticsResponseDto;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardReactionRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.postcard.service.PostcardService;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
@@ -20,6 +21,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,6 +46,9 @@ class MyPageServiceTest {
 
     @Mock
     private PostcardService postcardService;
+
+    @Mock
+    private PostcardReactionRepository postcardReactionRepository;
 
     @Test
     @DisplayName("유저가 없는 경우 예외 발생")
@@ -75,10 +80,11 @@ class MyPageServiceTest {
     @DisplayName("엽서 인벤토리 조회 - ALL 필터")
     void getMyPostcards_all() {
         // given
-        User user = User.builder().id(1L).build();
+        User user = User.builder().id(1L).nickname("test").build();
         Pageable pageable = PageRequest.of(0, 10);
         Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
         given(postcardService.getPostcardEntitiesByFilter(anyLong(), any(), any())).willReturn(new PageImpl<>(List.of(postcard)));
+        given(postcardReactionRepository.findAllByPostcardIn(any())).willReturn(Collections.emptyList());
 
         // when
         Page<MyPagePostcardResponseDto> result = myPageService.getMyPostcards(1L, "ALL", pageable);
@@ -86,37 +92,42 @@ class MyPageServiceTest {
         // then
         assertThat(result.getContent()).hasSize(1);
         verify(postcardService).getPostcardEntitiesByFilter(1L, "ALL", pageable);
+        verify(postcardReactionRepository).findAllByPostcardIn(any());
     }
 
     @Test
     @DisplayName("엽서 인벤토리 조회 - CREATED 필터")
     void getMyPostcards_created() {
         // given
-        User user = User.builder().id(1L).build();
+        User user = User.builder().id(1L).nickname("test").build();
         Pageable pageable = PageRequest.of(0, 10);
         Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
         given(postcardService.getPostcardEntitiesByFilter(anyLong(), any(), any())).willReturn(new PageImpl<>(List.of(postcard)));
+        given(postcardReactionRepository.findAllByPostcardIn(any())).willReturn(Collections.emptyList());
 
         // when
         myPageService.getMyPostcards(1L, "CREATED", pageable);
 
         // then
         verify(postcardService).getPostcardEntitiesByFilter(1L, "CREATED", pageable);
+        verify(postcardReactionRepository).findAllByPostcardIn(any());
     }
 
     @Test
     @DisplayName("엽서 인벤토리 조회 - ACQUIRED 필터")
     void getMyPostcards_acquired() {
         // given
-        User user = User.builder().id(1L).build();
+        User user = User.builder().id(1L).nickname("test").build();
         Pageable pageable = PageRequest.of(0, 10);
         Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
         given(postcardService.getPostcardEntitiesByFilter(anyLong(), any(), any())).willReturn(new PageImpl<>(List.of(postcard)));
+        given(postcardReactionRepository.findAllByPostcardIn(any())).willReturn(Collections.emptyList());
 
         // when
         myPageService.getMyPostcards(1L, "ACQUIRED", pageable);
 
         // then
         verify(postcardService).getPostcardEntitiesByFilter(1L, "ACQUIRED", pageable);
+        verify(postcardReactionRepository).findAllByPostcardIn(any());
     }
 }


### PR DESCRIPTION
## 📌 개요 (Overview)
 유저의 활동 내역, 통계, 및 보유 자산(엽서)을 한눈에 확인할 수 있는 마이페이지(mypage) 도메인 API를 구현했습니다.

## 🛠️ 작업 내용 (Changes)
   - 마이페이지 활동 통계 API 구현: 작성 게시물, 댓글, 보유 엽서 수 통합 조회
   - 나의 작성 목록 조회 API 구현: 게시물(카테고리 필터 포함), 댓글, 임시저장글 목록 페이징 조회
   - 내 글의 반응(댓글) 조회 API 구현: 내가 작성한 게시물에 달린 최신 댓글 모아보기
   - 상호작용 목록 조회 API 구현: 내가 해금한 둥지, 좋아요를 누른 둥지 목록 조회
   - 보유 엽서 인벤토리 조회 API 연동: 내가 만든 엽서 및 교환받은 엽서 목록 조회
   - 단위 테스트 구현: MyPageController 및 MyPageService에 대한 테스트 케이스 작성 및 검증 완료


``` 
 ---

  공통 규격
   - Base URL: /api/v1/mypage
   - 인증 헤더: Authorization: Bearer {JWT}
   - 목록 응답: data.content에 리스트가 포함되며, Page 객체의 페이징 정보가 포함됩니다.

  ---

  1. 활동 통계 조회
   - Method & Path: GET /statistics
   - Response Data:
       - nestCount (long): 내가 작성한 둥지 총 개수
       - commentCount (long): 내가 작성한 댓글 총 개수
       - postcardCount (long): 내가 보유한 엽서 총 개수

  ---

  2. 나의 작성 둥지 목록 조회
   - Method & Path: GET /nests
   - Query Params: categoryId (Long, 선택)
   - Response Data (리스트 개별 요소):
       - id (Long): 둥지 고유 ID
       - title (String): 둥지 제목
       - content (String): 둥지 본문 내용
       - thumbnailUrl (String): 대표 이미지 URL (없으면 null)
       - isUnlocked (boolean): 해금 여부 (본인 글이므로 항상 true)
       - createdAt (LocalDateTime): 작성 일시
       - updatedAt (LocalDateTime): 수정 일시

  ---

  3. 나의 작성 댓글 목록 조회
   - Method & Path: GET /comments
   - Response Data (리스트 개별 요소):
       - id (Long): 댓글 고유 ID
       - nestId (Long): 댓글이 작성된 둥지 ID
       - nestTitle (String): 댓글이 작성된 둥지 제목
       - content (String): 댓글 본문 내용
       - authorNickname (String): 작성자 닉네임 (본인)
       - createdAt (LocalDateTime): 작성 일시

  ---

  4. 나의 임시저장글 목록 조회
   - Method & Path: GET /drafts
   - Response Data (리스트 개별 요소):
       - id (Long): 임시저장 데이터 고유 ID
       - title (String): 임시저장된 제목
       - content (String): 임시저장된 내용
       - createdAt (LocalDateTime): 최초 생성 일시
       - updatedAt (LocalDateTime): 최종 수정 일시

  ---

  5. 해금한 둥지 목록 조회
   - Method & Path: GET /unlocks
   - Response Data (리스트 개별 요소):
       - id (Long): 둥지 고유 ID
       - title (String): 둥지 제목
       - content (String): 둥지 본문 내용
       - thumbnailUrl (String): 대표 이미지 URL
       - isUnlocked (boolean): 해금 여부 (항상 true)
       - createdAt (LocalDateTime): 작성 일시
       - updatedAt (LocalDateTime): 수정 일시

  ---

  6. 내 게시글의 반응(댓글) 조회
   - Method & Path: GET /reactions
   - Response Data (리스트 개별 요소):
       - id (Long): 댓글 고유 ID
       - nestId (Long): 내 둥지 ID
       - nestTitle (String): 내 둥지 제목
       - content (String): 타인이 남긴 댓글 내용
       - authorNickname (String): 댓글 작성자(타인) 닉네임
       - createdAt (LocalDateTime): 댓글 작성 일시

  ---

  7. 좋아요 누른 둥지 목록 조회
   - Method & Path: GET /likes
   - Response Data (리스트 개별 요소):
       - id (Long): 둥지 고유 ID
       - title (String): 둥지 제목
       - content (String): 둥지 본문 내용
       - thumbnailUrl (String): 대표 이미지 URL
       - isUnlocked (boolean): 해금 여부
       - createdAt (LocalDateTime): 작성 일시
       - updatedAt (LocalDateTime): 수정 일시

  ---

  8. 보유 엽서 인벤토리 조회
   - Method & Path: GET /postcards
   - Query Params: filter (String, 선택 - ALL, CREATED, ACQUIRED)
   - Response Data (리스트 개별 요소):
       - id (Long): 엽서 고유 ID
       - imageUrl (String): 엽서 이미지 URL
       - content (String): 엽서 메시지 내용
       - authorNickname (String): 엽서 원작자 닉네임
       - isMine (boolean): 내가 원작자인지 여부
       - createdAt (LocalDateTime): 엽서 생성 또는 획득 일시
       - reactionType: 엽서에 있는 반응 조회 
```


## 🔗 관련 이슈 (Related Issues)
- close #43 





