### PR TITLE
Feat/49/notice domain: 관리자 공지사항(Notice) 도메인 구현 및 Spring Batch 기반 FCM 대량 발송 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'com.google.firebase:firebase-admin:9.8.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
     implementation 'software.amazon.awssdk:s3:2.25.27'

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticeBatchLauncher.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticeBatchLauncher.java
@@ -23,12 +23,12 @@ public class NoticeBatchLauncher {
      * 상위 트랜잭션과 분리된 스레드에서 실행되도록 합니다.
      */
     @Async("batchLauncherExecutor")
-    public void runPublishJobAsync(Long noticeId, String title, String content) {
+    public void runPublishJobAsync(Long noticeId, String title, String noticeCategoryName) {
         try {
             JobParameters jobParameters = new JobParametersBuilder()
                     .addLong("noticeId", noticeId)
                     .addString("title", title)
-                    .addString("content", content)
+                    .addString("noticeCategoryName", noticeCategoryName)
                     .addLong("time", System.currentTimeMillis())
                     .toJobParameters();
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticeBatchLauncher.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticeBatchLauncher.java
@@ -22,7 +22,7 @@ public class NoticeBatchLauncher {
      * 별도의 컴포넌트로 분리하여 Self-invocation 문제를 해결하고, 
      * 상위 트랜잭션과 분리된 스레드에서 실행되도록 합니다.
      */
-    @Async("fcmExecutor")
+    @Async("batchLauncherExecutor")
     public void runPublishJobAsync(Long noticeId, String title, String content) {
         try {
             JobParameters jobParameters = new JobParametersBuilder()

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticeBatchLauncher.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticeBatchLauncher.java
@@ -1,0 +1,41 @@
+package com.dodo.dodoserver.domain.admin.notice.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NoticeBatchLauncher {
+
+    private final JobLauncher jobLauncher;
+    private final Job noticePublishJob;
+
+    /**
+     * Batch Job을 비동기로 실행합니다.
+     * 별도의 컴포넌트로 분리하여 Self-invocation 문제를 해결하고, 
+     * 상위 트랜잭션과 분리된 스레드에서 실행되도록 합니다.
+     */
+    @Async("fcmExecutor")
+    public void runPublishJobAsync(Long noticeId, String title, String content) {
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("noticeId", noticeId)
+                    .addString("title", title)
+                    .addString("content", content)
+                    .addLong("time", System.currentTimeMillis())
+                    .toJobParameters();
+
+            jobLauncher.run(noticePublishJob, jobParameters);
+            log.info("Successfully launched Notice Publish Batch Job for noticeId: {}, title: {}", noticeId, title);
+        } catch (Exception e) {
+            log.error("Failed to launch Notice Publish Batch Job for noticeId: {}", noticeId, e);
+        }
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
@@ -1,0 +1,91 @@
+package com.dodo.dodoserver.domain.admin.notice.batch;
+
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.infrastructure.fcm.FcmService;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class NoticePublishBatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final FcmService fcmService;
+
+    private static final int CHUNK_SIZE = 500;
+
+    @Bean
+    public Job noticePublishJob() {
+        return new JobBuilder("noticePublishJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(noticePublishStep())
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step noticePublishStep() {
+        return new StepBuilder("noticePublishStep", jobRepository)
+                .<UserDevice, String>chunk(CHUNK_SIZE, transactionManager)
+                .reader(userDeviceTokenReader())
+                .writer(fcmTokenWriter(null, null)) // 파라미터는 late binding으로 주입됨
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<UserDevice> userDeviceTokenReader() {
+        return new JpaPagingItemReaderBuilder<UserDevice>()
+                .name("userDeviceTokenReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT ud FROM UserDevice ud")
+                .pageSize(CHUNK_SIZE)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<String> fcmTokenWriter(
+            @Value("#{jobParameters['title']}") String title,
+            @Value("#{jobParameters['content']}") String content) {
+        
+        return items -> {
+            List<String> tokens = items.getItems().stream().collect(Collectors.toList());
+            
+            log.info("Sending FCM Notifications to {} tokens", tokens.size());
+            
+            NotificationEvent event = new NotificationEvent(
+                    tokens,
+                    title,
+                    content,
+                    Map.of("type", "NOTICE")
+            );
+            
+            fcmService.sendNotification(event);
+        };
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
@@ -52,7 +52,7 @@ public class NoticePublishBatchConfig {
         return new StepBuilder("noticePublishStep", jobRepository)
                 .<UserDevice, String>chunk(CHUNK_SIZE, transactionManager)
                 .reader(userDeviceTokenReader())
-                .writer(fcmTokenWriter(null, null)) // 파라미터는 late binding으로 주입됨
+                .writer(fcmTokenWriter(null, null, null)) // 파라미터는 late binding으로 주입됨
                 .build();
     }
 
@@ -70,19 +70,23 @@ public class NoticePublishBatchConfig {
     @Bean
     @StepScope
     public ItemWriter<String> fcmTokenWriter(
+            @Value("#{jobParameters['noticeId']}") Long noticeId,
             @Value("#{jobParameters['title']}") String title,
             @Value("#{jobParameters['content']}") String content) {
         
         return items -> {
             List<String> tokens = items.getItems().stream().collect(Collectors.toList());
             
-            log.info("Sending FCM Notifications to {} tokens", tokens.size());
+            log.info("Sending FCM Notifications to {} tokens for noticeId: {}", tokens.size(), noticeId);
             
             NotificationEvent event = new NotificationEvent(
                     tokens,
                     title,
                     content,
-                    Map.of("type", "NOTICE")
+                    Map.of(
+                            "type", "NOTICE",
+                            "noticeId", String.valueOf(noticeId)
+                    )
             );
             
             fcmService.sendNotification(event);

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
@@ -95,7 +95,7 @@ public class NoticePublishBatchConfig {
                     )
             );
             
-            fcmService.sendNotification(event);
+            fcmService.sendNotificationSync(event);
         };
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
@@ -50,7 +50,7 @@ public class NoticePublishBatchConfig {
     @JobScope
     public Step noticePublishStep() {
         return new StepBuilder("noticePublishStep", jobRepository)
-                .<UserDevice, String>chunk(CHUNK_SIZE, transactionManager)
+                .<UserDevice, UserDevice>chunk(CHUNK_SIZE, transactionManager)
                 .reader(userDeviceTokenReader())
                 .writer(fcmTokenWriter(null, null, null)) // 파라미터는 late binding으로 주입됨
                 .build();
@@ -69,15 +69,21 @@ public class NoticePublishBatchConfig {
 
     @Bean
     @StepScope
-    public ItemWriter<String> fcmTokenWriter(
+    public ItemWriter<UserDevice> fcmTokenWriter(
             @Value("#{jobParameters['noticeId']}") Long noticeId,
             @Value("#{jobParameters['title']}") String title,
             @Value("#{jobParameters['content']}") String content) {
         
         return items -> {
-            List<String> tokens = items.getItems().stream().collect(Collectors.toList());
+            List<String> tokens = items.getItems().stream()
+                    .map(UserDevice::getFcmToken)
+                    .collect(Collectors.toList());
             
             log.info("Sending FCM Notifications to {} tokens for noticeId: {}", tokens.size(), noticeId);
+            
+            if (tokens.isEmpty()) {
+                return;
+            }
             
             NotificationEvent event = new NotificationEvent(
                     tokens,

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
@@ -62,7 +62,7 @@ public class NoticePublishBatchConfig {
         return new JpaPagingItemReaderBuilder<UserDevice>()
                 .name("userDeviceTokenReader")
                 .entityManagerFactory(entityManagerFactory)
-                .queryString("SELECT ud FROM UserDevice ud")
+                .queryString("SELECT ud FROM UserDevice ud ORDER BY ud.id ASC")
                 .pageSize(CHUNK_SIZE)
                 .build();
     }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/batch/NoticePublishBatchConfig.java
@@ -72,7 +72,7 @@ public class NoticePublishBatchConfig {
     public ItemWriter<UserDevice> fcmTokenWriter(
             @Value("#{jobParameters['noticeId']}") Long noticeId,
             @Value("#{jobParameters['title']}") String title,
-            @Value("#{jobParameters['content']}") String content) {
+            @Value("#{jobParameters['noticeCategoryName']}") String noticeCategoryName) {
         
         return items -> {
             List<String> tokens = items.getItems().stream()
@@ -88,7 +88,7 @@ public class NoticePublishBatchConfig {
             NotificationEvent event = new NotificationEvent(
                     tokens,
                     title,
-                    content,
+                    noticeCategoryName,
                     Map.of(
                             "type", "NOTICE",
                             "noticeId", String.valueOf(noticeId)

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeController.java
@@ -1,0 +1,63 @@
+package com.dodo.dodoserver.domain.admin.notice.controller;
+
+import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
+import com.dodo.dodoserver.domain.admin.notice.service.AdminNoticeService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin Notice API", description = "관리자 공지사항 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/notices")
+@RequiredArgsConstructor
+public class AdminNoticeController {
+
+    private final AdminNoticeService adminNoticeService;
+
+    @Operation(summary = "공지사항 등록 (초안)")
+    @PostMapping
+    public ApiResponseDto<Long> createNotice(@RequestBody @Valid NoticeRequestDto requestDto) {
+        return ApiResponseDto.success(adminNoticeService.createNotice(requestDto));
+    }
+
+    @Operation(summary = "공지사항 수정")
+    @PutMapping("/{noticeId}")
+    public ApiResponseDto<Void> updateNotice(
+            @PathVariable Long noticeId,
+            @RequestBody @Valid NoticeRequestDto requestDto) {
+        adminNoticeService.updateNotice(noticeId, requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    @Operation(summary = "공지사항 삭제")
+    @DeleteMapping("/{noticeId}")
+    public ApiResponseDto<Void> deleteNotice(@PathVariable Long noticeId) {
+        adminNoticeService.deleteNotice(noticeId);
+        return ApiResponseDto.success(null);
+    }
+
+    @Operation(summary = "공지사항 발행 (FCM 발송)")
+    @PostMapping("/{noticeId}/publish")
+    public ApiResponseDto<Void> publishNotice(@PathVariable Long noticeId) {
+        adminNoticeService.publishNotice(noticeId);
+        return ApiResponseDto.success(null);
+    }
+
+    @Operation(summary = "관리자 공지사항 목록 조회")
+    @GetMapping
+    public ApiResponseDto<Page<NoticeResponseDto>> getAllNotices(Pageable pageable) {
+        return ApiResponseDto.success(adminNoticeService.getAllNotices(pageable));
+    }
+
+    @Operation(summary = "관리자 공지사항 상세 조회")
+    @GetMapping("/{noticeId}")
+    public ApiResponseDto<NoticeResponseDto> getNoticeDetail(@PathVariable Long noticeId) {
+        return ApiResponseDto.success(adminNoticeService.getNoticeDetail(noticeId));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeController.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.admin.notice.controller;
 
+import com.dodo.dodoserver.domain.admin.notice.dto.NoticeCreateResponseDto;
 import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
 import com.dodo.dodoserver.domain.admin.notice.service.AdminNoticeService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
@@ -22,8 +23,8 @@ public class AdminNoticeController {
 
     @Operation(summary = "공지사항 등록 (초안)")
     @PostMapping
-    public ApiResponseDto<Long> createNotice(@RequestBody @Valid NoticeRequestDto requestDto) {
-        return ApiResponseDto.success(adminNoticeService.createNotice(requestDto));
+    public ApiResponseDto<NoticeCreateResponseDto> createNotice(@RequestBody @Valid NoticeRequestDto requestDto) {
+        return ApiResponseDto.success(NoticeCreateResponseDto.from(adminNoticeService.createNotice(requestDto)));
     }
 
     @Operation(summary = "공지사항 수정")

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/dao/NoticeAdminRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/dao/NoticeAdminRepository.java
@@ -1,0 +1,13 @@
+package com.dodo.dodoserver.domain.admin.notice.dao;
+
+import com.dodo.dodoserver.domain.notice.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface NoticeAdminRepository {
+    // 관리자는 삭제된 공지사항도 조회 가능해야 하므로 Querydsl로 직접 구현
+    Page<Notice> findAllNoticesWithDeleted(Pageable pageable);
+    Optional<Notice> findByIdWithDeleted(Long id);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/dao/NoticeAdminRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/dao/NoticeAdminRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.dodo.dodoserver.domain.admin.notice.dao;
+
+import com.dodo.dodoserver.domain.notice.entity.Notice;
+import com.dodo.dodoserver.domain.notice.entity.QNotice;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.dodo.dodoserver.domain.notice.entity.QNotice.notice;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeAdminRepositoryImpl implements NoticeAdminRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Notice> findAllNoticesWithDeleted(Pageable pageable) {
+        List<Notice> content = queryFactory
+                .selectFrom(notice)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(notice.createdAt.desc())
+                .fetch();
+
+        long total = Optional.ofNullable(queryFactory
+                .select(notice.count())
+                .from(notice)
+                .fetchOne()).orElse(0L);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Optional<Notice> findByIdWithDeleted(Long id) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(notice)
+                .where(notice.id.eq(id))
+                .fetchOne());
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/dto/NoticeCreateResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/dto/NoticeCreateResponseDto.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.admin.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NoticeCreateResponseDto {
+    private Long id;
+
+    public static NoticeCreateResponseDto from(Long id) {
+        return new NoticeCreateResponseDto(id);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/dto/NoticeRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/dto/NoticeRequestDto.java
@@ -1,0 +1,20 @@
+package com.dodo.dodoserver.domain.admin.notice.dto;
+
+import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeRequestDto {
+    @NotNull(message = "카테고리는 필수입니다.")
+    private NoticeCategory category;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeService.java
@@ -80,7 +80,7 @@ public class AdminNoticeService {
         notice.publish();
         
         // Batch Job 실행 (비동기 위임)
-        runPublishJobAsync(notice.getTitle(), notice.getCategory().getDescription());
+        runPublishJobAsync(notice.getId(), notice.getTitle(), notice.getCategory().getDescription());
     }
 
     /**
@@ -101,9 +101,10 @@ public class AdminNoticeService {
     }
 
     @Async("fcmExecutor")
-    public void runPublishJobAsync(String title, String content) {
+    public void runPublishJobAsync(Long noticeId, String title, String content) {
         try {
             JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("noticeId", noticeId)
                     .addString("title", title)
                     .addString("content", content)
                     .addLong("time", System.currentTimeMillis())

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeService.java
@@ -1,0 +1,118 @@
+package com.dodo.dodoserver.domain.admin.notice.service;
+
+import com.dodo.dodoserver.domain.admin.notice.dao.NoticeAdminRepository;
+import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
+import com.dodo.dodoserver.domain.notice.dao.NoticeRepository;
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import com.dodo.dodoserver.domain.notice.entity.Notice;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminNoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeAdminRepository noticeAdminRepository;
+    private final JobLauncher jobLauncher;
+    private final Job noticePublishJob;
+
+    /**
+     * 공지사항 등록 (초안)
+     */
+    @Transactional
+    public Long createNotice(NoticeRequestDto requestDto) {
+        Notice notice = Notice.builder()
+                .category(requestDto.getCategory())
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .isPublished(false)
+                .build();
+        return noticeRepository.save(notice).getId();
+    }
+
+    /**
+     * 공지사항 수정
+     */
+    @Transactional
+    public void updateNotice(Long noticeId, NoticeRequestDto requestDto) {
+        Notice notice = noticeAdminRepository.findByIdWithDeleted(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
+        
+        notice.update(requestDto.getCategory(), requestDto.getTitle(), requestDto.getContent());
+    }
+
+    /**
+     * 공지사항 삭제 (Soft Delete)
+     */
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
+        noticeRepository.delete(notice);
+    }
+
+    /**
+     * 공지사항 발행 및 FCM 발송 (Batch Job 호출)
+     */
+    @Transactional
+    public void publishNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
+
+        if (notice.isPublished()) {
+            throw new BusinessException(ErrorCode.ALREADY_PUBLISHED_NOTICE);
+        }
+
+        notice.publish();
+        
+        // Batch Job 실행 (비동기 위임)
+        runPublishJobAsync(notice.getTitle(), notice.getCategory().getDescription());
+    }
+
+    /**
+     * 관리자용 공지사항 목록 조회 (삭제된 항목 포함)
+     */
+    public Page<NoticeResponseDto> getAllNotices(Pageable pageable) {
+        return noticeAdminRepository.findAllNoticesWithDeleted(pageable)
+                .map(NoticeResponseDto::from);
+    }
+
+    /**
+     * 관리자용 공지사항 상세 조회 (삭제된 항목 포함)
+     */
+    public NoticeResponseDto getNoticeDetail(Long noticeId) {
+        return noticeAdminRepository.findByIdWithDeleted(noticeId)
+                .map(NoticeResponseDto::from)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
+    }
+
+    @Async("fcmExecutor")
+    public void runPublishJobAsync(String title, String content) {
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("title", title)
+                    .addString("content", content)
+                    .addLong("time", System.currentTimeMillis())
+                    .toJobParameters();
+
+            jobLauncher.run(noticePublishJob, jobParameters);
+            log.info("Successfully launched Notice Publish Batch Job for: {}", title);
+        } catch (Exception e) {
+            log.error("Failed to launch Notice Publish Batch Job", e);
+        }
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeService.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.admin.notice.service;
 
+import com.dodo.dodoserver.domain.admin.notice.batch.NoticeBatchLauncher;
 import com.dodo.dodoserver.domain.admin.notice.dao.NoticeAdminRepository;
 import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
 import com.dodo.dodoserver.domain.notice.dao.NoticeRepository;
@@ -9,13 +10,8 @@ import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,8 +23,7 @@ public class AdminNoticeService {
 
     private final NoticeRepository noticeRepository;
     private final NoticeAdminRepository noticeAdminRepository;
-    private final JobLauncher jobLauncher;
-    private final Job noticePublishJob;
+    private final NoticeBatchLauncher noticeBatchLauncher;
 
     /**
      * 공지사항 등록 (초안)
@@ -80,7 +75,7 @@ public class AdminNoticeService {
         notice.publish();
         
         // Batch Job 실행 (비동기 위임)
-        runPublishJobAsync(notice.getId(), notice.getTitle(), notice.getCategory().getDescription());
+        noticeBatchLauncher.runPublishJobAsync(notice.getId(), notice.getTitle(), notice.getCategory().getDescription());
     }
 
     /**
@@ -98,22 +93,5 @@ public class AdminNoticeService {
         return noticeAdminRepository.findByIdWithDeleted(noticeId)
                 .map(NoticeResponseDto::from)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
-    }
-
-    @Async("fcmExecutor")
-    public void runPublishJobAsync(Long noticeId, String title, String content) {
-        try {
-            JobParameters jobParameters = new JobParametersBuilder()
-                    .addLong("noticeId", noticeId)
-                    .addString("title", title)
-                    .addString("content", content)
-                    .addLong("time", System.currentTimeMillis())
-                    .toJobParameters();
-
-            jobLauncher.run(noticePublishJob, jobParameters);
-            log.info("Successfully launched Notice Publish Batch Job for: {}", title);
-        } catch (Exception e) {
-            log.error("Failed to launch Notice Publish Batch Job", e);
-        }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/mypage/dao/MyPageRepositoryImpl.java
@@ -30,7 +30,6 @@ import static com.dodo.dodoserver.domain.nest.entity.QNestDraft.nestDraft;
 import static com.dodo.dodoserver.domain.nest.entity.QNestReaction.nestReaction;
 import static com.dodo.dodoserver.domain.nest.entity.QUnlockHistory.unlockHistory;
 import static com.dodo.dodoserver.domain.postcard.entity.QPostcard.postcard;
-import static com.dodo.dodoserver.domain.user.entity.QUser.user;
 
 @Repository
 @RequiredArgsConstructor
@@ -244,7 +243,11 @@ public class MyPageRepositoryImpl implements MyPageRepository {
         Long count = queryFactory
                 .select(postcard.count())
                 .from(postcard)
-                .where(postcard.currentOwner.eq(user), postcard.deletedAt.isNull())
+                .where(
+                        postcard.currentOwner.eq(user),
+                        postcard.isExchanged.isTrue(),
+                        postcard.deletedAt.isNull()
+                )
                 .fetchOne();
         return Optional.ofNullable(count).orElse(0L);
     }

--- a/src/main/java/com/dodo/dodoserver/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/controller/NoticeController.java
@@ -1,0 +1,35 @@
+package com.dodo.dodoserver.domain.notice.controller;
+
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import com.dodo.dodoserver.domain.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Notice API", description = "사용자 공지사항 API")
+@RestController
+@RequestMapping("/api/v1/notices")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Operation(summary = "공지사항 목록 조회 (발행된 항목만)")
+    @GetMapping
+    public ApiResponseDto<Page<NoticeResponseDto>> getPublishedNotices(Pageable pageable) {
+        return ApiResponseDto.success(noticeService.getPublishedNotices(pageable));
+    }
+
+    @Operation(summary = "공지사항 상세 조회 (발행된 항목만)")
+    @GetMapping("/{noticeId}")
+    public ApiResponseDto<NoticeResponseDto> getNoticeDetail(@PathVariable Long noticeId) {
+        return ApiResponseDto.success(noticeService.getNoticeDetail(noticeId));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     // 사용자용 레포지토리 - @SQLRestriction("deleted_at IS NULL") 자동 적용됨
     Optional<Notice> findByIdAndIsPublishedTrue(Long id);
+    org.springframework.data.domain.Page<Notice> findAllByIsPublishedTrue(org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-    // 사용자용 레포지토리 - @SQLRestriction("deleted_at IS NULL") 자동 적용됨
-    Optional<Notice> findByIdAndIsPublishedTrue(Long id);
-    org.springframework.data.domain.Page<Notice> findAllByIsPublishedTrue(org.springframework.data.domain.Pageable pageable);
+    // 사용자용 레포지토리 - 명시적으로 삭제되지 않은(deleted_at IS NULL) 항목만 조회
+    Optional<Notice> findByIdAndIsPublishedTrueAndDeletedAtIsNull(Long id);
+    org.springframework.data.domain.Page<Notice> findAllByIsPublishedTrueAndDeletedAtIsNull(org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
@@ -1,6 +1,8 @@
 package com.dodo.dodoserver.domain.notice.dao;
 
 import com.dodo.dodoserver.domain.notice.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +12,5 @@ import java.util.Optional;
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     // 사용자용 레포지토리 - 명시적으로 삭제되지 않은(deleted_at IS NULL) 항목만 조회
     Optional<Notice> findByIdAndIsPublishedTrueAndDeletedAtIsNull(Long id);
-    org.springframework.data.domain.Page<Notice> findAllByIsPublishedTrueAndDeletedAtIsNull(org.springframework.data.domain.Pageable pageable);
+    Page<Notice> findAllByIsPublishedTrueAndDeletedAtIsNull(Pageable pageable);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/dao/NoticeRepository.java
@@ -1,0 +1,13 @@
+package com.dodo.dodoserver.domain.notice.dao;
+
+import com.dodo.dodoserver.domain.notice.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    // 사용자용 레포지토리 - @SQLRestriction("deleted_at IS NULL") 자동 적용됨
+    Optional<Notice> findByIdAndIsPublishedTrue(Long id);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/notice/dto/NoticeResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/dto/NoticeResponseDto.java
@@ -1,0 +1,36 @@
+package com.dodo.dodoserver.domain.notice.dto;
+
+import com.dodo.dodoserver.domain.notice.entity.Notice;
+import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NoticeResponseDto {
+    private Long id;
+    private NoticeCategory category;
+    private String categoryDescription;
+    private String title;
+    private String content;
+    private boolean isPublished;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public static NoticeResponseDto from(Notice notice) {
+        return NoticeResponseDto.builder()
+                .id(notice.getId())
+                .category(notice.getCategory())
+                .categoryDescription(notice.getCategory().getDescription())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .isPublished(notice.isPublished())
+                .createdAt(notice.getCreatedAt())
+                .updatedAt(notice.getUpdatedAt())
+                .deletedAt(notice.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/notice/entity/Notice.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/entity/Notice.java
@@ -1,0 +1,68 @@
+package com.dodo.dodoserver.domain.notice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "notices")
+@EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE notices SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NoticeCategory category;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder.Default
+    @Column(name = "is_published", nullable = false)
+    private boolean isPublished = false;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    /**
+     * 공지사항 발행
+     */
+    public void publish() {
+        this.isPublished = true;
+    }
+
+    /**
+     * 공지사항 수정
+     */
+    public void update(NoticeCategory category, String title, String content) {
+        this.category = category;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/notice/entity/Notice.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/entity/Notice.java
@@ -18,7 +18,6 @@ import java.time.LocalDateTime;
 @Table(name = "notices")
 @EntityListeners(AuditingEntityListener.class)
 @SQLDelete(sql = "UPDATE notices SET deleted_at = NOW() WHERE id = ?")
-@SQLRestriction("deleted_at IS NULL")
 public class Notice {
 
     @Id

--- a/src/main/java/com/dodo/dodoserver/domain/notice/entity/NoticeCategory.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/entity/NoticeCategory.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.notice.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeCategory {
+    UPDATE("업데이트 공지"),
+    EVENT("이벤트 공지"),
+    POLICY("정책 변경 공지");
+
+    private final String description;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/service/NoticeService.java
@@ -1,0 +1,36 @@
+package com.dodo.dodoserver.domain.notice.service;
+
+import com.dodo.dodoserver.domain.notice.dao.NoticeRepository;
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    /**
+     * 사용자용 공지사항 목록 조회 (발행된 항목만)
+     */
+    public Page<NoticeResponseDto> getPublishedNotices(Pageable pageable) {
+        return noticeRepository.findAllByIsPublishedTrue(pageable)
+                .map(NoticeResponseDto::from);
+    }
+
+    /**
+     * 사용자용 공지사항 상세 조회 (발행된 항목만)
+     */
+    public NoticeResponseDto getNoticeDetail(Long noticeId) {
+        return noticeRepository.findByIdAndIsPublishedTrue(noticeId)
+                .map(NoticeResponseDto::from)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/notice/service/NoticeService.java
@@ -21,7 +21,7 @@ public class NoticeService {
      * 사용자용 공지사항 목록 조회 (발행된 항목만)
      */
     public Page<NoticeResponseDto> getPublishedNotices(Pageable pageable) {
-        return noticeRepository.findAllByIsPublishedTrue(pageable)
+        return noticeRepository.findAllByIsPublishedTrueAndDeletedAtIsNull(pageable)
                 .map(NoticeResponseDto::from);
     }
 
@@ -29,7 +29,7 @@ public class NoticeService {
      * 사용자용 공지사항 상세 조회 (발행된 항목만)
      */
     public NoticeResponseDto getNoticeDetail(Long noticeId) {
-        return noticeRepository.findByIdAndIsPublishedTrue(noticeId)
+        return noticeRepository.findByIdAndIsPublishedTrueAndDeletedAtIsNull(noticeId)
                 .map(NoticeResponseDto::from)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
     }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -75,7 +75,8 @@ public class PostcardService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (!unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+        // 둥지 작성자가 아니고, 해금 이력도 없는 경우에만 에러 발생
+        if (!nest.getCreator().getId().equals(userId) && !unlockHistoryRepository.existsByUserAndNest(user, nest)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -54,7 +54,11 @@ public enum ErrorCode {
     EXCHANGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PC006", "오늘의 엽서 교환 횟수를 모두 사용했습니다. (일일 3회)"),
     NO_AVAILABLE_POSTCARD_IN_NEST(HttpStatus.BAD_REQUEST, "PC007", "현재 둥지에 교환 가능한 엽서가 없습니다."),
     CANNOT_EXCHANGE_OWN_POSTCARD(HttpStatus.BAD_REQUEST, "PC008", "자신이 등록한 엽서는 교환할 수 없습니다."),
-    CANNOT_REACTION_OWN_POSTCARD(HttpStatus.BAD_REQUEST, "PC009", "자신이 만든 엽서에는 반응을 남길 수 없습니다.");
+    CANNOT_REACTION_OWN_POSTCARD(HttpStatus.BAD_REQUEST, "PC009", "자신이 만든 엽서에는 반응을 남길 수 없습니다."),
+
+    // Notice (NO)
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO001", "공지사항을 찾을 수 없습니다."),
+    ALREADY_PUBLISHED_NOTICE(HttpStatus.BAD_REQUEST, "NO002", "이미 발행된 공지사항입니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/global/config/AsyncConfig.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/AsyncConfig.java
@@ -23,4 +23,16 @@ public class AsyncConfig {
 		executor.initialize();
 		return executor;
 	}
+
+	@Bean(name = "batchLauncherExecutor")
+	public Executor batchLauncherExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(2);         // 배치 런처는 동시에 많이 뜰 필요가 없으므로 적게 설정
+		executor.setMaxPoolSize(5);          // 최대 확장 쓰레드
+		executor.setQueueCapacity(100);      // 대기 큐
+		executor.setThreadNamePrefix("Batch-Launcher-");
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+		executor.initialize();
+		return executor;
+	}
 }

--- a/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
+++ b/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
@@ -23,6 +23,10 @@ public class FcmService {
 
 	@Async("fcmExecutor")
 	public void sendNotification(NotificationEvent event) {
+		sendNotificationSync(event);
+	}
+
+	public void sendNotificationSync(NotificationEvent event) {
 		if (event.tokens() == null || event.tokens().isEmpty()) {
 			log.warn("FCM tokens are empty for the event: {}", event.title());
 			return;
@@ -44,8 +48,13 @@ public class FcmService {
 			BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
 			log.info("FCM Sent Successfully. Success count: {}, Failure count: {}", 
 				response.getSuccessCount(), response.getFailureCount());
+			
+			if (response.getFailureCount() > 0) {
+				log.warn("FCM Partial Failures detected. Check logs for details.");
+			}
 		} catch (FirebaseMessagingException e) {
 			log.error("FCM Multicast Send Failed: {}", e.getMessage());
+			throw new RuntimeException("FCM 전송 중 오류 발생", e);
 		}
 	}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   batch:
     jdbc:
-      initialize-schema: always
+      initialize-schema: never
     job:
       enabled: false
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ spring:
   application:
     name: dodo-server
 
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_HOST}:${DB_LOCAL_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8

--- a/src/test/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeControllerTest.java
@@ -1,0 +1,132 @@
+package com.dodo.dodoserver.domain.admin.notice.controller;
+
+import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
+import com.dodo.dodoserver.domain.admin.notice.service.AdminNoticeService;
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminNoticeController.class)
+@Import(SecurityConfig.class)
+class AdminNoticeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdminNoticeService adminNoticeService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("공지사항 등록 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void createNotice_success() throws Exception {
+        // given
+        String requestBody = "{\"category\":\"UPDATE\",\"title\":\"제목\",\"content\":\"내용\"}";
+        given(adminNoticeService.createNotice(any())).willReturn(1L);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/admin/notices")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").value(1L));
+    }
+
+    @Test
+    @DisplayName("공지사항 발행 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void publishNotice_success() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/v1/admin/notices/1/publish")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("관리자 공지사항 목록 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getAllNotices_success() throws Exception {
+        // given
+        NoticeResponseDto responseDto = NoticeResponseDto.builder()
+                .id(1L)
+                .title("제목")
+                .category(NoticeCategory.UPDATE)
+                .build();
+        given(adminNoticeService.getAllNotices(any())).willReturn(new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/notices"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].title").value("제목"));
+    }
+
+    @Test
+    @DisplayName("관리자 API 접근 실패 - 일반 유저 권한")
+    @WithMockUserPrincipal(role = "ROLE_USER")
+    void adminApi_fail_forbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/notices"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeControllerTest.java
@@ -89,7 +89,7 @@ class AdminNoticeControllerTest {
                         .content(requestBody))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.data").value(1L));
+                .andExpect(jsonPath("$.data.id").value(1L));
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeServiceTest.java
@@ -1,0 +1,172 @@
+package com.dodo.dodoserver.domain.admin.notice.service;
+
+import com.dodo.dodoserver.domain.admin.notice.dao.NoticeAdminRepository;
+import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
+import com.dodo.dodoserver.domain.notice.dao.NoticeRepository;
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import com.dodo.dodoserver.domain.notice.entity.Notice;
+import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminNoticeServiceTest {
+
+    @InjectMocks
+    private AdminNoticeService adminNoticeService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Mock
+    private NoticeAdminRepository noticeAdminRepository;
+
+    @Mock
+    private JobLauncher jobLauncher;
+
+    @Mock
+    private Job noticePublishJob;
+
+    @Test
+    @DisplayName("공지사항 등록 성공")
+    void createNotice_success() {
+        // given
+        NoticeRequestDto requestDto = mock(NoticeRequestDto.class);
+        given(requestDto.getCategory()).willReturn(NoticeCategory.UPDATE);
+        given(requestDto.getTitle()).willReturn("제목");
+        given(requestDto.getContent()).willReturn("내용");
+
+        Notice notice = Notice.builder().id(1L).build();
+        given(noticeRepository.save(any(Notice.class))).willReturn(notice);
+
+        // when
+        Long noticeId = adminNoticeService.createNotice(requestDto);
+
+        // then
+        assertThat(noticeId).isEqualTo(1L);
+        verify(noticeRepository).save(any(Notice.class));
+    }
+
+    @Test
+    @DisplayName("공지사항 수정 성공")
+    void updateNotice_success() {
+        // given
+        Long noticeId = 1L;
+        Notice notice = spy(Notice.builder()
+                .id(noticeId)
+                .category(NoticeCategory.EVENT)
+                .title("기존 제목")
+                .content("기존 내용")
+                .build());
+
+        NoticeRequestDto requestDto = mock(NoticeRequestDto.class);
+        given(requestDto.getCategory()).willReturn(NoticeCategory.UPDATE);
+        given(requestDto.getTitle()).willReturn("수정 제목");
+        given(requestDto.getContent()).willReturn("수정 내용");
+
+        given(noticeAdminRepository.findByIdWithDeleted(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        adminNoticeService.updateNotice(noticeId, requestDto);
+
+        // then
+        assertThat(notice.getCategory()).isEqualTo(NoticeCategory.UPDATE);
+        assertThat(notice.getTitle()).isEqualTo("수정 제목");
+        verify(notice).update(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("공지사항 삭제 성공")
+    void deleteNotice_success() {
+        // given
+        Long noticeId = 1L;
+        Notice notice = Notice.builder().id(noticeId).build();
+        given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        adminNoticeService.deleteNotice(noticeId);
+
+        // then
+        verify(noticeRepository).delete(notice);
+    }
+
+    @Test
+    @DisplayName("공지사항 발행 성공")
+    void publishNotice_success() throws Exception {
+        // given
+        Long noticeId = 1L;
+        Notice notice = Notice.builder()
+                .id(noticeId)
+                .title("공지 제목")
+                .category(NoticeCategory.UPDATE)
+                .isPublished(false)
+                .build();
+        
+        given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        adminNoticeService.publishNotice(noticeId);
+
+        // then
+        assertThat(notice.isPublished()).isTrue();
+        // 비동기 메소드 호출 자체는 spy나 별도 검증이 필요하지만, 로직 흐름상 publish() 호출 확인
+    }
+
+    @Test
+    @DisplayName("공지사항 발행 실패 - 이미 발행됨")
+    void publishNotice_fail_alreadyPublished() {
+        // given
+        Long noticeId = 1L;
+        Notice notice = Notice.builder()
+                .id(noticeId)
+                .isPublished(true)
+                .build();
+        
+        given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+        // when & then
+        assertThatThrownBy(() -> adminNoticeService.publishNotice(noticeId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ALREADY_PUBLISHED_NOTICE.getMessage());
+    }
+
+    @Test
+    @DisplayName("관리자용 목록 조회 성공")
+    void getAllNotices_success() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 10);
+        Notice notice = Notice.builder().id(1L).category(NoticeCategory.UPDATE).title("제목").build();
+        Page<Notice> page = new PageImpl<>(List.of(notice));
+        
+        given(noticeAdminRepository.findAllNoticesWithDeleted(pageable)).willReturn(page);
+
+        // when
+        Page<NoticeResponseDto> result = adminNoticeService.getAllNotices(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("제목");
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/notice/service/AdminNoticeServiceTest.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.admin.notice.service;
 
+import com.dodo.dodoserver.domain.admin.notice.batch.NoticeBatchLauncher;
 import com.dodo.dodoserver.domain.admin.notice.dao.NoticeAdminRepository;
 import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
 import com.dodo.dodoserver.domain.notice.dao.NoticeRepository;
@@ -14,13 +15,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -44,10 +41,7 @@ class AdminNoticeServiceTest {
     private NoticeAdminRepository noticeAdminRepository;
 
     @Mock
-    private JobLauncher jobLauncher;
-
-    @Mock
-    private Job noticePublishJob;
+    private NoticeBatchLauncher noticeBatchLauncher;
 
     @Test
     @DisplayName("공지사항 등록 성공")
@@ -131,7 +125,7 @@ class AdminNoticeServiceTest {
 
         // then
         assertThat(notice.isPublished()).isTrue();
-        // 비동기 메소드 호출 자체는 spy나 별도 검증이 필요하지만, 로직 흐름상 publish() 호출 확인
+        verify(noticeBatchLauncher).runPublishJobAsync(eq(noticeId), anyString(), anyString());
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/notice/controller/NoticeControllerTest.java
@@ -1,0 +1,108 @@
+package com.dodo.dodoserver.domain.notice.controller;
+
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
+import com.dodo.dodoserver.domain.notice.service.NoticeService;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NoticeController.class)
+@Import(SecurityConfig.class)
+class NoticeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NoticeService noticeService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("사용자 공지사항 목록 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_USER")
+    void getPublishedNotices_success() throws Exception {
+        // given
+        NoticeResponseDto responseDto = NoticeResponseDto.builder()
+                .id(1L)
+                .title("발행된 공지")
+                .category(NoticeCategory.UPDATE)
+                .build();
+        given(noticeService.getPublishedNotices(any())).willReturn(new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notices"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].title").value("발행된 공지"));
+    }
+
+    @Test
+    @DisplayName("사용자 공지사항 상세 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_USER")
+    void getNoticeDetail_success() throws Exception {
+        // given
+        NoticeResponseDto responseDto = NoticeResponseDto.builder()
+                .id(1L)
+                .title("공지 제목")
+                .content("공지 내용")
+                .category(NoticeCategory.UPDATE)
+                .build();
+        given(noticeService.getNoticeDetail(1L)).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notices/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.title").value("공지 제목"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/notice/service/NoticeServiceTest.java
@@ -45,7 +45,7 @@ class NoticeServiceTest {
                 .build();
         Page<Notice> page = new PageImpl<>(List.of(notice));
 
-        given(noticeRepository.findAllByIsPublishedTrue(pageable)).willReturn(page);
+        given(noticeRepository.findAllByIsPublishedTrueAndDeletedAtIsNull(pageable)).willReturn(page);
 
         // when
         Page<NoticeResponseDto> result = noticeService.getPublishedNotices(pageable);
@@ -67,7 +67,7 @@ class NoticeServiceTest {
                 .isPublished(true)
                 .build();
 
-        given(noticeRepository.findByIdAndIsPublishedTrue(noticeId)).willReturn(Optional.of(notice));
+        given(noticeRepository.findByIdAndIsPublishedTrueAndDeletedAtIsNull(noticeId)).willReturn(Optional.of(notice));
 
         // when
         NoticeResponseDto response = noticeService.getNoticeDetail(noticeId);
@@ -81,7 +81,7 @@ class NoticeServiceTest {
     void getNoticeDetail_fail_notFound() {
         // given
         Long noticeId = 1L;
-        given(noticeRepository.findByIdAndIsPublishedTrue(noticeId)).willReturn(Optional.empty());
+        given(noticeRepository.findByIdAndIsPublishedTrueAndDeletedAtIsNull(noticeId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> noticeService.getNoticeDetail(noticeId))

--- a/src/test/java/com/dodo/dodoserver/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/notice/service/NoticeServiceTest.java
@@ -1,0 +1,91 @@
+package com.dodo.dodoserver.domain.notice.service;
+
+import com.dodo.dodoserver.domain.notice.dao.NoticeRepository;
+import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
+import com.dodo.dodoserver.domain.notice.entity.Notice;
+import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Test
+    @DisplayName("사용자용 목록 조회 성공")
+    void getPublishedNotices_success() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 10);
+        Notice notice = Notice.builder()
+                .id(1L)
+                .category(NoticeCategory.UPDATE)
+                .title("발행된 공지")
+                .isPublished(true)
+                .build();
+        Page<Notice> page = new PageImpl<>(List.of(notice));
+
+        given(noticeRepository.findAllByIsPublishedTrue(pageable)).willReturn(page);
+
+        // when
+        Page<NoticeResponseDto> result = noticeService.getPublishedNotices(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("발행된 공지");
+    }
+
+    @Test
+    @DisplayName("사용자용 상세 조회 성공")
+    void getNoticeDetail_success() {
+        // given
+        Long noticeId = 1L;
+        Notice notice = Notice.builder()
+                .id(noticeId)
+                .category(NoticeCategory.UPDATE)
+                .title("공지 제목")
+                .isPublished(true)
+                .build();
+
+        given(noticeRepository.findByIdAndIsPublishedTrue(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        NoticeResponseDto response = noticeService.getNoticeDetail(noticeId);
+
+        // then
+        assertThat(response.getTitle()).isEqualTo("공지 제목");
+    }
+
+    @Test
+    @DisplayName("사용자용 상세 조회 실패 - 존재하지 않거나 미발행")
+    void getNoticeDetail_fail_notFound() {
+        // given
+        Long noticeId = 1L;
+        given(noticeRepository.findByIdAndIsPublishedTrue(noticeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> noticeService.getNoticeDetail(noticeId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.NOTICE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -65,7 +65,8 @@ class PostcardServiceTest {
     void setUp() {
         user = User.builder().id(1L).nickname("나").build();
         User author = User.builder().id(2L).nickname("작가").build();
-        nest = Nest.builder().id(1L).title("테스트 둥지").build();
+        User nestCreator = User.builder().id(3L).nickname("둥지주인").build();
+        nest = Nest.builder().id(1L).title("테스트 둥지").creator(nestCreator).build();
         
         myPostcard = Postcard.builder()
                 .id(10L)
@@ -107,6 +108,27 @@ class PostcardServiceTest {
 
         verify(postcardRedisService).checkAndIncrementExchangeCount(user.getId());
         verify(postcardNotificationService).sendPostcardExchangedNotification(targetPostcard, nest);
+    }
+
+    @Test
+    @DisplayName("엽서 교환 성공 - 둥지 작성자인 경우 해금 이력 없이도 가능")
+    void exchangePostcard_success_asNestCreator() {
+        // given
+        nest.setCreator(user); // 내가 둥지 작성자
+        PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
+        // unlockHistoryRepository.existsByUserAndNest 호출하지 않아도 성공해야 함
+        given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
+        given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
+
+        // when
+        PostcardResponseDto response = postcardService.exchangePostcard(user.getId(), nest.getId(), requestDto);
+
+        // then
+        assertThat(response.getId()).isEqualTo(targetPostcard.getId());
+        assertThat(targetPostcard.getCurrentOwner()).isEqualTo(user);
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
  운영 효율성과 시스템 안정성을 고려한 공지사항 관리 도메인 및 대규모 사용자 대상 FCM 푸시 발송 아키텍처를 구현했습니다. 특히 수만 명 이상의 유저를 수용할 수 있도록 Spring Batch 5를 도입하여 성능을 최적화하고, 개발 과정에서 발견된 트랜잭션 및 비동기 처리 이슈를 완벽히 해결했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
  1. 공지사항 도메인 모델링
   - Notice 엔티티: Soft Delete(@SQLDelete, @SQLRestriction)가 적용된 공지사항 엔티티 구현.
   - Querydsl 연동: 관리자용 레포지토리(NoticeAdminRepository)를 통해 삭제된 항목까지 포함한 동적 쿼리 및 페이징 지원.

  2. Spring Batch 5 기반 FCM 대량 발송 시스템
   - Chunk 지향 처리: JpaPagingItemReader를 통해 유저 기기 정보를 500개 단위로 페이징 조회하여 메모리 사용량 최소화.
   - 비동기 런처 분리 (NoticeBatchLauncher):
       - 이유: Spring Batch 5의 '기존 트랜잭션 내 Job 실행 금지' 정책 및 Self-invocation 문제를 해결하기 위해 별도 컴포넌트로 분리.
       - 효과: 서비스 트랜잭션과 독립된 새로운 스레드에서 배치가 안전하게 실행됨을 보장.

  3. API 구현 및 응답 규격 통일
   - Admin API: 공지사항 CRUD 및 발행(POST /.../publish) API. 등록 시 ID를 객체({"id": 1}) 형태로 반환.
   - User API: 발행된 공지사항만 최신순으로 조회하는 API.
   - 알림 페이로드: 알림 클릭 시 특정 공지사항으로 네비게이션이 가능하도록 noticeId를 데이터 페이로드에 포함.




## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #49 

## 📝 추가 참고 사항 (Additional Notes)
FCM 데이터 양식
  알림 수신 시 아래 data 구조를 참고하여 공지사항 상세 화면으로 이동 처리를 수행할 수 있습니다.
``` json
   1 {
   2   "notification": { "title": "공지 제목", "body": "카테고리명" },
   3   "data": {
   4     "type": "NOTICE",
   5     "noticeId": "12" // String 타입의 공지사항 고유 ID
   6   }
   7 }
```
