### PR TITLE
Feat/51/admin whitelist auto assign

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/controller/AdminEmailWhitelistController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/controller/AdminEmailWhitelistController.java
@@ -1,0 +1,45 @@
+package com.dodo.dodoserver.domain.admin.user.controller;
+
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistRequestDto;
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistResponseDto;
+import com.dodo.dodoserver.domain.admin.user.service.AdminEmailWhitelistService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/whitelists")
+public class AdminEmailWhitelistController {
+
+    private final AdminEmailWhitelistService adminEmailWhitelistService;
+
+    /**
+     * 화이트리스트 목록 조회
+     */
+    @GetMapping
+    public ApiResponseDto<List<AdminEmailWhitelistResponseDto>> getWhitelists() {
+        return ApiResponseDto.success(adminEmailWhitelistService.getWhitelists());
+    }
+
+    /**
+     * 화이트리스트 이메일 추가
+     */
+    @PostMapping
+    public ApiResponseDto<AdminEmailWhitelistResponseDto> addWhitelist(
+            @Valid @RequestBody AdminEmailWhitelistRequestDto requestDto) {
+        return ApiResponseDto.success(adminEmailWhitelistService.addWhitelist(requestDto));
+    }
+
+    /**
+     * 화이트리스트 이메일 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ApiResponseDto<Void> removeWhitelist(@PathVariable Long id) {
+        adminEmailWhitelistService.removeWhitelist(id);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/dao/AdminEmailWhitelistRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/dao/AdminEmailWhitelistRepository.java
@@ -1,0 +1,13 @@
+package com.dodo.dodoserver.domain.admin.user.dao;
+
+import com.dodo.dodoserver.domain.admin.user.entity.AdminEmailWhitelist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminEmailWhitelistRepository extends JpaRepository<AdminEmailWhitelist, Long> {
+    Optional<AdminEmailWhitelist> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/dto/AdminEmailWhitelistRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/dto/AdminEmailWhitelistRequestDto.java
@@ -1,0 +1,18 @@
+package com.dodo.dodoserver.domain.admin.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminEmailWhitelistRequestDto {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    private String remark;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/dto/AdminEmailWhitelistResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/dto/AdminEmailWhitelistResponseDto.java
@@ -1,0 +1,27 @@
+package com.dodo.dodoserver.domain.admin.user.dto;
+
+import com.dodo.dodoserver.domain.admin.user.entity.AdminEmailWhitelist;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminEmailWhitelistResponseDto {
+    private Long id;
+    private String email;
+    private String remark;
+    private LocalDateTime createdAt;
+
+    public static AdminEmailWhitelistResponseDto from(AdminEmailWhitelist entity) {
+        return AdminEmailWhitelistResponseDto.builder()
+                .id(entity.getId())
+                .email(entity.getEmail())
+                .remark(entity.getRemark())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/AdminEmailWhitelist.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/AdminEmailWhitelist.java
@@ -1,0 +1,36 @@
+package com.dodo.dodoserver.domain.admin.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 권한을 자동으로 부여할 이메일 화이트리스트를 관리하는 엔티티입니다.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "admin_email_whitelists")
+@EntityListeners(AuditingEntityListener.class)
+public class AdminEmailWhitelist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = true)
+    private String remark; // 비고 (예: "운영자 홍길동")
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminEmailWhitelistService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminEmailWhitelistService.java
@@ -1,0 +1,58 @@
+package com.dodo.dodoserver.domain.admin.user.service;
+
+import com.dodo.dodoserver.domain.admin.user.dao.AdminEmailWhitelistRepository;
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistRequestDto;
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistResponseDto;
+import com.dodo.dodoserver.domain.admin.user.entity.AdminEmailWhitelist;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminEmailWhitelistService {
+
+    private final AdminEmailWhitelistRepository adminEmailWhitelistRepository;
+
+    /**
+     * 전체 화이트리스트 목록 조회
+     */
+    public List<AdminEmailWhitelistResponseDto> getWhitelists() {
+        return adminEmailWhitelistRepository.findAll().stream()
+                .map(AdminEmailWhitelistResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 화이트리스트 이메일 추가
+     */
+    @Transactional
+    public AdminEmailWhitelistResponseDto addWhitelist(AdminEmailWhitelistRequestDto dto) {
+        if (adminEmailWhitelistRepository.existsByEmail(dto.getEmail())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_WHITELIST_EMAIL);
+        }
+
+        AdminEmailWhitelist whitelist = AdminEmailWhitelist.builder()
+                .email(dto.getEmail())
+                .remark(dto.getRemark())
+                .build();
+
+        return AdminEmailWhitelistResponseDto.from(adminEmailWhitelistRepository.save(whitelist));
+    }
+
+    /**
+     * 화이트리스트 이메일 삭제
+     */
+    @Transactional
+    public void removeWhitelist(Long id) {
+        AdminEmailWhitelist whitelist = adminEmailWhitelistRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WHITELIST_NOT_FOUND));
+        adminEmailWhitelistRepository.delete(whitelist);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/dto/TokenResponseDto.java
@@ -15,13 +15,15 @@ public class TokenResponseDto {
     private String refreshToken;
     private Long accessTokenExpiresIn;
     private boolean isOnboarded; // 추가: 온보딩 완료 여부
+    private String role; // 추가: 유저 권한 (USER, ADMIN)
 
-    public static TokenResponseDto of(String accessToken, String refreshToken, Long expiresIn, boolean isOnboarded) {
+    public static TokenResponseDto of(String accessToken, String refreshToken, Long expiresIn, boolean isOnboarded, String role) {
         return TokenResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .accessTokenExpiresIn(expiresIn)
                 .isOnboarded(isOnboarded)
+                .role(role)
                 .build();
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/auth/service/AuthService.java
@@ -55,6 +55,7 @@ public class AuthService {
                 .refreshToken(newRefreshToken)
                 .accessTokenExpiresIn(tokenProvider.getAccessTokenExpiration())
                 .isOnboarded(user.isOnboarded())
+                .role(user.getRole().getKey())
                 .build();
     }
 

--- a/src/main/java/com/dodo/dodoserver/domain/test/TestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/test/TestController.java
@@ -60,7 +60,7 @@ public class TestController {
         String accessToken = jwtTokenProvider.createAccessToken(id, email, role);
         String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
-        return ApiResponseDto.success(TokenResponseDto.of(accessToken, refreshToken, 3600L, false));
+        return ApiResponseDto.success(TokenResponseDto.of(accessToken, refreshToken, 3600L, false, role));
     }
 
     @GetMapping("/hello")

--- a/src/main/java/com/dodo/dodoserver/domain/test/TestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/test/TestService.java
@@ -36,7 +36,19 @@ public class TestService {
         entityManager.createNativeQuery("DELETE FROM nest_reactions WHERE user_id = :userId").setParameter("userId", userId).executeUpdate();
         entityManager.createNativeQuery("DELETE FROM unlock_histories WHERE user_id = :userId").setParameter("userId", userId).executeUpdate();
 
-        // 3. 사용자가 만든 둥지 관련 전체 삭제
+        // 3. 엽서 및 엽서 반응 정리
+        // 유저가 한 엽서 반응 삭제
+        entityManager.createNativeQuery("DELETE FROM postcard_reactions WHERE user_id = :userId")
+                .setParameter("userId", userId).executeUpdate();
+
+        // 유저와 관련된 엽서(본인 제작, 본인 소유, 또는 본인 둥지에 등록된 엽서)의 반응 및 엽서 자체 삭제
+        String userPostcardIds = "SELECT id FROM postcards WHERE original_author_id = :userId OR current_owner_id = :userId OR nest_id IN (SELECT id FROM nests WHERE creator_id = :userId)";
+        entityManager.createNativeQuery("DELETE FROM postcard_reactions WHERE postcard_id IN (" + userPostcardIds + ")")
+                .setParameter("userId", userId).executeUpdate();
+        entityManager.createNativeQuery("DELETE FROM postcards WHERE original_author_id = :userId OR current_owner_id = :userId OR nest_id IN (SELECT id FROM nests WHERE creator_id = :userId)")
+                .setParameter("userId", userId).executeUpdate();
+
+        // 4. 사용자가 만든 둥지 관련 전체 삭제
         // 둥지에 달린 타인의 댓글/좋아요/반응 먼저 삭제
         String nestIdSubQuery = "(SELECT id FROM nests WHERE creator_id = :userId)";
         entityManager.createNativeQuery("DELETE FROM comment_likes WHERE comment_id IN (SELECT id FROM nest_comments WHERE nest_id IN " + nestIdSubQuery + ")")
@@ -57,13 +69,13 @@ public class TestService {
         entityManager.createNativeQuery("DELETE FROM nests WHERE creator_id = :userId")
                 .setParameter("userId", userId).executeUpdate();
 
-        // 4. 기타 정보 삭제
+        // 5. 기타 정보 삭제
         entityManager.createNativeQuery("DELETE FROM nest_drafts WHERE creator_id = :userId").setParameter("userId", userId).executeUpdate();
         entityManager.createNativeQuery("DELETE FROM user_devices WHERE user_id = :userId").setParameter("userId", userId).executeUpdate();
         entityManager.createNativeQuery("DELETE FROM user_interests WHERE user_id = :userId").setParameter("userId", userId).executeUpdate();
         entityManager.createNativeQuery("DELETE FROM user_profiles WHERE user_id = :userId").setParameter("userId", userId).executeUpdate();
 
-        // 5. 최종 유저 삭제
+        // 6. 최종 유저 삭제
         entityManager.createNativeQuery("DELETE FROM users WHERE id = :userId").setParameter("userId", userId).executeUpdate();
 
         log.info("회원 하드 삭제 완료: userId={}", userId);

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -58,7 +58,11 @@ public enum ErrorCode {
 
     // Notice (NO)
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO001", "공지사항을 찾을 수 없습니다."),
-    ALREADY_PUBLISHED_NOTICE(HttpStatus.BAD_REQUEST, "NO002", "이미 발행된 공지사항입니다.");
+    ALREADY_PUBLISHED_NOTICE(HttpStatus.BAD_REQUEST, "NO002", "이미 발행된 공지사항입니다."),
+
+    // Whitelist (W)
+    WHITELIST_NOT_FOUND(HttpStatus.NOT_FOUND, "W001", "화이트리스트 정보를 찾을 수 없습니다."),
+    DUPLICATE_WHITELIST_EMAIL(HttpStatus.BAD_REQUEST, "W002", "이미 화이트리스트에 등록된 이메일입니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/CustomOAuth2UserService.java
@@ -1,19 +1,16 @@
 package com.dodo.dodoserver.global.security;
 
+import com.dodo.dodoserver.domain.admin.user.dao.AdminEmailWhitelistRepository;
 import com.dodo.dodoserver.domain.user.entity.Role;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
 
 /**
  * 구글 등 소셜 서버로부터 사용자 정보를 전달받아 처리하는 서비스 클래스입니다.
@@ -23,6 +20,7 @@ import java.util.Collections;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final UserRepository userRepository;
+    private final AdminEmailWhitelistRepository adminEmailWhitelistRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -50,6 +48,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     /**
      * 기존 회원이면 정보를 업데이트하고, 신규 회원이면 새로운 User 엔티티를 생성하여 저장합니다.
+     * 화이트리스트에 포함된 이메일인 경우 관리자 권한과 자동 온보딩을 처리합니다.
      */
     private User saveOrUpdate(String provider, String providerId, String email, String nickname) {
         User user = userRepository.findByProviderAndProviderId(provider, providerId)
@@ -59,13 +58,22 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                     }
                     return entity;
                 })
-                .orElse(User.builder()
-                        .email(email)
-                        .nickname(nickname)
-                        .provider(provider)
-                        .providerId(providerId)
-                        .role(Role.USER) // 기본 권한 부여
-                        .build());
+                .orElseGet(() -> adminEmailWhitelistRepository.findByEmail(email)
+                        .map(whitelist -> User.builder()
+                                .email(email)
+                                .nickname("관리자_" + whitelist.getId())
+                                .provider(provider)
+                                .providerId(providerId)
+                                .role(Role.ADMIN)
+                                .isOnboarded(true)
+                                .build())
+                        .orElse(User.builder()
+                                .email(email)
+                                .nickname(nickname)
+                                .provider(provider)
+                                .providerId(providerId)
+                                .role(Role.USER)
+                                .build()));
 
         return userRepository.save(user);
     }

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -15,6 +15,7 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 /*
   소셜 로그인(OAuth2)이 최종 성공했을 때 실행되는 핸들러
@@ -67,7 +68,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private boolean isSanctioned(User user) {
         return user.getSanctionedUntil() != null && 
-               user.getSanctionedUntil().isAfter(java.time.LocalDateTime.now());
+               user.getSanctionedUntil().isAfter(LocalDateTime.now());
     }
 
     private void sendSanctionResponse(HttpServletResponse response, User user) throws IOException {

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -59,7 +59,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         // TokenResponseDto 생성 시 isOnboarded 값을 함께 전달
         String result = objectMapper.writeValueAsString(ApiResponseDto.success(
-            TokenResponseDto.of(accessToken, refreshToken, 1800L, user.isOnboarded())
+            TokenResponseDto.of(accessToken, refreshToken, 1800L, user.isOnboarded(), role)
         ));
 
         response.getWriter().write(result);

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminEmailWhitelistControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminEmailWhitelistControllerTest.java
@@ -1,0 +1,135 @@
+package com.dodo.dodoserver.domain.admin.user.controller;
+
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistRequestDto;
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistResponseDto;
+import com.dodo.dodoserver.domain.admin.user.service.AdminEmailWhitelistService;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminEmailWhitelistController.class)
+@Import(SecurityConfig.class)
+class AdminEmailWhitelistControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdminEmailWhitelistService adminEmailWhitelistService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("화이트리스트 목록 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getWhitelists_success() throws Exception {
+        // given
+        AdminEmailWhitelistResponseDto responseDto = AdminEmailWhitelistResponseDto.builder()
+                .id(1L)
+                .email("admin@dodo.com")
+                .remark("운영자")
+                .build();
+        given(adminEmailWhitelistService.getWhitelists()).willReturn(List.of(responseDto));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/whitelists"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].email").value("admin@dodo.com"));
+    }
+
+    @Test
+    @DisplayName("화이트리스트 추가 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void addWhitelist_success() throws Exception {
+        // given
+        AdminEmailWhitelistRequestDto requestDto = new AdminEmailWhitelistRequestDto("new@dodo.com", "비고");
+        AdminEmailWhitelistResponseDto responseDto = AdminEmailWhitelistResponseDto.builder()
+                .id(1L)
+                .email("new@dodo.com")
+                .remark("비고")
+                .build();
+        given(adminEmailWhitelistService.addWhitelist(any())).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/admin/whitelists")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.email").value("new@dodo.com"));
+    }
+
+    @Test
+    @DisplayName("화이트리스트 삭제 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void removeWhitelist_success() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/admin/whitelists/1").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("화이트리스트 조회 실패 - 일반 유저")
+    @WithMockUserPrincipal(role = "ROLE_USER")
+    void getWhitelists_fail_forbidden() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/whitelists"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/service/AdminEmailWhitelistServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/service/AdminEmailWhitelistServiceTest.java
@@ -1,0 +1,108 @@
+package com.dodo.dodoserver.domain.admin.user.service;
+
+import com.dodo.dodoserver.domain.admin.user.dao.AdminEmailWhitelistRepository;
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistRequestDto;
+import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistResponseDto;
+import com.dodo.dodoserver.domain.admin.user.entity.AdminEmailWhitelist;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminEmailWhitelistServiceTest {
+
+    @InjectMocks
+    private AdminEmailWhitelistService adminEmailWhitelistService;
+
+    @Mock
+    private AdminEmailWhitelistRepository adminEmailWhitelistRepository;
+
+    @Test
+    @DisplayName("화이트리스트 목록 조회 성공")
+    void getWhitelists_success() {
+        // given
+        AdminEmailWhitelist whitelist = AdminEmailWhitelist.builder().id(1L).email("test@dodo.com").build();
+        given(adminEmailWhitelistRepository.findAll()).willReturn(List.of(whitelist));
+
+        // when
+        List<AdminEmailWhitelistResponseDto> result = adminEmailWhitelistService.getWhitelists();
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getEmail()).isEqualTo("test@dodo.com");
+    }
+
+    @Test
+    @DisplayName("화이트리스트 추가 성공")
+    void addWhitelist_success() {
+        // given
+        AdminEmailWhitelistRequestDto dto = new AdminEmailWhitelistRequestDto("new@dodo.com", "비고");
+        AdminEmailWhitelist whitelist = AdminEmailWhitelist.builder().id(1L).email("new@dodo.com").remark("비고").build();
+
+        given(adminEmailWhitelistRepository.existsByEmail(dto.getEmail())).willReturn(false);
+        given(adminEmailWhitelistRepository.save(any(AdminEmailWhitelist.class))).willReturn(whitelist);
+
+        // when
+        AdminEmailWhitelistResponseDto result = adminEmailWhitelistService.addWhitelist(dto);
+
+        // then
+        assertThat(result.getEmail()).isEqualTo("new@dodo.com");
+        assertThat(result.getRemark()).isEqualTo("비고");
+        verify(adminEmailWhitelistRepository, times(1)).save(any(AdminEmailWhitelist.class));
+    }
+
+    @Test
+    @DisplayName("화이트리스트 추가 실패 - 이미 존재하는 이메일")
+    void addWhitelist_fail_duplicateEmail() {
+        // given
+        AdminEmailWhitelistRequestDto dto = new AdminEmailWhitelistRequestDto("duplicate@dodo.com", null);
+        given(adminEmailWhitelistRepository.existsByEmail(dto.getEmail())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminEmailWhitelistService.addWhitelist(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.DUPLICATE_WHITELIST_EMAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("화이트리스트 삭제 성공")
+    void removeWhitelist_success() {
+        // given
+        Long id = 1L;
+        AdminEmailWhitelist whitelist = AdminEmailWhitelist.builder().id(id).email("delete@dodo.com").build();
+        given(adminEmailWhitelistRepository.findById(id)).willReturn(Optional.of(whitelist));
+
+        // when
+        adminEmailWhitelistService.removeWhitelist(id);
+
+        // then
+        verify(adminEmailWhitelistRepository, times(1)).delete(whitelist);
+    }
+
+    @Test
+    @DisplayName("화이트리스트 삭제 실패 - 존재하지 않는 ID")
+    void removeWhitelist_fail_notFound() {
+        // given
+        Long id = 999L;
+        given(adminEmailWhitelistRepository.findById(id)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminEmailWhitelistService.removeWhitelist(id))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.WHITELIST_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/auth/controller/AuthControllerTest.java
@@ -71,7 +71,7 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("토큰 재발급 성공 - 온보딩 상태 포함 확인")
+    @DisplayName("토큰 재발급 성공 - 온보딩 상태 및 권한 포함 확인")
     @WithMockUserPrincipal
     void reissue_success() throws Exception {
         // given
@@ -81,6 +81,7 @@ class AuthControllerTest {
                 .refreshToken("new-refresh")
                 .accessTokenExpiresIn(3600L)
                 .isOnboarded(true)
+                .role("ROLE_USER")
                 .build();
 
         given(authService.reissue("refresh-token")).willReturn(responseDto);
@@ -93,7 +94,8 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.accessToken").value("new-access"))
-                .andExpect(jsonPath("$.data.onboarded").value(true));
+                .andExpect(jsonPath("$.data.onboarded").value(true))
+                .andExpect(jsonPath("$.data.role").value("ROLE_USER"));
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
  운영 효율성을 위해 특정 이메일을 가진 사용자가 가입할 때 즉시 관리자(ADMIN) 권한을 부여하고, 온보딩 절차를 자동 스킵하는 '이메일 화이트리스트' 기능을 구현했습니다. 또한, 보안 강화를 위해 모든 토큰 응답에 유저 권한 정보를 포함하도록 수정했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - 화이트리스트 엔티티 및 관리 기능 구현
     - AdminEmailWhitelist 엔티티 및 Repository 생성
     - 관리자 전용 화이트리스트 조회/추가/삭제 API 개발 (AdminEmailWhitelistController, Service)
     - 중복 등록 방지 및 존재하지 않는 항목 삭제 시 예외 처리 추가 (W001, W002)
   - OAuth2 가입 로직 연동
     - CustomOAuth2UserService에서 신규 가입 시 화이트리스트 대조 로직 추가
     - 대상자인 경우 role: ADMIN, isOnboarded: true 설정 및 관리자_{id} 형식의 자동 닉네임 부여
   - 토큰 응답 스펙 확장
     - TokenResponseDto에 role 필드 추가 (로그인 및 토큰 재발급 시 권한 정보 반환)
   - 테스트 환경 개선
     - TestService.hardDeleteUser 수정: 사용자 삭제 시 엽서(Postcard) 및 엽서 반응 데이터도 함께 삭제되도록 강화
   - 검증 완료
     - AdminEmailWhitelistServiceTest & AdminEmailWhitelistControllerTest 작성 및 통과
     - AuthControllerTest 수정: 토큰 재발급 시 role 필드 검증 로직 추가

## 📸 스크린샷 / 결과 (Screenshots / Results)
``` json
   - 관리자 화이트리스트 조회 결과 예시

   1 {
   2   "status": "SUCCESS",
   3   "code": "200",
   4   "data": [
   5     { "id": 1, "email": "admin@dodo.com", "remark": "운영팀장", "createdAt": "2026-05-18T17:00:00" }
   6   ]
   7 }
   - 토큰 응답 결과 예시

   1 {
   2   "status": "SUCCESS",
   3   "code": "200",
   4   "data": {
   5     "accessToken": "...",
   6     "role": "ROLE_ADMIN"
   7   }
   8 }
```


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #51 

## 📝 추가 참고 사항 (Additional Notes)
   - 화이트리스트 확인 로직은 최초 가입(회원가입) 시점에만 동작합니다. 이미 가입된 일반 유저의 권한을 소급 적용하여 변경하지는 않습니다.
   - 클라이언트 개발자는 로그인 응답의 role 필드를 통해 관리자 여부를 판단하고, isOnboarded가 true일 경우 프로필 설정 화면을 스킵하도록 구현이 필요합니다.
