### PR TITLE
Feat/47/admin category management: 관리자 카테고리 관리 기능 

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/controller/AdminCategoryController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/controller/AdminCategoryController.java
@@ -1,0 +1,54 @@
+package com.dodo.dodoserver.domain.admin.category.controller;
+
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryRequestDto;
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryResponseDto;
+import com.dodo.dodoserver.domain.admin.category.dto.CategoryOrderUpdateRequestDto;
+import com.dodo.dodoserver.domain.admin.category.service.AdminCategoryService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/categories")
+@RequiredArgsConstructor
+public class AdminCategoryController {
+
+    private final AdminCategoryService adminCategoryService;
+
+    @GetMapping
+    public ApiResponseDto<List<AdminCategoryResponseDto>> getCategories(
+            @RequestParam(defaultValue = "true") boolean includeDeleted,
+            @RequestParam(required = false) String sortBy) {
+        return ApiResponseDto.success(adminCategoryService.getCategories(includeDeleted, sortBy));
+    }
+
+    @PostMapping
+    public ApiResponseDto<AdminCategoryResponseDto> createCategory(
+            @RequestBody @Valid AdminCategoryRequestDto requestDto) {
+        return ApiResponseDto.success(adminCategoryService.createCategory(requestDto));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponseDto<Void> updateCategory(
+            @PathVariable Long id,
+            @RequestBody @Valid AdminCategoryRequestDto requestDto) {
+        adminCategoryService.updateCategory(id, requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    @PutMapping("/orders")
+    public ApiResponseDto<Void> updateCategoryOrders(
+            @RequestBody @Valid CategoryOrderUpdateRequestDto requestDto) {
+        adminCategoryService.updateCategoryOrders(requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponseDto<Void> deleteCategory(@PathVariable Long id) {
+        adminCategoryService.deleteCategory(id);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepository.java
@@ -1,0 +1,9 @@
+package com.dodo.dodoserver.domain.admin.category.dao;
+
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryResponseDto;
+
+import java.util.List;
+
+public interface CategoryAdminRepository {
+    List<AdminCategoryResponseDto> findAllAdminCategories(boolean includeDeleted, String sortBy);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepositoryImpl.java
@@ -24,7 +24,7 @@ public class CategoryAdminRepositoryImpl implements CategoryAdminRepository {
 
     @Override
     public List<AdminCategoryResponseDto> findAllAdminCategories(boolean includeDeleted, String sortBy) {
-        NumberExpression<Long> nestCount = Expressions.asNumber(
+        NumberExpression<Long> nestCount = Expressions.numberTemplate(Long.class, "({0})",
                 JPAExpressions.select(nestCategory.count())
                         .from(nestCategory)
                         .join(nestCategory.nest, nest)
@@ -33,13 +33,13 @@ public class CategoryAdminRepositoryImpl implements CategoryAdminRepository {
         ).coalesce(0L);
 
         JPAQuery<AdminCategoryResponseDto> query = queryFactory
-                .select(Projections.fields(AdminCategoryResponseDto.class,
+                .select(Projections.constructor(AdminCategoryResponseDto.class,
                         category.id,
                         category.name,
                         category.sortOrder,
                         category.createdAt,
                         category.deletedAt,
-                        nestCount.as("nestCount")
+                        nestCount
                 ))
                 .from(category);
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.dodo.dodoserver.domain.admin.category.dao;
+
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.dodo.dodoserver.domain.category.entity.QCategory.category;
+import static com.dodo.dodoserver.domain.nest.entity.QNest.nest;
+import static com.dodo.dodoserver.domain.nest.entity.QNestCategory.nestCategory;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryAdminRepositoryImpl implements CategoryAdminRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AdminCategoryResponseDto> findAllAdminCategories(boolean includeDeleted, String sortBy) {
+        NumberExpression<Long> nestCount = Expressions.asNumber(
+                JPAExpressions.select(nestCategory.count())
+                        .from(nestCategory)
+                        .join(nestCategory.nest, nest)
+                        .where(nestCategory.category.id.eq(category.id)
+                                .and(nest.deletedAt.isNull()))
+        ).coalesce(0L);
+
+        JPAQuery<AdminCategoryResponseDto> query = queryFactory
+                .select(Projections.constructor(AdminCategoryResponseDto.class,
+                        category.id,
+                        category.name,
+                        category.sortOrder,
+                        category.createdAt,
+                        category.deletedAt,
+                        nestCount
+                ))
+                .from(category);
+
+        if (!includeDeleted) {
+            query.where(category.deletedAt.isNull());
+        }
+
+        if ("nestCount".equals(sortBy)) {
+            query.orderBy(nestCount.desc(), category.sortOrder.asc());
+        } else {
+            query.orderBy(category.sortOrder.asc(), category.createdAt.desc());
+        }
+
+        return query.fetch();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/dao/CategoryAdminRepositoryImpl.java
@@ -33,13 +33,13 @@ public class CategoryAdminRepositoryImpl implements CategoryAdminRepository {
         ).coalesce(0L);
 
         JPAQuery<AdminCategoryResponseDto> query = queryFactory
-                .select(Projections.constructor(AdminCategoryResponseDto.class,
+                .select(Projections.fields(AdminCategoryResponseDto.class,
                         category.id,
                         category.name,
                         category.sortOrder,
                         category.createdAt,
                         category.deletedAt,
-                        nestCount
+                        nestCount.as("nestCount")
                 ))
                 .from(category);
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/dto/AdminCategoryRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/dto/AdminCategoryRequestDto.java
@@ -1,0 +1,15 @@
+package com.dodo.dodoserver.domain.admin.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AdminCategoryRequestDto {
+
+    @NotBlank(message = "카테고리 이름은 필수입니다.")
+    @Size(max = 50, message = "카테고리 이름은 50자 이내여야 합니다.")
+    private String name;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/dto/AdminCategoryResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/dto/AdminCategoryResponseDto.java
@@ -1,0 +1,18 @@
+package com.dodo.dodoserver.domain.admin.category.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminCategoryResponseDto {
+    private Long id;
+    private String name;
+    private Integer sortOrder;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+    private Long nestCount;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/dto/CategoryOrderUpdateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/dto/CategoryOrderUpdateRequestDto.java
@@ -1,0 +1,29 @@
+package com.dodo.dodoserver.domain.admin.category.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CategoryOrderUpdateRequestDto {
+
+    @NotEmpty(message = "순서 변경 정보는 필수입니다.")
+    @Valid
+    private List<CategoryOrderDto> orders;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class CategoryOrderDto {
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        private Long id;
+
+        @NotNull(message = "순서는 필수입니다.")
+        private Integer sortOrder;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
@@ -35,7 +35,6 @@ public class AdminCategoryService {
             throw new BusinessException(ErrorCode.DUPLICATE_CATEGORY_NAME);
         }
 
-        // 가장 마지막 순서 찾기 (최적화: DB에서 직접 MAX 조회)
         Integer maxSortOrder = categoryRepository.findMaxSortOrder().orElse(-1);
 
         Category category = Category.builder()
@@ -45,7 +44,6 @@ public class AdminCategoryService {
 
         Category savedCategory = categoryRepository.save(category);
         
-        // 새로 생성된 카테고리 정보 반환 (nestCount는 0)
         return AdminCategoryResponseDto.builder()
                 .id(savedCategory.getId())
                 .name(savedCategory.getName())

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
@@ -1,0 +1,106 @@
+package com.dodo.dodoserver.domain.admin.category.service;
+
+import com.dodo.dodoserver.domain.admin.category.dao.CategoryAdminRepository;
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryRequestDto;
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryResponseDto;
+import com.dodo.dodoserver.domain.admin.category.dto.CategoryOrderUpdateRequestDto;
+import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
+import com.dodo.dodoserver.domain.category.entity.Category;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminCategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryAdminRepository categoryAdminRepository;
+
+    @Transactional(readOnly = true)
+    public List<AdminCategoryResponseDto> getCategories(boolean includeDeleted, String sortBy) {
+        return categoryAdminRepository.findAllAdminCategories(includeDeleted, sortBy);
+    }
+
+    @Transactional
+    public AdminCategoryResponseDto createCategory(AdminCategoryRequestDto requestDto) {
+        if (categoryRepository.findByName(requestDto.getName()).isPresent()) {
+            throw new BusinessException(ErrorCode.DUPLICATE_CATEGORY_NAME);
+        }
+
+        // 가장 마지막 순서 찾기
+        Integer maxSortOrder = categoryRepository.findAll().stream()
+                .map(Category::getSortOrder)
+                .max(Integer::compareTo)
+                .orElse(-1);
+
+        Category category = Category.builder()
+                .name(requestDto.getName())
+                .sortOrder(maxSortOrder + 1)
+                .build();
+
+        categoryRepository.save(category);
+        
+        // 새로 생성된 카테고리 정보 반환 (nestCount는 0)
+        return AdminCategoryResponseDto.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .sortOrder(category.getSortOrder())
+                .createdAt(category.getCreatedAt())
+                .deletedAt(category.getDeletedAt())
+                .nestCount(0L)
+                .build();
+    }
+
+    @Transactional
+    public void updateCategory(Long id, AdminCategoryRequestDto requestDto) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        categoryRepository.findByName(requestDto.getName())
+                .ifPresent(existing -> {
+                    if (!existing.getId().equals(id)) {
+                        throw new BusinessException(ErrorCode.DUPLICATE_CATEGORY_NAME);
+                    }
+                });
+
+        category.setName(requestDto.getName());
+    }
+
+    @Transactional
+    public void updateCategoryOrders(CategoryOrderUpdateRequestDto requestDto) {
+        List<Long> categoryIds = requestDto.getOrders().stream()
+                .map(CategoryOrderUpdateRequestDto.CategoryOrderDto::getId)
+                .collect(Collectors.toList());
+
+        List<Category> categories = categoryRepository.findAllById(categoryIds);
+        Map<Long, Category> categoryMap = categories.stream()
+                .collect(Collectors.toMap(Category::getId, c -> c));
+
+        requestDto.getOrders().forEach(orderDto -> {
+            Category category = categoryMap.get(orderDto.getId());
+            if (category != null) {
+                category.setSortOrder(orderDto.getSortOrder());
+            }
+        });
+    }
+
+    @Transactional
+    public void deleteCategory(Long id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        if (category.getDeletedAt() != null) {
+            throw new BusinessException(ErrorCode.ALREADY_DELETED_CATEGORY);
+        }
+
+        category.setDeletedAt(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryService.java
@@ -35,26 +35,23 @@ public class AdminCategoryService {
             throw new BusinessException(ErrorCode.DUPLICATE_CATEGORY_NAME);
         }
 
-        // 가장 마지막 순서 찾기
-        Integer maxSortOrder = categoryRepository.findAll().stream()
-                .map(Category::getSortOrder)
-                .max(Integer::compareTo)
-                .orElse(-1);
+        // 가장 마지막 순서 찾기 (최적화: DB에서 직접 MAX 조회)
+        Integer maxSortOrder = categoryRepository.findMaxSortOrder().orElse(-1);
 
         Category category = Category.builder()
                 .name(requestDto.getName())
                 .sortOrder(maxSortOrder + 1)
                 .build();
 
-        categoryRepository.save(category);
+        Category savedCategory = categoryRepository.save(category);
         
         // 새로 생성된 카테고리 정보 반환 (nestCount는 0)
         return AdminCategoryResponseDto.builder()
-                .id(category.getId())
-                .name(category.getName())
-                .sortOrder(category.getSortOrder())
-                .createdAt(category.getCreatedAt())
-                .deletedAt(category.getDeletedAt())
+                .id(savedCategory.getId())
+                .name(savedCategory.getName())
+                .sortOrder(savedCategory.getSortOrder())
+                .createdAt(savedCategory.getCreatedAt())
+                .deletedAt(savedCategory.getDeletedAt())
                 .nestCount(0L)
                 .build();
     }
@@ -81,14 +78,17 @@ public class AdminCategoryService {
                 .collect(Collectors.toList());
 
         List<Category> categories = categoryRepository.findAllById(categoryIds);
+        
+        if (categories.size() != categoryIds.size()) {
+            throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+
         Map<Long, Category> categoryMap = categories.stream()
                 .collect(Collectors.toMap(Category::getId, c -> c));
 
         requestDto.getOrders().forEach(orderDto -> {
             Category category = categoryMap.get(orderDto.getId());
-            if (category != null) {
-                category.setSortOrder(orderDto.getSortOrder());
-            }
+            category.setSortOrder(orderDto.getSortOrder());
         });
     }
 
@@ -101,6 +101,6 @@ public class AdminCategoryService {
             throw new BusinessException(ErrorCode.ALREADY_DELETED_CATEGORY);
         }
 
-        category.setDeletedAt(LocalDateTime.now());
+        categoryRepository.delete(category);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/category/controller/CategoryController.java
@@ -1,11 +1,9 @@
 package com.dodo.dodoserver.domain.category.controller;
 
 import com.dodo.dodoserver.domain.category.service.CategoryService;
-import com.dodo.dodoserver.domain.category.dto.CategoryRequestDto;
 import com.dodo.dodoserver.domain.category.dto.CategoryResponseDto;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,26 +16,8 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    @PostMapping // admin
-    public ApiResponseDto<CategoryResponseDto> createCategory(@RequestBody @Valid CategoryRequestDto requestDto) {
-        return ApiResponseDto.success(categoryService.createCategory(requestDto));
-    }
-
     @GetMapping
     public ApiResponseDto<List<CategoryResponseDto>> getAllCategories() {
         return ApiResponseDto.success(categoryService.getAllCategories());
-    }
-
-    @PatchMapping("/{id}") // admin
-    public ApiResponseDto<CategoryResponseDto> updateCategory(
-            @PathVariable Long id,
-            @RequestBody @Valid CategoryRequestDto requestDto) {
-        return ApiResponseDto.success(categoryService.updateCategory(id, requestDto));
-    }
-
-    @DeleteMapping("/{id}") // admin
-    public ApiResponseDto<String> deleteCategory(@PathVariable Long id) {
-        categoryService.deleteCategory(id);
-        return ApiResponseDto.success("카테고리가 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/category/dao/CategoryRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/category/dao/CategoryRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByName(String name);
+    List<Category> findAllByDeletedAtIsNullOrderBySortOrderAsc();
 }

--- a/src/main/java/com/dodo/dodoserver/domain/category/dao/CategoryRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/category/dao/CategoryRepository.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.category.dao;
 
 import com.dodo.dodoserver.domain.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +12,7 @@ import java.util.List;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByName(String name);
     List<Category> findAllByDeletedAtIsNullOrderBySortOrderAsc();
+
+    @Query("SELECT MAX(c.sortOrder) FROM Category c")
+    Optional<Integer> findMaxSortOrder();
 }

--- a/src/main/java/com/dodo/dodoserver/domain/category/entity/Category.java
+++ b/src/main/java/com/dodo/dodoserver/domain/category/entity/Category.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.category.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 @Builder
 @Table(name = "categories")
 @EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE categories SET deleted_at = NOW() WHERE id = ?")
 public class Category {
 
     @Id

--- a/src/main/java/com/dodo/dodoserver/domain/category/entity/Category.java
+++ b/src/main/java/com/dodo/dodoserver/domain/category/entity/Category.java
@@ -25,7 +25,14 @@ public class Category {
     @Column(nullable = false, unique = true, length = 50)
     private String name;
 
+    @Builder.Default
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder = 0;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/category/service/CategoryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/category/service/CategoryService.java
@@ -1,12 +1,7 @@
 package com.dodo.dodoserver.domain.category.service;
 
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
-import com.dodo.dodoserver.domain.category.dto.CategoryRequestDto;
 import com.dodo.dodoserver.domain.category.dto.CategoryResponseDto;
-import com.dodo.dodoserver.domain.category.entity.Category;
-import com.dodo.dodoserver.error.ErrorCode;
-import com.dodo.dodoserver.error.exception.BusinessException;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,44 +15,10 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
-    @Transactional
-    public CategoryResponseDto createCategory(CategoryRequestDto requestDto) {
-        if (categoryRepository.findByName(requestDto.getName()).isPresent()) {
-            throw new BusinessException(ErrorCode.DUPLICATE_CATEGORY_NAME);
-        }
-
-        Category category = Category.builder()
-                .name(requestDto.getName())
-                .build();
-
-        return CategoryResponseDto.from(categoryRepository.save(category));
-    }
-
     @Transactional(readOnly = true)
     public List<CategoryResponseDto> getAllCategories() {
-        return categoryRepository.findAll().stream()
+        return categoryRepository.findAllByDeletedAtIsNullOrderBySortOrderAsc().stream()
                 .map(CategoryResponseDto::from)
                 .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public CategoryResponseDto updateCategory(Long id, CategoryRequestDto requestDto) {
-        Category category = categoryRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
-
-        if (categoryRepository.findByName(requestDto.getName()).isPresent()) {
-            throw new BusinessException(ErrorCode.DUPLICATE_CATEGORY_NAME);
-        }
-
-        category.setName(requestDto.getName());
-        return CategoryResponseDto.from(category);
-    }
-
-    @Transactional
-    public void deleteCategory(Long id) {
-        Category category = categoryRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
-        
-        categoryRepository.delete(category);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -111,6 +111,10 @@ public class NestService {
             requestDto.getCategoryIds().forEach(categoryId -> {
                 Category category = categoryRepository.findById(categoryId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+                if (category.getDeletedAt() != null) {
+                    throw new BusinessException(ErrorCode.ALREADY_DELETED_CATEGORY);
+                }
                 
                 NestCategory nestCategory = NestCategory.builder()
                         .nest(savedNest)
@@ -167,6 +171,10 @@ public class NestService {
             requestDto.getCategoryIds().forEach(categoryId -> {
                 Category category = categoryRepository.findById(categoryId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+                if (category.getDeletedAt() != null) {
+                    throw new BusinessException(ErrorCode.ALREADY_DELETED_CATEGORY);
+                }
                 
                 NestCategory nestCategory = NestCategory.builder()
                         .nest(nest)

--- a/src/main/java/com/dodo/dodoserver/domain/user/service/UserInterestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/service/UserInterestService.java
@@ -61,6 +61,11 @@ public class UserInterestService {
                 .map(categoryId -> {
                     Category category = categoryRepository.findById(categoryId)
                             .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+                    if (category.getDeletedAt() != null) {
+                        throw new BusinessException(ErrorCode.ALREADY_DELETED_CATEGORY);
+                    }
+
                     return UserInterest.builder()
                             .user(user)
                             .category(category)

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     // Category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CA001", "카테고리를 찾을 수 없습니다."),
     DUPLICATE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "CA002", "이미 존재하는 카테고리 이름입니다."),
+    ALREADY_DELETED_CATEGORY(HttpStatus.BAD_REQUEST, "CA003", "이미 삭제된 카테고리입니다."),
 
     // Nest (N)
     NEST_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "둥지를 찾을 수 없습니다."),

--- a/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
@@ -60,9 +60,6 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(WHITE_LIST).permitAll()
 				.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-				.requestMatchers(org.springframework.http.HttpMethod.POST, "/api/v1/categories/**").hasRole("ADMIN")
-				.requestMatchers(org.springframework.http.HttpMethod.PATCH, "/api/v1/categories/**").hasRole("ADMIN")
-				.requestMatchers(org.springframework.http.HttpMethod.DELETE, "/api/v1/categories/**").hasRole("ADMIN")
 				.anyRequest().authenticated()
 			)
 

--- a/src/test/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryServiceTest.java
@@ -57,15 +57,23 @@ class AdminCategoryServiceTest {
     void createCategory_success() {
         // given
         AdminCategoryRequestDto requestDto = new AdminCategoryRequestDto("운동");
+        Category category = Category.builder()
+                .id(1L)
+                .name("운동")
+                .sortOrder(1)
+                .build();
+        
         given(categoryRepository.findByName("운동")).willReturn(Optional.empty());
-        given(categoryRepository.findAll()).willReturn(List.of());
+        given(categoryRepository.findMaxSortOrder()).willReturn(Optional.of(0));
+        given(categoryRepository.save(any(Category.class))).willReturn(category);
 
         // when
         AdminCategoryResponseDto result = adminCategoryService.createCategory(requestDto);
 
         // then
         assertThat(result.getName()).isEqualTo("운동");
-        assertThat(result.getSortOrder()).isEqualTo(0);
+        assertThat(result.getSortOrder()).isEqualTo(1);
+        assertThat(result.getId()).isEqualTo(1L);
         verify(categoryRepository, times(1)).save(any(Category.class));
     }
 
@@ -102,7 +110,7 @@ class AdminCategoryServiceTest {
         adminCategoryService.deleteCategory(categoryId);
 
         // then
-        assertThat(category.getDeletedAt()).isNotNull();
+        verify(categoryRepository, times(1)).delete(category);
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/category/service/AdminCategoryServiceTest.java
@@ -1,0 +1,122 @@
+package com.dodo.dodoserver.domain.admin.category.service;
+
+import com.dodo.dodoserver.domain.admin.category.dao.CategoryAdminRepository;
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryRequestDto;
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryResponseDto;
+import com.dodo.dodoserver.domain.admin.category.dto.CategoryOrderUpdateRequestDto;
+import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
+import com.dodo.dodoserver.domain.category.entity.Category;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminCategoryServiceTest {
+
+    @InjectMocks
+    private AdminCategoryService adminCategoryService;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private CategoryAdminRepository categoryAdminRepository;
+
+    @Test
+    @DisplayName("관리자용 카테고리 목록 조회 성공")
+    void getCategories_success() {
+        // given
+        AdminCategoryResponseDto dto = AdminCategoryResponseDto.builder()
+                .id(1L).name("운동").sortOrder(0).nestCount(5L).build();
+        given(categoryAdminRepository.findAllAdminCategories(true, "nestCount")).willReturn(List.of(dto));
+
+        // when
+        List<AdminCategoryResponseDto> result = adminCategoryService.getCategories(true, "nestCount");
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("운동");
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 성공")
+    void createCategory_success() {
+        // given
+        AdminCategoryRequestDto requestDto = new AdminCategoryRequestDto("운동");
+        given(categoryRepository.findByName("운동")).willReturn(Optional.empty());
+        given(categoryRepository.findAll()).willReturn(List.of());
+
+        // when
+        AdminCategoryResponseDto result = adminCategoryService.createCategory(requestDto);
+
+        // then
+        assertThat(result.getName()).isEqualTo("운동");
+        assertThat(result.getSortOrder()).isEqualTo(0);
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("카테고리 순서 변경 성공")
+    void updateCategoryOrders_success() {
+        // given
+        Category cat1 = Category.builder().id(1L).sortOrder(0).build();
+        Category cat2 = Category.builder().id(2L).sortOrder(1).build();
+        CategoryOrderUpdateRequestDto requestDto = new CategoryOrderUpdateRequestDto(List.of(
+                new CategoryOrderUpdateRequestDto.CategoryOrderDto(1L, 1),
+                new CategoryOrderUpdateRequestDto.CategoryOrderDto(2L, 0)
+        ));
+
+        given(categoryRepository.findAllById(any())).willReturn(List.of(cat1, cat2));
+
+        // when
+        adminCategoryService.updateCategoryOrders(requestDto);
+
+        // then
+        assertThat(cat1.getSortOrder()).isEqualTo(1);
+        assertThat(cat2.getSortOrder()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제(Soft Delete) 성공")
+    void deleteCategory_success() {
+        // given
+        Long categoryId = 1L;
+        Category category = Category.builder().id(categoryId).name("운동").build();
+        given(categoryRepository.findById(categoryId)).willReturn(Optional.of(category));
+
+        // when
+        adminCategoryService.deleteCategory(categoryId);
+
+        // then
+        assertThat(category.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 카테고리 삭제 시도 시 예외 발생")
+    void deleteCategory_fail_alreadyDeleted() {
+        // given
+        Long categoryId = 1L;
+        Category category = Category.builder().id(categoryId).name("운동")
+                .deletedAt(java.time.LocalDateTime.now()).build();
+        given(categoryRepository.findById(categoryId)).willReturn(Optional.of(category));
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.deleteCategory(categoryId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ALREADY_DELETED_CATEGORY.getMessage());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/category/controller/CategoryControllerTest.java
@@ -1,13 +1,11 @@
 package com.dodo.dodoserver.domain.category.controller;
 
-import com.dodo.dodoserver.domain.category.dto.CategoryRequestDto;
 import com.dodo.dodoserver.domain.category.dto.CategoryResponseDto;
 import com.dodo.dodoserver.domain.category.service.CategoryService;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
 import com.dodo.dodoserver.global.security.JwtTokenProvider;
 import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.http.MediaType;
 import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,9 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -45,9 +40,6 @@ class CategoryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockitoBean
     private CategoryService categoryService;
@@ -72,51 +64,12 @@ class CategoryControllerTest {
     @BeforeEach
     void setUp() throws ServletException, IOException {
         doAnswer(invocation -> {
-            // 메서드 호출 시 전달된 인자 추출 (0: Request, 1: Response, 2: FilterChain)
             HttpServletRequest request = invocation.getArgument(0);
             HttpServletResponse response = invocation.getArgument(1);
             FilterChain filterChain = invocation.getArgument(2);
-
-            // 가짜 필터 로직 대신 다음 필터 체인으로 요청을 강제 전달
             filterChain.doFilter(request, response);
             return null;
         }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
-    }
-
-    @Test
-    @DisplayName("카테고리 생성 성공 - ADMIN 권한 필요")
-    @WithMockUserPrincipal(role = "ROLE_ADMIN")
-    void createCategory_success() throws Exception {
-        // given
-        CategoryRequestDto requestDto = new CategoryRequestDto("운동");
-        CategoryResponseDto responseDto = new CategoryResponseDto(1L, "운동", LocalDateTime.now());
-
-        given(categoryService.createCategory(any(CategoryRequestDto.class))).willReturn(responseDto);
-
-        // when & then
-        mockMvc.perform(post("/api/v1/categories")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.data.name").value("운동"));
-    }
-
-    @Test
-    @DisplayName("카테고리 생성 실패 - 권한 없음(USER)")
-    @WithMockUserPrincipal(role = "ROLE_USER")
-    void createCategory_fail_forbidden() throws Exception {
-        // given
-        CategoryRequestDto requestDto = new CategoryRequestDto("운동");
-
-        // when & then
-        mockMvc.perform(post("/api/v1/categories")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -135,84 +88,5 @@ class CategoryControllerTest {
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[0].name").value("운동"))
                 .andExpect(jsonPath("$.data[1].name").value("공부"));
-    }
-
-    @Test
-    @DisplayName("카테고리 수정 성공 - ADMIN 권한")
-    @WithMockUserPrincipal(role = "ROLE_ADMIN")
-    void updateCategory_success() throws Exception {
-        // given
-        Long categoryId = 1L;
-        CategoryRequestDto requestDto = new CategoryRequestDto("독서");
-        CategoryResponseDto responseDto = new CategoryResponseDto(categoryId, "독서", LocalDateTime.now());
-
-        given(categoryService.updateCategory(eq(categoryId), any(CategoryRequestDto.class))).willReturn(responseDto);
-
-        // when & then
-        mockMvc.perform(patch("/api/v1/categories/{id}", categoryId)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.name").value("독서"));
-    }
-
-    @Test
-    @DisplayName("카테고리 삭제 성공 - ADMIN 권한")
-    @WithMockUserPrincipal(role = "ROLE_ADMIN")
-    void deleteCategory_success() throws Exception {
-        // given
-        Long categoryId = 1L;
-
-        // when & then
-        mockMvc.perform(delete("/api/v1/categories/{id}", categoryId)
-                        .with(csrf()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").value("카테고리가 성공적으로 삭제되었습니다."));
-    }
-
-    @Test
-    @DisplayName("카테고리 생성 실패 - 유효성 검증 오류 (이름 누락)")
-    @WithMockUserPrincipal(role = "ROLE_ADMIN")
-    void createCategory_fail_invalidInput() throws Exception {
-        // given
-        CategoryRequestDto requestDto = new CategoryRequestDto("");
-
-        // when & then
-        mockMvc.perform(post("/api/v1/categories")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("G005"));
-    }
-
-    @Test
-    @DisplayName("카테고리 수정 실패 - 권한 없음(USER)")
-    @WithMockUserPrincipal(role = "ROLE_USER")
-    void updateCategory_fail_forbidden() throws Exception {
-        // given
-        Long categoryId = 1L;
-        CategoryRequestDto requestDto = new CategoryRequestDto("독서");
-
-        // when & then
-        mockMvc.perform(patch("/api/v1/categories/{id}", categoryId)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isForbidden());
-    }
-
-    @Test
-    @DisplayName("카테고리 삭제 실패 - 권한 없음(USER)")
-    @WithMockUserPrincipal(role = "ROLE_USER")
-    void deleteCategory_fail_forbidden() throws Exception {
-        // given
-        Long categoryId = 1L;
-
-        // when & then
-        mockMvc.perform(delete("/api/v1/categories/{id}", categoryId)
-                        .with(csrf()))
-                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/category/service/CategoryServiceTest.java
@@ -1,11 +1,8 @@
 package com.dodo.dodoserver.domain.category.service;
 
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
-import com.dodo.dodoserver.domain.category.dto.CategoryRequestDto;
 import com.dodo.dodoserver.domain.category.dto.CategoryResponseDto;
 import com.dodo.dodoserver.domain.category.entity.Category;
-import com.dodo.dodoserver.error.ErrorCode;
-import com.dodo.dodoserver.error.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,15 +10,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CategoryServiceTest {
@@ -33,49 +25,12 @@ class CategoryServiceTest {
     private CategoryRepository categoryRepository;
 
     @Test
-    @DisplayName("카테고리 생성 성공")
-    void createCategory_success() {
-        // given
-        CategoryRequestDto requestDto = new CategoryRequestDto("운동");
-        Category category = Category.builder()
-                .id(1L)
-                .name("운동")
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        given(categoryRepository.findByName("운동")).willReturn(Optional.empty());
-        given(categoryRepository.save(any(Category.class))).willReturn(category);
-
-        // when
-        CategoryResponseDto responseDto = categoryService.createCategory(requestDto);
-
-        // then
-        assertThat(responseDto.getName()).isEqualTo("운동");
-        assertThat(responseDto.getId()).isEqualTo(1L);
-        verify(categoryRepository, times(1)).save(any(Category.class));
-    }
-
-    @Test
-    @DisplayName("카테고리 생성 실패 - 중복된 이름")
-    void createCategory_fail_duplicateName() {
-        // given
-        CategoryRequestDto requestDto = new CategoryRequestDto("운동");
-        Category existingCategory = Category.builder().name("운동").build();
-        given(categoryRepository.findByName("운동")).willReturn(Optional.of(existingCategory));
-
-        // when & then
-        assertThatThrownBy(() -> categoryService.createCategory(requestDto))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.DUPLICATE_CATEGORY_NAME.getMessage());
-    }
-
-    @Test
     @DisplayName("전체 카테고리 조회 성공")
     void getAllCategories_success() {
         // given
-        Category cat1 = Category.builder().id(1L).name("운동").build();
-        Category cat2 = Category.builder().id(2L).name("공부").build();
-        given(categoryRepository.findAll()).willReturn(List.of(cat1, cat2));
+        Category cat1 = Category.builder().id(1L).name("운동").sortOrder(1).build();
+        Category cat2 = Category.builder().id(2L).name("공부").sortOrder(2).build();
+        given(categoryRepository.findAllByDeletedAtIsNullOrderBySortOrderAsc()).willReturn(List.of(cat1, cat2));
 
         // when
         List<CategoryResponseDto> categories = categoryService.getAllCategories();
@@ -84,68 +39,5 @@ class CategoryServiceTest {
         assertThat(categories).hasSize(2);
         assertThat(categories.get(0).getName()).isEqualTo("운동");
         assertThat(categories.get(1).getName()).isEqualTo("공부");
-    }
-
-    @Test
-    @DisplayName("카테고리 수정 성공")
-    void updateCategory_success() {
-        // given
-        Long categoryId = 1L;
-        CategoryRequestDto requestDto = new CategoryRequestDto("독서");
-        Category category = Category.builder().id(categoryId).name("운동").build();
-
-        given(categoryRepository.findById(categoryId)).willReturn(Optional.of(category));
-        given(categoryRepository.findByName("독서")).willReturn(Optional.empty());
-
-        // when
-        CategoryResponseDto responseDto = categoryService.updateCategory(categoryId, requestDto);
-
-        // then
-        assertThat(responseDto.getName()).isEqualTo("독서");
-    }
-
-    @Test
-    @DisplayName("카테고리 수정 실패 - 존재하지 않는 카테고리")
-    void updateCategory_fail_notFound() {
-        // given
-        Long categoryId = 99L;
-        CategoryRequestDto requestDto = new CategoryRequestDto("독서");
-        given(categoryRepository.findById(categoryId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> categoryService.updateCategory(categoryId, requestDto))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.CATEGORY_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("카테고리 수정 실패 - 중복된 이름")
-    void updateCategory_fail_duplicateName() {
-        // given
-        Long categoryId = 1L;
-        CategoryRequestDto requestDto = new CategoryRequestDto("중복이름");
-        Category category = Category.builder().id(categoryId).name("기존이름").build();
-        Category existingCategory = Category.builder().id(2L).name("중복이름").build();
-
-        given(categoryRepository.findById(categoryId)).willReturn(Optional.of(category));
-        given(categoryRepository.findByName("중복이름")).willReturn(Optional.of(existingCategory));
-
-        // when & then
-        assertThatThrownBy(() -> categoryService.updateCategory(categoryId, requestDto))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.DUPLICATE_CATEGORY_NAME.getMessage());
-    }
-
-    @Test
-    @DisplayName("카테고리 삭제 실패 - 존재하지 않는 카테고리")
-    void deleteCategory_fail_notFound() {
-        // given
-        Long categoryId = 99L;
-        given(categoryRepository.findById(categoryId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> categoryService.deleteCategory(categoryId))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.CATEGORY_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## 📌 개요 (Overview)
  관리자가 서비스의 카테고리를 효율적으로 관리할 수 있도록 관리자 전용 카테고리 관리 시스템을 구축하고, 기존 카테고리 도메인의 책임을 분리하였습니다. 카테고리 노출 순서 제어와 Soft Delete 기능을 통해 서비스 운영의 유연성을 높였습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
  1. 엔티티 확장 및 인프라 구축
   - [x] Category 엔티티 필드 추가: sort_order (노출 순서), deleted_at (논리 삭제 일시)
   - [x] CategoryAdminRepository (Querydsl) 구현: 카테고리별 활성 둥지 개수 집계 및 동적 정렬 쿼리 작성

  2. 관리자 전용 API 구현 (/api/v1/admin/categories)
   - [x] 목록 조회: 통계(둥지 수) 포함 및 삭제 항목 필터링 기능
   - [x] 일괄 순서 변경: PUT 메서드를 활용한 전체 카테고리 노출 순서 업데이트
   - [x] Soft Delete: 카테고리 삭제 시 기존 둥지 데이터 보존을 위한 논리 삭제 처리
   - [x] 기본 CRUD: 카테고리 생성 및 이름 수정 기능

  3. 기존 도메인 최적화 및 보안
   - [x] CategoryController: 생성/수정/삭제 권한을 관리자 도메인으로 이전 및 코드 정리
   - [x] NestService & UserInterestService: 둥지 생성/수정 시 삭제된 카테고리 사용 방지 검증 로직 추가
   - [x] SecurityConfig: 관리자 전용 경로 권한 설정 통합 (/api/v1/admin/**)

  4. 테스트 및 문서화
   - [x] AdminCategoryServiceTest: 순서 변경, Soft Delete 등 핵심 비즈니스 로직 단위 테스트 완료
   - [x] CategoryControllerTest: 리팩토링된 유저용 조회 API 테스트 업데이트
   - [x] API 명세서 최신화 (삭제된 카테고리 포함 둥지 수정 시 클라이언트 대응 가이드 포함)




## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #47 

  📝 추가 참고 사항 (Additional Notes)
   - 클라이언트 유의사항: 둥지 수정 시 기존에 설정된 카테고리가 삭제된 상태라면 에러(CA003)가 발생합니다. 클라이언트에서는 수정 화면 진입 시 활성 카테고리 목록과 대조하여 사용자에게 카테고리 재선택을 유도해야
     합니다.
   - DB 마이그레이션: 기존 카테고리 데이터의 sort_order는 기본값 0으로 세팅되므로, 배정 후 관리자 API를 통해 순서 재배치가 필요합니다.
