### PR TITLE
Feat/54/admin nest management

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
@@ -2,12 +2,15 @@ package com.dodo.dodoserver.domain.admin.nest.controller;
 
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Admin Comment", description = "관리자용 댓글 관리 API")
 @RestController
 @RequestMapping("/api/v1/admin/comments")
 @RequiredArgsConstructor
@@ -15,6 +18,7 @@ public class AdminCommentController {
 
     private final AdminNestService adminNestService;
 
+    @Operation(summary = "관리자 전용 댓글 삭제", description = "댓글을 소프트 삭제 처리합니다. 대댓글 구조를 유지하기 위해 논리 삭제만 수행합니다.")
     @DeleteMapping("/{commentId}")
     public ApiResponseDto<Void> deleteComment(@PathVariable Long commentId) {
         adminNestService.deleteComment(commentId);

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
@@ -1,0 +1,23 @@
+package com.dodo.dodoserver.domain.admin.nest.controller;
+
+import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/comments")
+@RequiredArgsConstructor
+public class AdminCommentController {
+
+    private final AdminNestService adminNestService;
+
+    @DeleteMapping("/{commentId}")
+    public ApiResponseDto<Void> deleteComment(@PathVariable Long commentId) {
+        adminNestService.deleteComment(commentId);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
@@ -21,7 +21,7 @@ public class AdminCommentController {
     @Operation(summary = "관리자 전용 댓글 삭제", description = "댓글을 소프트 삭제 처리합니다. 대댓글 구조를 유지하기 위해 논리 삭제만 수행합니다.")
     @DeleteMapping("/{commentId}")
     public ApiResponseDto<Void> deleteComment(@PathVariable Long commentId) {
-        adminNestService.deleteComment(commentId);
+        adminNestService.deleteCommentForAdmin(commentId);
         return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
@@ -1,6 +1,7 @@
 package com.dodo.dodoserver.domain.admin.nest.controller;
 
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
@@ -39,5 +40,13 @@ public class AdminNestController {
     @GetMapping("/{nestId}/comments")
     public ApiResponseDto<List<AdminCommentResponseDto>> getNestComments(@PathVariable Long nestId) {
         return ApiResponseDto.success(adminNestService.getNestComments(nestId));
+    }
+
+    @DeleteMapping("/{nestId}")
+    public ApiResponseDto<Void> deleteNest(
+            @PathVariable Long nestId,
+            @RequestBody AdminNestDeleteRequestDto requestDto) {
+        adminNestService.deleteNest(nestId, requestDto);
+        return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
@@ -33,19 +33,19 @@ public class AdminNestController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestParam(required = false) String sort,
             @RequestParam(required = false, defaultValue = "ACTIVE_ONLY") String includeDeleted) {
-        return ApiResponseDto.success(adminNestService.getNests(pageable, startDate, endDate, sort, includeDeleted));
+        return ApiResponseDto.success(adminNestService.getNestsForAdmin(pageable, startDate, endDate, sort, includeDeleted));
     }
 
     @Operation(summary = "관리자 전용 게시물 상세 조회", description = "위치 검증이나 해금 이력과 관계없이 게시물의 원본 상세 데이터(본문, 이미지 등)를 조회합니다.")
     @GetMapping("/{nestId}")
     public ApiResponseDto<AdminNestDetailResponseDto> getNestDetail(@PathVariable Long nestId) {
-        return ApiResponseDto.success(adminNestService.getNestDetail(nestId));
+        return ApiResponseDto.success(adminNestService.getNestDetailForAdmin(nestId));
     }
 
     @Operation(summary = "관리자 전용 둥지별 댓글 목록 조회", description = "해당 둥지의 모든 댓글(삭제된 것 포함)을 조회하며, 각 댓글의 대기 신고 수를 포함합니다.")
     @GetMapping("/{nestId}/comments")
     public ApiResponseDto<List<AdminCommentResponseDto>> getNestComments(@PathVariable Long nestId) {
-        return ApiResponseDto.success(adminNestService.getNestComments(nestId));
+        return ApiResponseDto.success(adminNestService.getNestCommentsForAdmin(nestId));
     }
 
     @Operation(summary = "관리자 전용 게시물 삭제", description = "게시물을 소프트 삭제 처리하며, 작성자에게 FCM 알림을 발송하고 연관 엽서를 원상복구합니다.")
@@ -53,7 +53,7 @@ public class AdminNestController {
     public ApiResponseDto<Void> deleteNest(
             @PathVariable Long nestId,
             @RequestBody AdminNestDeleteRequestDto requestDto) {
-        adminNestService.deleteNest(nestId, requestDto);
+        adminNestService.deleteNestForAdmin(nestId, requestDto);
         return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
@@ -6,6 +6,8 @@ import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
+@Tag(name = "Admin Nest", description = "관리자용 게시물 관리 API")
 @RestController
 @RequestMapping("/api/v1/admin/nests")
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class AdminNestController {
 
     private final AdminNestService adminNestService;
 
+    @Operation(summary = "전체 게시물(Nest) 관리 목록 조회", description = "필터 조건 및 정렬에 따라 전체 게시물 목록을 조회합니다. 삭제된 게시물 포함 여부를 선택할 수 있습니다.")
     @GetMapping
     public ApiResponseDto<Page<AdminNestResponseDto>> getNests(
             Pageable pageable,
@@ -32,16 +36,19 @@ public class AdminNestController {
         return ApiResponseDto.success(adminNestService.getNests(pageable, startDate, endDate, sort, includeDeleted));
     }
 
+    @Operation(summary = "관리자 전용 게시물 상세 조회", description = "위치 검증이나 해금 이력과 관계없이 게시물의 원본 상세 데이터(본문, 이미지 등)를 조회합니다.")
     @GetMapping("/{nestId}")
     public ApiResponseDto<AdminNestDetailResponseDto> getNestDetail(@PathVariable Long nestId) {
         return ApiResponseDto.success(adminNestService.getNestDetail(nestId));
     }
 
+    @Operation(summary = "관리자 전용 둥지별 댓글 목록 조회", description = "해당 둥지의 모든 댓글(삭제된 것 포함)을 조회하며, 각 댓글의 대기 신고 수를 포함합니다.")
     @GetMapping("/{nestId}/comments")
     public ApiResponseDto<List<AdminCommentResponseDto>> getNestComments(@PathVariable Long nestId) {
         return ApiResponseDto.success(adminNestService.getNestComments(nestId));
     }
 
+    @Operation(summary = "관리자 전용 게시물 삭제", description = "게시물을 소프트 삭제 처리하며, 작성자에게 FCM 알림을 발송하고 연관 엽서를 원상복구합니다.")
     @DeleteMapping("/{nestId}")
     public ApiResponseDto<Void> deleteNest(
             @PathVariable Long nestId,

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestController.java
@@ -1,0 +1,43 @@
+package com.dodo.dodoserver.domain.admin.nest.controller;
+
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/nests")
+@RequiredArgsConstructor
+public class AdminNestController {
+
+    private final AdminNestService adminNestService;
+
+    @GetMapping
+    public ApiResponseDto<Page<AdminNestResponseDto>> getNests(
+            Pageable pageable,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String sort,
+            @RequestParam(required = false, defaultValue = "ACTIVE_ONLY") String includeDeleted) {
+        return ApiResponseDto.success(adminNestService.getNests(pageable, startDate, endDate, sort, includeDeleted));
+    }
+
+    @GetMapping("/{nestId}")
+    public ApiResponseDto<AdminNestDetailResponseDto> getNestDetail(@PathVariable Long nestId) {
+        return ApiResponseDto.success(adminNestService.getNestDetail(nestId));
+    }
+
+    @GetMapping("/{nestId}/comments")
+    public ApiResponseDto<List<AdminCommentResponseDto>> getNestComments(@PathVariable Long nestId) {
+        return ApiResponseDto.success(adminNestService.getNestComments(nestId));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.dodo.dodoserver.domain.admin.nest.dao;
+
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+public interface AdminNestRepositoryCustom {
+    Page<AdminNestResponseDto> findNestsForAdmin(
+            Pageable pageable, 
+            LocalDate startDate, 
+            LocalDate endDate, 
+            String sort, 
+            String includeDeleted);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
@@ -74,14 +74,14 @@ public class AdminNestRepositoryCustomImpl implements AdminNestRepositoryCustom 
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = queryFactory
+        Long total = queryFactory
                 .select(nest.id.count())
                 .from(nest)
                 .where(dateCondition, deletedCondition)
                 .fetchOne();
 
         if (results.isEmpty()) {
-            return new PageImpl<>(Collections.emptyList(), pageable, total);
+            return new PageImpl<>(Collections.emptyList(), pageable, total != null ? total : 0L);
         }
 
         List<Long> nestIds = results.stream()
@@ -95,23 +95,30 @@ public class AdminNestRepositoryCustomImpl implements AdminNestRepositoryCustom 
                 .where(report.targetId.in(nestIds), report.reportType.eq(ReportType.NEST))
                 .fetch()
                 .stream()
+                .filter(t -> t.get(report.targetId) != null && t.get(report.reason) != null)
                 .collect(Collectors.groupingBy(
                         t -> t.get(report.targetId),
                         Collectors.mapping(t -> t.get(report.reason), Collectors.toList())
                 ));
 
-        List<AdminNestResponseDto> content = results.stream().map(t -> AdminNestResponseDto.builder()
-                .nestId(t.get(nest.id))
-                .authorNickname(t.get(user.nickname))
-                .content(t.get(nest.content))
-                .createdAt(t.get(nest.createdAt))
-                .likeCount(t.get(nestReaction.countDistinct()))
-                .commentCount(t.get(nestComment.countDistinct()))
-                .reportCount(t.get(report.countDistinct()))
-                .reasons(reasonMap.getOrDefault(t.get(nest.id), Collections.emptyList()).stream().distinct().toList())
-                .build()).collect(Collectors.toList());
+        List<AdminNestResponseDto> content = results.stream().map(t -> {
+            Long likeCount = t.get(nestReaction.countDistinct());
+            Long commentCount = t.get(nestComment.countDistinct());
+            Long reportCount = t.get(report.countDistinct());
 
-        return new PageImpl<>(content, pageable, total);
+            return AdminNestResponseDto.builder()
+                    .nestId(t.get(nest.id))
+                    .authorNickname(t.get(user.nickname))
+                    .content(t.get(nest.content))
+                    .createdAt(t.get(nest.createdAt))
+                    .likeCount(likeCount != null ? likeCount : 0L)
+                    .commentCount(commentCount != null ? commentCount : 0L)
+                    .reportCount(reportCount != null ? reportCount : 0L)
+                    .reasons(reasonMap.getOrDefault(t.get(nest.id), Collections.emptyList()).stream().distinct().toList())
+                    .build();
+        }).collect(Collectors.toList());
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     private BooleanExpression getDeletedCondition(String includeDeleted) {

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
@@ -1,0 +1,136 @@
+package com.dodo.dodoserver.domain.admin.nest.dao;
+
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.dodo.dodoserver.domain.nest.entity.QNest.nest;
+import static com.dodo.dodoserver.domain.nest.entity.QNestComment.nestComment;
+import static com.dodo.dodoserver.domain.nest.entity.QNestReaction.nestReaction;
+import static com.dodo.dodoserver.domain.report.entity.QReport.report;
+import static com.dodo.dodoserver.domain.user.entity.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminNestRepositoryCustomImpl implements AdminNestRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AdminNestResponseDto> findNestsForAdmin(
+            Pageable pageable, 
+            LocalDate startDate, 
+            LocalDate endDate, 
+            String sort, 
+            String includeDeleted) {
+
+        // 1. 기본 필터 조건 설정
+        BooleanExpression dateCondition = null;
+        if (startDate != null && endDate != null) {
+            dateCondition = nest.createdAt.between(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
+        }
+
+        BooleanExpression deletedCondition = getDeletedCondition(includeDeleted);
+
+        // 2. 메인 쿼리: Nest 정보와 각종 카운트 집계
+        // @SQLRestriction 우회를 위해 selectFrom(nest) 대신 필드를 직접 선택
+        List<Tuple> results = queryFactory
+                .select(
+                        nest.id,
+                        user.nickname,
+                        nest.content,
+                        nest.createdAt,
+                        nestReaction.countDistinct(),
+                        nestComment.countDistinct(),
+                        report.countDistinct(),
+                        nest.viewCount
+                )
+                .from(nest)
+                .join(nest.creator, user)
+                .leftJoin(nestReaction).on(nestReaction.nest.eq(nest))
+                .leftJoin(nestComment).on(nestComment.nest.eq(nest))
+                .leftJoin(report).on(report.targetId.eq(nest.id).and(report.reportType.eq(ReportType.NEST)))
+                .where(dateCondition, deletedCondition)
+                .groupBy(nest.id, user.nickname, nest.content, nest.createdAt, nest.viewCount)
+                .orderBy(getOrderSpecifier(sort))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(nest.id.count())
+                .from(nest)
+                .where(dateCondition, deletedCondition)
+                .fetchOne();
+
+        if (results.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, total);
+        }
+
+        List<Long> nestIds = results.stream()
+                .map(t -> t.get(nest.id))
+                .collect(Collectors.toList());
+
+        // 3. 신고 사유 리스트 별도 조회 (N+1 방지)
+        Map<Long, List<ReportReason>> reasonMap = queryFactory
+                .select(report.targetId, report.reason)
+                .from(report)
+                .where(report.targetId.in(nestIds), report.reportType.eq(ReportType.NEST))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(report.targetId),
+                        Collectors.mapping(t -> t.get(report.reason), Collectors.toList())
+                ));
+
+        List<AdminNestResponseDto> content = results.stream().map(t -> AdminNestResponseDto.builder()
+                .nestId(t.get(nest.id))
+                .authorNickname(t.get(user.nickname))
+                .content(t.get(nest.content))
+                .createdAt(t.get(nest.createdAt))
+                .likeCount(t.get(nestReaction.countDistinct()))
+                .commentCount(t.get(nestComment.countDistinct()))
+                .reportCount(t.get(report.countDistinct()))
+                .reasons(reasonMap.getOrDefault(t.get(nest.id), Collections.emptyList()).stream().distinct().toList())
+                .build()).collect(Collectors.toList());
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression getDeletedCondition(String includeDeleted) {
+        if ("ALL".equalsIgnoreCase(includeDeleted)) {
+            return null;
+        } else if ("DELETED_ONLY".equalsIgnoreCase(includeDeleted)) {
+            return nest.deletedAt.isNotNull();
+        } else { // ACTIVE_ONLY 또는 기본값
+            return nest.deletedAt.isNull();
+        }
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sort) {
+        if (sort == null) return new OrderSpecifier<>(Order.DESC, nest.createdAt);
+        return switch (sort.toUpperCase()) {
+            case "LIKE" -> new OrderSpecifier<>(Order.DESC, nestReaction.countDistinct());
+            case "COMMENT" -> new OrderSpecifier<>(Order.DESC, nestComment.countDistinct());
+            case "VIEW" -> new OrderSpecifier<>(Order.DESC, nest.viewCount);
+            default -> new OrderSpecifier<>(Order.DESC, nest.createdAt);
+        };
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentResponseDto.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.admin.nest.dto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,4 +17,5 @@ public class AdminCommentResponseDto {
     private LocalDateTime createdAt;
     private boolean isDeleted;
     private long pendingReportCount;
+    private List<AdminCommentResponseDto> children;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentResponseDto.java
@@ -1,0 +1,19 @@
+package com.dodo.dodoserver.domain.admin.nest.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdminCommentResponseDto {
+    private Long commentId;
+    private Long parentId;
+    private String authorNickname;
+    private String content;
+    private LocalDateTime createdAt;
+    private boolean isDeleted;
+    private long pendingReportCount;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestDeleteRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestDeleteRequestDto.java
@@ -1,0 +1,10 @@
+package com.dodo.dodoserver.domain.admin.nest.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminNestDeleteRequestDto {
+    private String reason;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestDetailResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestDetailResponseDto.java
@@ -1,0 +1,22 @@
+package com.dodo.dodoserver.domain.admin.nest.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdminNestDetailResponseDto {
+    private Long nestId;
+    private String title;
+    private String content;
+    private String authorNickname;
+    private Double latitude;
+    private Double longitude;
+    private List<String> imageUrls;
+    private List<Long> categoryIds;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestResponseDto.java
@@ -1,0 +1,22 @@
+package com.dodo.dodoserver.domain.admin.nest.dto;
+
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdminNestResponseDto {
+    private Long nestId;
+    private String authorNickname;
+    private String content;
+    private LocalDateTime createdAt;
+    private long likeCount;
+    private long commentCount;
+    private long reportCount;
+    private List<ReportReason> reasons;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -1,6 +1,7 @@
 package com.dodo.dodoserver.domain.admin.nest.service;
 
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
 import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
@@ -10,8 +11,13 @@ import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.nest.entity.NestCategory;
 import com.dodo.dodoserver.domain.nest.entity.NestComment;
 import com.dodo.dodoserver.domain.nest.entity.NestImage;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
 import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.infrastructure.fcm.FcmService;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
@@ -30,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.dodo.dodoserver.domain.report.entity.QReport.report;
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
 
 @Service
 @RequiredArgsConstructor
@@ -39,8 +46,11 @@ public class AdminNestService {
     private final NestRepository nestRepository;
     private final NestCommentRepository nestCommentRepository;
     private final NestCategoryRepository nestCategoryRepository;
+    private final PostcardRepository postcardRepository;
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
+    private final UserDeviceRepository userDeviceRepository;
+    private final FcmService fcmService;
     private final JPAQueryFactory queryFactory;
 
     public Page<AdminNestResponseDto> getNests(
@@ -54,8 +64,6 @@ public class AdminNestService {
 
     public AdminNestDetailResponseDto getNestDetail(Long nestId) {
         // @SQLRestriction을 우회하여 삭제된 둥지도 상세 조회가 가능해야 함
-        // 여기서는 findById 대신 네이티브 쿼리나 직접 쿼리 작성을 고려할 수 있으나, 
-        // 일단 요구사항에 따라 원본 데이터를 상세하게 보여주는 것에 집중
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
@@ -112,5 +120,43 @@ public class AdminNestService {
                 .isDeleted(c.getDeletedAt() != null)
                 .pendingReportCount(pendingReportCounts.getOrDefault(c.getId(), 0L))
                 .build()).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteNest(Long nestId, AdminNestDeleteRequestDto requestDto) {
+        Nest nest = nestRepository.findById(nestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
+
+        // 1. FCM 알림 발송 (비동기 권장되나 FcmService 내부에 @Async 적용됨)
+        List<String> tokens = userDeviceRepository.findByUserId(nest.getCreator().getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .collect(Collectors.toList());
+        
+        if (!tokens.isEmpty()) {
+            fcmService.sendNotification(new NotificationEvent(
+                    tokens,
+                    TITLE_NEST_DELETED,
+                    requestDto.getReason(),
+                    Map.of(KEY_TYPE, TYPE_NEST_DELETED, KEY_NEST_ID, nestId.toString())
+            ));
+        }
+
+        // 2. 연관 엽서 원상복구
+        postcardRepository.recoverSharedPostcardsByNest(nest);
+
+        // 3. 하위 댓글 일괄 소프트 삭제
+        nestCommentRepository.deleteAllByNest(nest);
+
+        // 4. 둥지 소프트 삭제
+        nestRepository.delete(nest);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId) {
+        NestComment comment = nestCommentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+        
+        // 하위 대댓글은 유지하고 해당 댓글만 소프트 삭제
+        nestCommentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -8,7 +8,6 @@ import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
-import com.dodo.dodoserver.domain.nest.entity.NestCategory;
 import com.dodo.dodoserver.domain.nest.entity.NestComment;
 import com.dodo.dodoserver.domain.nest.entity.NestImage;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
@@ -55,7 +54,7 @@ public class AdminNestService {
     private final FcmService fcmService;
     private final JPAQueryFactory queryFactory;
 
-    public Page<AdminNestResponseDto> getNests(
+    public Page<AdminNestResponseDto> getNestsForAdmin(
             Pageable pageable, 
             LocalDate startDate, 
             LocalDate endDate, 
@@ -64,7 +63,7 @@ public class AdminNestService {
         return nestRepository.findNestsForAdmin(pageable, startDate, endDate, sort, includeDeleted);
     }
 
-    public AdminNestDetailResponseDto getNestDetail(Long nestId) {
+    public AdminNestDetailResponseDto getNestDetailForAdmin(Long nestId) {
         // @SQLRestriction을 우회하여 삭제된 둥지도 상세 조회가 가능해야 함
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
@@ -86,7 +85,7 @@ public class AdminNestService {
                 .build();
     }
 
-    public List<AdminCommentResponseDto> getNestComments(Long nestId) {
+    public List<AdminCommentResponseDto> getNestCommentsForAdmin(Long nestId) {
         // 1. 해당 둥지의 모든 댓글 조회 (삭제된 댓글 포함)
         List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
 
@@ -157,7 +156,7 @@ public class AdminNestService {
     }
 
     @Transactional
-    public void deleteNest(Long nestId, AdminNestDeleteRequestDto requestDto) {
+    public void deleteNestForAdmin(Long nestId, AdminNestDeleteRequestDto requestDto) {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
@@ -186,7 +185,7 @@ public class AdminNestService {
     }
 
     @Transactional
-    public void deleteComment(Long commentId) {
+    public void deleteCommentForAdmin(Long commentId) {
         NestComment comment = nestCommentRepository.findById(commentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
         

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -86,6 +86,11 @@ public class AdminNestService {
     }
 
     public List<AdminCommentResponseDto> getNestCommentsForAdmin(Long nestId) {
+        // 0. 둥지 존재 여부 확인 (소프트 삭제된 경우 N001 에러)
+        if (!nestRepository.existsById(nestId)) {
+            throw new BusinessException(ErrorCode.NEST_NOT_FOUND);
+        }
+
         // 1. 해당 둥지의 모든 댓글 조회 (삭제된 댓글 포함)
         List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -4,9 +4,7 @@ import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
-import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
-import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
-import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.dao.*;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.nest.entity.NestComment;
 import com.dodo.dodoserver.domain.nest.entity.NestImage;
@@ -47,6 +45,8 @@ public class AdminNestService {
     private final NestRepository nestRepository;
     private final NestCommentRepository nestCommentRepository;
     private final NestCategoryRepository nestCategoryRepository;
+    private final NestReactionRepository nestReactionRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final PostcardRepository postcardRepository;
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
@@ -177,10 +177,17 @@ public class AdminNestService {
         // 2. 연관 엽서 원상복구
         postcardRepository.recoverSharedPostcardsByNest(nest);
 
-        // 3. 하위 댓글 일괄 소프트 삭제
+        // 3. 연관 소셜 데이터 정리 (좋아요, 리액션) - 하드 딜리트
+        List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
+        if (!allComments.isEmpty()) {
+            commentLikeRepository.deleteByCommentIn(allComments);
+        }
+        nestReactionRepository.deleteByNest(nest);
+
+        // 4. 하위 댓글 일괄 소프트 삭제
         nestCommentRepository.deleteAllByNest(nest);
 
-        // 4. 둥지 소프트 삭제
+        // 5. 둥지 소프트 삭제
         nestRepository.delete(nest);
     }
 
@@ -189,7 +196,10 @@ public class AdminNestService {
         NestComment comment = nestCommentRepository.findById(commentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
         
-        // 하위 대댓글은 유지하고 해당 댓글만 소프트 삭제
+        // 1. 해당 댓글의 좋아요 데이터 정리 (하드 딜리트)
+        commentLikeRepository.deleteByComment(comment);
+
+        // 2. 하위 대댓글은 유지하고 해당 댓글만 소프트 삭제
         nestCommentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -1,0 +1,116 @@
+package com.dodo.dodoserver.domain.admin.nest.service;
+
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
+import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.NestCategory;
+import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import com.dodo.dodoserver.domain.nest.entity.NestImage;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.dodo.dodoserver.domain.report.entity.QReport.report;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminNestService {
+
+    private final NestRepository nestRepository;
+    private final NestCommentRepository nestCommentRepository;
+    private final NestCategoryRepository nestCategoryRepository;
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final JPAQueryFactory queryFactory;
+
+    public Page<AdminNestResponseDto> getNests(
+            Pageable pageable, 
+            LocalDate startDate, 
+            LocalDate endDate, 
+            String sort, 
+            String includeDeleted) {
+        return nestRepository.findNestsForAdmin(pageable, startDate, endDate, sort, includeDeleted);
+    }
+
+    public AdminNestDetailResponseDto getNestDetail(Long nestId) {
+        // @SQLRestriction을 우회하여 삭제된 둥지도 상세 조회가 가능해야 함
+        // 여기서는 findById 대신 네이티브 쿼리나 직접 쿼리 작성을 고려할 수 있으나, 
+        // 일단 요구사항에 따라 원본 데이터를 상세하게 보여주는 것에 집중
+        Nest nest = nestRepository.findById(nestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
+
+        List<Long> categoryIds = nestCategoryRepository.findAllByNest(nest).stream()
+                .map(nc -> nc.getCategory().getId())
+                .collect(Collectors.toList());
+
+        return AdminNestDetailResponseDto.builder()
+                .nestId(nest.getId())
+                .title(nest.getTitle())
+                .content(nest.getContent())
+                .authorNickname(nest.getCreator().getNickname())
+                .latitude(nest.getLocation().getPoint().getY())
+                .longitude(nest.getLocation().getPoint().getX())
+                .imageUrls(nest.getImages().stream().map(NestImage::getImageUrl).collect(Collectors.toList()))
+                .categoryIds(categoryIds)
+                .createdAt(nest.getCreatedAt())
+                .build();
+    }
+
+    public List<AdminCommentResponseDto> getNestComments(Long nestId) {
+        // 1. 해당 둥지의 모든 댓글 조회 (삭제된 댓글 포함)
+        List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
+        
+        if (allComments.isEmpty()) return List.of();
+
+        // 2. 유저 정보 일괄 조회 (Native Query 결과이므로 LAZY 로딩 방지)
+        List<Long> userIds = allComments.stream().map(c -> c.getUser().getId()).distinct().toList();
+        Map<Long, String> nicknameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getNickname));
+
+        // 3. 각 댓글별 대기(PENDING) 신고 수 일괄 조회
+        List<Long> commentIds = allComments.stream().map(NestComment::getId).toList();
+        Map<Long, Long> pendingReportCounts = queryFactory
+                .select(report.targetId, report.count())
+                .from(report)
+                .where(
+                        report.reportType.eq(ReportType.COMMENT),
+                        report.targetId.in(commentIds),
+                        report.status.eq(ReportStatus.PENDING)
+                )
+                .groupBy(report.targetId)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(t -> t.get(report.targetId), t -> t.get(report.count())));
+
+        // 4. DTO 변환
+        return allComments.stream().map(c -> AdminCommentResponseDto.builder()
+                .commentId(c.getId())
+                .parentId(c.getParent() != null ? c.getParent().getId() : null)
+                .authorNickname(nicknameMap.getOrDefault(c.getUser().getId(), "알 수 없음"))
+                .content(c.getContent())
+                .createdAt(c.getCreatedAt())
+                .isDeleted(c.getDeletedAt() != null)
+                .pendingReportCount(pendingReportCounts.getOrDefault(c.getId(), 0L))
+                .build()).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -31,6 +31,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -87,7 +89,7 @@ public class AdminNestService {
     public List<AdminCommentResponseDto> getNestComments(Long nestId) {
         // 1. 해당 둥지의 모든 댓글 조회 (삭제된 댓글 포함)
         List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
-        
+
         if (allComments.isEmpty()) return List.of();
 
         // 2. 유저 정보 일괄 조회 (Native Query 결과이므로 LAZY 로딩 방지)
@@ -110,16 +112,48 @@ public class AdminNestService {
                 .stream()
                 .collect(Collectors.toMap(t -> t.get(report.targetId), t -> t.get(report.count())));
 
-        // 4. DTO 변환
-        return allComments.stream().map(c -> AdminCommentResponseDto.builder()
-                .commentId(c.getId())
-                .parentId(c.getParent() != null ? c.getParent().getId() : null)
-                .authorNickname(nicknameMap.getOrDefault(c.getUser().getId(), "알 수 없음"))
-                .content(c.getContent())
-                .createdAt(c.getCreatedAt())
-                .isDeleted(c.getDeletedAt() != null)
-                .pendingReportCount(pendingReportCounts.getOrDefault(c.getId(), 0L))
-                .build()).collect(Collectors.toList());
+        // 4. 부모 ID를 기준으로 그룹화 (트리 구조 생성용)
+        Map<Long, List<NestComment>> childrenMap = allComments.stream()
+                .filter(c -> c.getParent() != null)
+                .collect(Collectors.groupingBy(c -> c.getParent().getId()));
+
+        // 5. 최상위 댓글 추출 및 정렬 (최신순)
+        List<NestComment> topComments = allComments.stream()
+                .filter(c -> c.getParent() == null)
+                .sorted(Comparator.comparing(NestComment::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+        // 6. 트리 구조 변환
+        return topComments.stream()
+                .map(c -> convertToAdminCommentResponseDto(c, childrenMap, nicknameMap, pendingReportCounts))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 관리자용 댓글 DTO 변환 (재귀를 통한 트리 구조 생성)
+     */
+    private AdminCommentResponseDto convertToAdminCommentResponseDto(
+            NestComment comment,
+            Map<Long, List<NestComment>> childrenMap,
+            Map<Long, String> nicknameMap,
+            Map<Long, Long> pendingReportCounts) {
+
+        List<NestComment> children = childrenMap.getOrDefault(comment.getId(), Collections.emptyList());
+        // 대댓글은 생성순으로 정렬
+        children.sort(Comparator.comparing(NestComment::getCreatedAt));
+
+        return AdminCommentResponseDto.builder()
+                .commentId(comment.getId())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .authorNickname(nicknameMap.getOrDefault(comment.getUser().getId(), "알 수 없음"))
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .isDeleted(comment.getDeletedAt() != null)
+                .pendingReportCount(pendingReportCounts.getOrDefault(comment.getId(), 0L))
+                .children(children.stream()
+                        .map(child -> convertToAdminCommentResponseDto(child, childrenMap, nicknameMap, pendingReportCounts))
+                        .collect(Collectors.toList()))
+                .build();
     }
 
     @Transactional

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportController.java
@@ -6,6 +6,8 @@ import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.report.service.AdminReportService;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Admin Report", description = "관리자용 신고 관리 API")
 @RestController
 @RequestMapping("/api/v1/admin/reports")
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class AdminReportController {
 
     private final AdminReportService adminReportService;
 
+    @Operation(summary = "신고된 둥지 목록 조회", description = "신고가 접수된 둥지(게시물) 목록을 집계하여 조회합니다. PENDING 또는 PROCESSED 상태인 데이터만 노출됩니다.")
     @GetMapping("/nests")
     public ApiResponseDto<Page<AdminNestReportResponseDto>> getReportedNests(
             Pageable pageable,
@@ -28,6 +32,7 @@ public class AdminReportController {
         return ApiResponseDto.success(adminReportService.getReportedNests(pageable, sort));
     }
 
+    @Operation(summary = "신고된 댓글 목록 조회", description = "신고가 접수된 댓글 목록을 집계하여 조회합니다. PENDING 또는 PROCESSED 상태인 데이터만 노출됩니다.")
     @GetMapping("/comments")
     public ApiResponseDto<Page<AdminCommentReportResponseDto>> getReportedComments(
             Pageable pageable,
@@ -35,6 +40,7 @@ public class AdminReportController {
         return ApiResponseDto.success(adminReportService.getReportedComments(pageable, sort));
     }
 
+    @Operation(summary = "신고 상세 및 통계 조회", description = "특정 콘텐츠(둥지/댓글/엽서)의 사유별 대기 신고 통계 및 기타 사유 상세 내용을 조회합니다.")
     @GetMapping("/details")
     public ApiResponseDto<ReportDetailResponseDto> getReportDetails(
             @RequestParam ReportType targetType,

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportController.java
@@ -1,0 +1,44 @@
+package com.dodo.dodoserver.domain.admin.report.controller;
+
+import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.report.service.AdminReportService;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final AdminReportService adminReportService;
+
+    @GetMapping("/nests")
+    public ApiResponseDto<Page<AdminNestReportResponseDto>> getReportedNests(
+            Pageable pageable,
+            @RequestParam(required = false) String sort) {
+        return ApiResponseDto.success(adminReportService.getReportedNests(pageable, sort));
+    }
+
+    @GetMapping("/comments")
+    public ApiResponseDto<Page<AdminCommentReportResponseDto>> getReportedComments(
+            Pageable pageable,
+            @RequestParam(required = false) String sort) {
+        return ApiResponseDto.success(adminReportService.getReportedComments(pageable, sort));
+    }
+
+    @GetMapping("/details")
+    public ApiResponseDto<ReportDetailResponseDto> getReportDetails(
+            @RequestParam ReportType targetType,
+            @RequestParam Long targetId) {
+        return ApiResponseDto.success(adminReportService.getReportDetails(targetType, targetId));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.dodo.dodoserver.domain.admin.report.dao;
+
+import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Map;
+
+public interface AdminReportRepositoryCustom {
+    Page<AdminNestReportResponseDto> findReportedNests(Pageable pageable, String sort);
+    Page<AdminCommentReportResponseDto> findReportedComments(Pageable pageable, String sort);
+    Map<String, Long> countPendingReportsByTarget(ReportType targetType, Long targetId);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
@@ -1,0 +1,249 @@
+package com.dodo.dodoserver.domain.admin.report.dao;
+
+import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.dodo.dodoserver.domain.nest.entity.QNest.nest;
+import static com.dodo.dodoserver.domain.nest.entity.QNestComment.nestComment;
+import static com.dodo.dodoserver.domain.report.entity.QReport.report;
+import static com.dodo.dodoserver.domain.user.entity.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AdminNestReportResponseDto> findReportedNests(Pageable pageable, String sort) {
+        // 1. 신고된 Nest ID 목록 및 통계 정보 조회 (PENDING, PROCESSED 상태만)
+        List<Tuple> results = queryFactory
+                .select(
+                        report.targetId,
+                        report.createdAt.min(),
+                        report.createdAt.max(),
+                        report.targetId.count(),
+                        report.status.min() // 상태 정렬용 (PENDING < PROCESSED)
+                )
+                .from(report)
+                .where(
+                        report.reportType.eq(ReportType.NEST),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .groupBy(report.targetId)
+                .orderBy(getNestOrderSpecifier(sort))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(report.targetId)
+                .from(report)
+                .where(
+                        report.reportType.eq(ReportType.NEST),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .groupBy(report.targetId)
+                .fetch().size();
+
+        if (results.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, total);
+        }
+
+        List<Long> targetIds = results.stream()
+                .map(t -> t.get(report.targetId))
+                .collect(Collectors.toList());
+
+        // 2. Nest 상세 정보 및 모든 사유 조회
+        Map<Long, List<ReportReason>> reasonMap = queryFactory
+                .select(report.targetId, report.reason)
+                .from(report)
+                .where(report.targetId.in(targetIds), report.reportType.eq(ReportType.NEST))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(report.targetId),
+                        Collectors.mapping(t -> t.get(report.reason), Collectors.toList())
+                ));
+
+        Map<Long, Tuple> nestInfoMap = queryFactory
+                .select(nest.id, user.nickname, nest.content, report.status)
+                .from(nest)
+                .join(nest.creator, user)
+                .join(report).on(report.targetId.eq(nest.id).and(report.reportType.eq(ReportType.NEST)))
+                .where(nest.id.in(targetIds))
+                .groupBy(nest.id, user.nickname, nest.content, report.status)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(t -> t.get(nest.id), t -> t, (oldV, newV) -> oldV));
+
+        List<AdminNestReportResponseDto> content = results.stream().map(t -> {
+            Long id = t.get(report.targetId);
+            Tuple info = nestInfoMap.get(id);
+            return AdminNestReportResponseDto.builder()
+                    .nestId(id)
+                    .authorNickname(info != null ? info.get(user.nickname) : "알 수 없음")
+                    .content(info != null ? info.get(nest.content) : "")
+                    .firstReportedAt(t.get(report.createdAt.min()))
+                    .lastReportedAt(t.get(report.createdAt.max()))
+                    .reportCount(t.get(report.targetId.count()))
+                    .reasons(reasonMap.getOrDefault(id, Collections.emptyList()).stream().distinct().toList())
+                    .status(info != null ? info.get(report.status) : ReportStatus.PENDING)
+                    .build();
+        }).collect(Collectors.toList());
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<AdminCommentReportResponseDto> findReportedComments(Pageable pageable, String sort) {
+        // Comment 신고 목록 조회 로직 (Nest와 유사)
+        List<Tuple> results = queryFactory
+                .select(
+                        report.targetId,
+                        report.createdAt.max(),
+                        report.targetId.count(),
+                        report.status.min()
+                )
+                .from(report)
+                .where(
+                        report.reportType.eq(ReportType.COMMENT),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .groupBy(report.targetId)
+                .orderBy(getCommentOrderSpecifier(sort))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(report.targetId)
+                .from(report)
+                .where(
+                        report.reportType.eq(ReportType.COMMENT),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .groupBy(report.targetId)
+                .fetch().size();
+
+        if (results.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, total);
+        }
+
+        List<Long> targetIds = results.stream()
+                .map(t -> t.get(report.targetId))
+                .collect(Collectors.toList());
+
+        Map<Long, List<ReportReason>> reasonMap = queryFactory
+                .select(report.targetId, report.reason)
+                .from(report)
+                .where(report.targetId.in(targetIds), report.reportType.eq(ReportType.COMMENT))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(report.targetId),
+                        Collectors.mapping(t -> t.get(report.reason), Collectors.toList())
+                ));
+
+        Map<Long, Tuple> commentInfoMap = queryFactory
+                .select(nestComment.id, user.nickname, nestComment.content, nest.id, nest.title, report.status)
+                .from(nestComment)
+                .join(nestComment.user, user)
+                .join(nestComment.nest, nest)
+                .join(report).on(report.targetId.eq(nestComment.id).and(report.reportType.eq(ReportType.COMMENT)))
+                .where(nestComment.id.in(targetIds))
+                .groupBy(nestComment.id, user.nickname, nestComment.content, nest.id, nest.title, report.status)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(t -> t.get(nestComment.id), t -> t, (oldV, newV) -> oldV));
+
+        List<AdminCommentReportResponseDto> content = results.stream().map(t -> {
+            Long id = t.get(report.targetId);
+            Tuple info = commentInfoMap.get(id);
+            return AdminCommentReportResponseDto.builder()
+                    .commentId(id)
+                    .authorNickname(info != null ? info.get(user.nickname) : "알 수 없음")
+                    .commentContent(info != null ? info.get(nestComment.content) : "")
+                    .nestId(info != null ? info.get(nest.id) : null)
+                    .nestTitle(info != null ? info.get(nest.title) : "알 수 없음")
+                    .lastReportedAt(t.get(report.createdAt.max()))
+                    .reportCount(t.get(report.targetId.count()))
+                    .reasons(reasonMap.getOrDefault(id, Collections.emptyList()).stream().distinct().toList())
+                    .status(info != null ? info.get(report.status) : ReportStatus.PENDING)
+                    .build();
+        }).collect(Collectors.toList());
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Map<String, Long> countPendingReportsByTarget(ReportType targetType, Long targetId) {
+        List<Tuple> results = queryFactory
+                .select(report.reason, report.count())
+                .from(report)
+                .where(
+                        report.reportType.eq(targetType),
+                        report.targetId.eq(targetId),
+                        report.status.eq(ReportStatus.PENDING)
+                )
+                .groupBy(report.reason)
+                .fetch();
+
+        Map<String, Long> stats = new HashMap<>();
+        // 초기값 설정
+        stats.put("pendingAbuseCount", 0L);
+        stats.put("pendingSpamCount", 0L);
+        stats.put("pendingAdvertisementCount", 0L);
+        stats.put("pendingOtherCount", 0L);
+
+        for (Tuple t : results) {
+            ReportReason reason = t.get(report.reason);
+            Long count = t.get(report.count());
+            if (reason != null) {
+                switch (reason) {
+                    case ABUSE -> stats.put("pendingAbuseCount", count);
+                    case SPAM -> stats.put("pendingSpamCount", count);
+                    case ADVERTISEMENT -> stats.put("pendingAdvertisementCount", count);
+                    case OTHER -> stats.put("pendingOtherCount", count);
+                }
+            }
+        }
+        return stats;
+    }
+
+    private OrderSpecifier<?> getNestOrderSpecifier(String sort) {
+        if (sort == null) return new OrderSpecifier<>(Order.DESC, report.createdAt.max());
+        return switch (sort) {
+            case "FIRST_REPORT" -> new OrderSpecifier<>(Order.ASC, report.createdAt.min());
+            case "REPORT_COUNT" -> new OrderSpecifier<>(Order.DESC, report.targetId.count());
+            case "STATUS" -> new OrderSpecifier<>(Order.ASC, report.status.min());
+            default -> new OrderSpecifier<>(Order.DESC, report.createdAt.max());
+        };
+    }
+
+    private OrderSpecifier<?> getCommentOrderSpecifier(String sort) {
+        if (sort == null) return new OrderSpecifier<>(Order.DESC, report.createdAt.max());
+        return switch (sort) {
+            case "REPORT_COUNT" -> new OrderSpecifier<>(Order.DESC, report.targetId.count());
+            case "NEST_ID" -> new OrderSpecifier<>(Order.ASC, report.targetId); // 이 정렬은 조인이 필요할 수 있어 보완 필요
+            default -> new OrderSpecifier<>(Order.DESC, report.createdAt.max());
+        };
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
@@ -53,18 +53,17 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = queryFactory
-                .select(report.targetId)
+        Long total = queryFactory
+                .select(report.targetId.countDistinct())
                 .from(report)
                 .where(
                         report.reportType.eq(ReportType.NEST),
                         report.status.ne(ReportStatus.REJECTED)
                 )
-                .groupBy(report.targetId)
-                .fetch().size();
+                .fetchOne();
 
         if (results.isEmpty()) {
-            return new PageImpl<>(Collections.emptyList(), pageable, total);
+            return new PageImpl<>(Collections.emptyList(), pageable, total != null ? total : 0L);
         }
 
         List<Long> targetIds = results.stream()
@@ -78,6 +77,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 .where(report.targetId.in(targetIds), report.reportType.eq(ReportType.NEST))
                 .fetch()
                 .stream()
+                .filter(t -> t.get(report.targetId) != null && t.get(report.reason) != null)
                 .collect(Collectors.groupingBy(
                         t -> t.get(report.targetId),
                         Collectors.mapping(t -> t.get(report.reason), Collectors.toList())
@@ -97,19 +97,21 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
         List<AdminNestReportResponseDto> content = results.stream().map(t -> {
             Long id = t.get(report.targetId);
             Tuple info = nestInfoMap.get(id);
+            Long reportCount = t.get(report.targetId.count());
+            
             return AdminNestReportResponseDto.builder()
                     .nestId(id)
                     .authorNickname(info != null ? info.get(user.nickname) : "알 수 없음")
                     .content(info != null ? info.get(nest.content) : "")
                     .firstReportedAt(t.get(report.createdAt.min()))
                     .lastReportedAt(t.get(report.createdAt.max()))
-                    .reportCount(t.get(report.targetId.count()))
+                    .reportCount(reportCount != null ? reportCount : 0L)
                     .reasons(reasonMap.getOrDefault(id, Collections.emptyList()).stream().distinct().toList())
                     .status(info != null ? info.get(report.status) : ReportStatus.PENDING)
                     .build();
         }).collect(Collectors.toList());
 
-        return new PageImpl<>(content, pageable, total);
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     @Override
@@ -133,18 +135,17 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = queryFactory
-                .select(report.targetId)
+        Long total = queryFactory
+                .select(report.targetId.countDistinct())
                 .from(report)
                 .where(
                         report.reportType.eq(ReportType.COMMENT),
                         report.status.ne(ReportStatus.REJECTED)
                 )
-                .groupBy(report.targetId)
-                .fetch().size();
+                .fetchOne();
 
         if (results.isEmpty()) {
-            return new PageImpl<>(Collections.emptyList(), pageable, total);
+            return new PageImpl<>(Collections.emptyList(), pageable, total != null ? total : 0L);
         }
 
         List<Long> targetIds = results.stream()
@@ -157,6 +158,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 .where(report.targetId.in(targetIds), report.reportType.eq(ReportType.COMMENT))
                 .fetch()
                 .stream()
+                .filter(t -> t.get(report.targetId) != null && t.get(report.reason) != null)
                 .collect(Collectors.groupingBy(
                         t -> t.get(report.targetId),
                         Collectors.mapping(t -> t.get(report.reason), Collectors.toList())
@@ -177,6 +179,8 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
         List<AdminCommentReportResponseDto> content = results.stream().map(t -> {
             Long id = t.get(report.targetId);
             Tuple info = commentInfoMap.get(id);
+            Long reportCount = t.get(report.targetId.count());
+
             return AdminCommentReportResponseDto.builder()
                     .commentId(id)
                     .authorNickname(info != null ? info.get(user.nickname) : "알 수 없음")
@@ -184,13 +188,13 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                     .nestId(info != null ? info.get(nest.id) : null)
                     .nestTitle(info != null ? info.get(nest.title) : "알 수 없음")
                     .lastReportedAt(t.get(report.createdAt.max()))
-                    .reportCount(t.get(report.targetId.count()))
+                    .reportCount(reportCount != null ? reportCount : 0L)
                     .reasons(reasonMap.getOrDefault(id, Collections.emptyList()).stream().distinct().toList())
                     .status(info != null ? info.get(report.status) : ReportStatus.PENDING)
                     .build();
         }).collect(Collectors.toList());
 
-        return new PageImpl<>(content, pageable, total);
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     @Override

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminCommentReportResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminCommentReportResponseDto.java
@@ -1,0 +1,24 @@
+package com.dodo.dodoserver.domain.admin.report.dto;
+
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdminCommentReportResponseDto {
+    private Long commentId;
+    private String authorNickname;
+    private String commentContent;
+    private Long nestId;
+    private String nestTitle;
+    private LocalDateTime lastReportedAt;
+    private long reportCount;
+    private List<ReportReason> reasons;
+    private ReportStatus status;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminNestReportResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminNestReportResponseDto.java
@@ -1,0 +1,23 @@
+package com.dodo.dodoserver.domain.admin.report.dto;
+
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdminNestReportResponseDto {
+    private Long nestId;
+    private String authorNickname;
+    private String content;
+    private LocalDateTime firstReportedAt;
+    private LocalDateTime lastReportedAt;
+    private long reportCount;
+    private List<ReportReason> reasons;
+    private ReportStatus status;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/ReportDetailResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/ReportDetailResponseDto.java
@@ -1,0 +1,18 @@
+package com.dodo.dodoserver.domain.admin.report.dto;
+
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReportDetailResponseDto {
+    private ReportType targetType;
+    private Long targetId;
+    private Map<String, Long> stats;
+    private List<String> otherReportContents;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportService.java
@@ -1,0 +1,58 @@
+package com.dodo.dodoserver.domain.admin.report.service;
+
+import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.entity.Report;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReportService {
+
+    private final ReportRepository reportRepository;
+
+    public Page<AdminNestReportResponseDto> getReportedNests(Pageable pageable, String sort) {
+        return reportRepository.findReportedNests(pageable, sort);
+    }
+
+    public Page<AdminCommentReportResponseDto> getReportedComments(Pageable pageable, String sort) {
+        return reportRepository.findReportedComments(pageable, sort);
+    }
+
+    public ReportDetailResponseDto getReportDetails(ReportType targetType, Long targetId) {
+        // 1. 통계 조회
+        Map<String, Long> stats = reportRepository.countPendingReportsByTarget(targetType, targetId);
+
+        // 2. OTHER 사유의 상세 내용 리스트 조회
+        // (네이티브 쿼리 대신 간단하므로 JpaRepository 기본 메서드 활용을 고려할 수 있으나, 
+        // 필터링 조건이 명확하므로 별도 쿼리가 유리할 수 있음. 여기서는 일단 전체 조회 후 필터링)
+        List<String> otherReportContents = reportRepository.findAll().stream()
+                .filter(r -> r.getReportType() == targetType && 
+                             r.getTargetId().equals(targetId) && 
+                             r.getReason() == ReportReason.OTHER && 
+                             r.getStatus() == ReportStatus.PENDING)
+                .map(Report::getContent)
+                .collect(Collectors.toList());
+
+        return ReportDetailResponseDto.builder()
+                .targetType(targetType)
+                .targetId(targetId)
+                .stats(stats)
+                .otherReportContents(otherReportContents)
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/CommentLikeRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/CommentLikeRepository.java
@@ -4,6 +4,9 @@ import com.dodo.dodoserver.domain.nest.entity.CommentLike;
 import com.dodo.dodoserver.domain.nest.entity.NestComment;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -13,4 +16,12 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     Optional<CommentLike> findByUserAndComment(User user, NestComment comment);
     boolean existsByUserAndComment(User user, NestComment comment);
     List<CommentLike> findAllByUserAndCommentIn(User user, Collection<NestComment> comments);
+
+    @Modifying
+    @Query("DELETE FROM CommentLike cl WHERE cl.comment = :comment")
+    void deleteByComment(@Param("comment") NestComment comment);
+
+    @Modifying
+    @Query("DELETE FROM CommentLike cl WHERE cl.comment IN :comments")
+    void deleteByCommentIn(@Param("comments") Collection<NestComment> comments);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestCommentRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestCommentRepository.java
@@ -13,5 +13,7 @@ public interface NestCommentRepository extends JpaRepository<NestComment, Long> 
     @Query("SELECT nc FROM NestComment nc JOIN FETCH nc.user WHERE nc.nest = :nest")
     List<NestComment> findAllByNestWithUser(@Param("nest") Nest nest);
 
-
+    // [어드민/가림처리용] 삭제된 댓글을 포함하여 특정 둥지의 모든 댓글 조회 (Native Query로 SQLRestriction 우회)
+    @Query(value = "SELECT * FROM nest_comments WHERE nest_id = :nestId", nativeQuery = true)
+    List<NestComment> findAllByNestIdIncludingDeletedNative(@Param("nestId") Long nestId);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestCommentRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestCommentRepository.java
@@ -16,4 +16,6 @@ public interface NestCommentRepository extends JpaRepository<NestComment, Long> 
     // [어드민/가림처리용] 삭제된 댓글을 포함하여 특정 둥지의 모든 댓글 조회 (Native Query로 SQLRestriction 우회)
     @Query(value = "SELECT * FROM nest_comments WHERE nest_id = :nestId", nativeQuery = true)
     List<NestComment> findAllByNestIdIncludingDeletedNative(@Param("nestId") Long nestId);
+
+    void deleteAllByNest(Nest nest);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestReactionRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestReactionRepository.java
@@ -5,10 +5,17 @@ import com.dodo.dodoserver.domain.nest.entity.NestReaction;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface NestReactionRepository extends JpaRepository<NestReaction, Long> {
     Optional<NestReaction> findByUserAndNest(User user, Nest nest);
     long countByNestAndReactionType(Nest nest, ReactionType reactionType);
+
+    @Modifying
+    @Query("DELETE FROM NestReaction nr WHERE nr.nest = :nest")
+    void deleteByNest(@Param("nest") Nest nest);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.nest.dao;
 
+import com.dodo.dodoserver.domain.admin.nest.dao.AdminNestRepositoryCustom;
 import com.dodo.dodoserver.domain.nest.dao.querydsl.NestRepositoryCustom;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,7 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface NestRepository extends JpaRepository<Nest, Long>, NestRepositoryCustom {
+public interface NestRepository extends JpaRepository<Nest, Long>, NestRepositoryCustom, AdminNestRepositoryCustom {
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Nest n SET n.viewCount = n.viewCount + :increment WHERE n.id = :nestId")

--- a/src/main/java/com/dodo/dodoserver/domain/nest/entity/NestComment.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/entity/NestComment.java
@@ -41,7 +41,7 @@ public class NestComment {
     private NestComment parent;
 
     @Builder.Default
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "parent", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<NestComment> children = new ArrayList<>();
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -226,6 +226,14 @@ public class NestService {
             throw new BusinessException(ErrorCode.NOT_NEST_CREATOR);
         }
 
+        // [추가] 데이터 무결성을 위해 연관 데이터 정리
+        // 1. 연관 엽서 원상복구
+        postcardRepository.recoverSharedPostcardsByNest(nest);
+
+        // 2. 하위 댓글 일괄 소프트 삭제
+        nestCommentRepository.deleteAllByNest(nest);
+
+        // 3. 둥지 본체 삭제
         nestRepository.delete(nest);
         log.info("둥지 삭제 완료: ID={}", nestId);
     }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -226,14 +226,21 @@ public class NestService {
             throw new BusinessException(ErrorCode.NOT_NEST_CREATOR);
         }
 
-        // [추가] 데이터 무결성을 위해 연관 데이터 정리
+        // 데이터 무결성을 위해 연관 데이터 정리
         // 1. 연관 엽서 원상복구
         postcardRepository.recoverSharedPostcardsByNest(nest);
 
-        // 2. 하위 댓글 일괄 소프트 삭제
+        // 2. 연관 소셜 데이터 정리 (좋아요, 리액션) - 하드 딜리트
+        List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
+        if (!allComments.isEmpty()) {
+            commentLikeRepository.deleteByCommentIn(allComments);
+        }
+        nestReactionRepository.deleteByNest(nest);
+
+        // 3. 하위 댓글 일괄 소프트 삭제
         nestCommentRepository.deleteAllByNest(nest);
 
-        // 3. 둥지 본체 삭제
+        // 4. 둥지 본체 삭제
         nestRepository.delete(nest);
         log.info("둥지 삭제 완료: ID={}", nestId);
     }
@@ -311,11 +318,14 @@ public class NestService {
             throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
         }
 
+        // 해당 댓글의 좋아요 데이터 정리 (하드 딜리트)
+        commentLikeRepository.deleteByComment(comment);
+
         nestCommentRepository.delete(comment);
     }
 
     /**
-     * ID 리스트 둥지 요약 정보 조회 (정렬 추가)
+     * ID 리스트 둥지 요약 정보 조회
      */
     @Transactional(readOnly = true)
     public List<NestSummaryResponseDto> getNestsByIds(Long userId, List<Long> nestIds, Sort sort) {
@@ -348,7 +358,7 @@ public class NestService {
     /**
      * 둥지 상세 정보 조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public NestDetailResponseDto getNestDetail(Long userId, Long nestId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -400,7 +410,7 @@ public class NestService {
     }
 
     /**
-     * 둥지 ID로 댓글 리스트 조회 (트리 구조, N+1 문제 완벽 해결)
+     * 둥지 ID로 댓글 리스트 조회
      */
     @Transactional(readOnly = true)
     public List<CommentResponseDto> getCommentsByNestId(Long currentUserId, Long nestId, String sortBy) {
@@ -408,12 +418,12 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        // [수정] 네이티브 쿼리를 사용하여 삭제된 댓글도 포함하여 조회
+        // 네이티브 쿼리를 사용하여 삭제된 댓글도 포함하여 조회
         List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
 
         if (allComments.isEmpty()) return Collections.emptyList();
 
-        // [수정] 네이티브 쿼리 결과로 인해 LAZY 로딩이 발생할 수 있으므로 유저 정보 별도 로드 (기존 profileImageMap 로직 활용을 위해 User 객체 유지 필요 시 보완)
+        // 네이티브 쿼리 결과로 인해 LAZY 로딩이 발생할 수 있으므로 유저 정보 별도 로드 (기존 profileImageMap 로직 활용을 위해 User 객체 유지 필요 시 보완)
         Set<User> authors = allComments.stream().map(NestComment::getUser).collect(Collectors.toSet());
         Map<Long, String> profileImageMap = userProfileRepository.findAllByUserIn(authors).stream()
                 .filter(p -> p.getUser() != null)

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -400,12 +400,14 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        List<NestComment> allComments = nestCommentRepository.findAllByNestWithUser(nest);
+        // [수정] 네이티브 쿼리를 사용하여 삭제된 댓글도 포함하여 조회
+        List<NestComment> allComments = nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId);
 
         if (allComments.isEmpty()) return Collections.emptyList();
 
+        // [수정] 네이티브 쿼리 결과로 인해 LAZY 로딩이 발생할 수 있으므로 유저 정보 별도 로드 (기존 profileImageMap 로직 활용을 위해 User 객체 유지 필요 시 보완)
         Set<User> authors = allComments.stream().map(NestComment::getUser).collect(Collectors.toSet());
-        Map<Long, String> profileImageMap = userProfileRepository.findAllByUserIn(authors).stream() // (profile Id, image url)
+        Map<Long, String> profileImageMap = userProfileRepository.findAllByUserIn(authors).stream()
                 .filter(p -> p.getUser() != null)
                 .collect(Collectors.toMap(p -> p.getUser().getId(), UserProfile::getProfileImageUrl, (oldV, newV) -> oldV));
 
@@ -463,11 +465,11 @@ public class NestService {
 
         return CommentResponseDto.builder()
                 .id(comment.getId())
-                .content(comment.getContent())
-                .nickname(comment.getUser().getNickname())
-                .profileImageUrl(profileImageMap.get(comment.getUser().getId()))
+                .content(comment.getDeletedAt() != null ? "삭제된 댓글 입니다." : comment.getContent())
+                .nickname(comment.getDeletedAt() != null ? "익명" : comment.getUser().getNickname())
+                .profileImageUrl(comment.getDeletedAt() != null ? null : profileImageMap.get(comment.getUser().getId()))
                 .createdAt(comment.getCreatedAt())
-                .likeCount(comment.getLikeCount())
+                .likeCount(comment.getDeletedAt() != null ? 0L : comment.getLikeCount())
                 .isLiked(likedCommentIds.contains(comment.getId()))
                 .children(children.stream()
                         .map(child -> convertToCommentResponseDto(child, childrenMap, profileImageMap, likedCommentIds))

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -44,4 +45,8 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
 
     @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.currentOwner = :user AND p.originalAuthor != :user")
     Page<Postcard> findAcquiredByUser(@Param("user") User user, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Postcard p SET p.isShared = false, p.nest = null WHERE p.nest = :nest")
+    void recoverSharedPostcardsByNest(@Param("nest") Nest nest);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/report/controller/ReportController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/controller/ReportController.java
@@ -1,0 +1,30 @@
+package com.dodo.dodoserver.domain.report.controller;
+
+import com.dodo.dodoserver.domain.report.dto.ReportRequestDto;
+import com.dodo.dodoserver.domain.report.service.ReportService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ApiResponseDto<Void> createReport(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody ReportRequestDto requestDto) {
+        
+        reportService.createReport(userPrincipal.getUser(), requestDto);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/report/controller/ReportController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/controller/ReportController.java
@@ -24,7 +24,7 @@ public class ReportController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody ReportRequestDto requestDto) {
         
-        reportService.createReport(userPrincipal.getUser(), requestDto);
+        reportService.createReport(userPrincipal.getId(), requestDto);
         return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/report/controller/ReportController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/controller/ReportController.java
@@ -4,6 +4,8 @@ import com.dodo.dodoserver.domain.report.dto.ReportRequestDto;
 import com.dodo.dodoserver.domain.report.service.ReportService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Report", description = "신고 API")
 @RestController
 @RequestMapping("/api/v1/reports")
 @RequiredArgsConstructor
@@ -19,6 +22,7 @@ public class ReportController {
 
     private final ReportService reportService;
 
+    @Operation(summary = "도메인 통합 신고하기", description = "둥지, 댓글, 엽서 등 도메인에 관계없이 신고를 접수합니다. 사유가 OTHER일 경우 상세 내용이 필수입니다.")
     @PostMapping
     public ApiResponseDto<Void> createReport(
             @AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
@@ -1,7 +1,8 @@
 package com.dodo.dodoserver.domain.report.dao;
 
+import com.dodo.dodoserver.domain.admin.report.dao.AdminReportRepositoryCustom;
 import com.dodo.dodoserver.domain.report.entity.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReportRepository extends JpaRepository<Report, Long> {
+public interface ReportRepository extends JpaRepository<Report, Long>, AdminReportRepositoryCustom {
 }

--- a/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.dodo.dodoserver.domain.report.dao;
+
+import com.dodo.dodoserver.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/dodo/dodoserver/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/dto/ReportRequestDto.java
@@ -1,0 +1,24 @@
+package com.dodo.dodoserver.domain.report.dto;
+
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReportRequestDto {
+
+    @NotNull(message = "신고 타입은 필수입니다.")
+    private ReportType reportType;
+
+    @NotNull(message = "신고 대상 ID는 필수입니다.")
+    private Long targetId;
+
+    @NotNull(message = "신고 사유는 필수입니다.")
+    private ReportReason reason;
+
+    private String content;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/report/entity/Report.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/entity/Report.java
@@ -1,0 +1,55 @@
+package com.dodo.dodoserver.domain.report.entity;
+
+import com.dodo.dodoserver.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "reports")
+@EntityListeners(AuditingEntityListener.class)
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_type", nullable = false)
+    private ReportType reportType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reason;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportStatus status = ReportStatus.PENDING;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // 처리 상태 변경 메서드
+    public void updateStatus(ReportStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/report/entity/ReportReason.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/entity/ReportReason.java
@@ -1,0 +1,15 @@
+package com.dodo.dodoserver.domain.report.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportReason {
+    ABUSE("욕설 및 비방"),
+    SPAM("도배성 게시글"),
+    ADVERTISEMENT("영리목적/광고"),
+    OTHER("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/report/entity/ReportStatus.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/entity/ReportStatus.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.report.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportStatus {
+    PENDING("대기"),
+    PROCESSED("처리 완료"),
+    REJECTED("반려");
+
+    private final String description;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/report/entity/ReportType.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/entity/ReportType.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.report.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportType {
+    NEST("둥지"),
+    COMMENT("댓글"),
+    POSTCARD("엽서");
+
+    private final String description;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/report/service/ReportService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/service/ReportService.java
@@ -7,6 +7,7 @@ import com.dodo.dodoserver.domain.report.dao.ReportRepository;
 import com.dodo.dodoserver.domain.report.dto.ReportRequestDto;
 import com.dodo.dodoserver.domain.report.entity.Report;
 import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
@@ -23,18 +24,22 @@ public class ReportService {
     private final NestRepository nestRepository;
     private final NestCommentRepository nestCommentRepository;
     private final PostcardRepository postcardRepository;
+    private final UserRepository userRepository;
 
-    public void createReport(User reporter, ReportRequestDto requestDto) {
-        // 1. 대상 존재 여부 검증
+    public void createReport(Long userId, ReportRequestDto requestDto) {
+        User reporter = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 대상 존재 여부 검증
         validateTargetExistence(requestDto);
 
-        // 2. 기타 사유일 경우 상세 내용 필수 체크
+        // 기타 사유일 경우 상세 내용 필수 체크
         if (requestDto.getReason() == ReportReason.OTHER && 
             (requestDto.getContent() == null || requestDto.getContent().isBlank())) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        // 3. 신고 생성 및 저장
+        // 신고 생성 및 저장
         Report report = Report.builder()
                 .reporter(reporter)
                 .reportType(requestDto.getReportType())

--- a/src/main/java/com/dodo/dodoserver/domain/report/service/ReportService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/service/ReportService.java
@@ -1,0 +1,68 @@
+package com.dodo.dodoserver.domain.report.service;
+
+import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.dto.ReportRequestDto;
+import com.dodo.dodoserver.domain.report.entity.Report;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final NestRepository nestRepository;
+    private final NestCommentRepository nestCommentRepository;
+    private final PostcardRepository postcardRepository;
+
+    public void createReport(User reporter, ReportRequestDto requestDto) {
+        // 1. 대상 존재 여부 검증
+        validateTargetExistence(requestDto);
+
+        // 2. 기타 사유일 경우 상세 내용 필수 체크
+        if (requestDto.getReason() == ReportReason.OTHER && 
+            (requestDto.getContent() == null || requestDto.getContent().isBlank())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 3. 신고 생성 및 저장
+        Report report = Report.builder()
+                .reporter(reporter)
+                .reportType(requestDto.getReportType())
+                .targetId(requestDto.getTargetId())
+                .reason(requestDto.getReason())
+                .content(requestDto.getContent())
+                .build();
+
+        reportRepository.save(report);
+    }
+
+    private void validateTargetExistence(ReportRequestDto requestDto) {
+        switch (requestDto.getReportType()) {
+            case NEST -> {
+                if (!nestRepository.existsById(requestDto.getTargetId())) {
+                    throw new BusinessException(ErrorCode.NEST_NOT_FOUND);
+                }
+            }
+            case COMMENT -> {
+                if (!nestCommentRepository.existsById(requestDto.getTargetId())) {
+                    throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND);
+                }
+            }
+            case POSTCARD -> {
+                if (!postcardRepository.existsById(requestDto.getTargetId())) {
+                    throw new BusinessException(ErrorCode.POSTCARD_NOT_FOUND);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "N005", "임시 저장된 둥지를 찾을 수 없습니다."),
     DRAFT_NOT_PUBLISHABLE(HttpStatus.BAD_REQUEST, "N006", "필수 정보(제목, 내용, 반경, 카테고리)가 누락되어 발행할 수 없습니다."),
     NEST_NOT_UNLOCKED(HttpStatus.FORBIDDEN, "N007", "해당 둥지의 상세 내용을 보려면 해금이 필요합니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "N008", "댓글을 찾을 수 없습니다."),
 
     // Postcard (PC)
     POSTCARD_NOT_FOUND(HttpStatus.NOT_FOUND, "PC001", "엽서를 찾을 수 없습니다."),

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -16,8 +16,10 @@ public final class NotificationConstants {
     public static final String TYPE_COMMENT_LIKE = "COMMENT_LIKE";
     public static final String TYPE_POSTCARD_EXCHANGED = "POSTCARD_EXCHANGED";
     public static final String TYPE_POSTCARD_LIKE = "POSTCARD_LIKE";
+    public static final String TYPE_NEST_DELETED = "NEST_DELETED";
 
     // Message Templates
+    public static final String TITLE_NEST_DELETED = "둥지 삭제 알림";
     public static final String TITLE_NEW_COMMENT = "둥지에 새 댓글이 달렸습니다!";
     public static final String BODY_NEW_COMMENT = "%s님이 댓글을 남겼습니다.";
     public static final String TITLE_NEW_REPLY = "내 댓글에 답글이 달렸습니다!";

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentControllerTest.java
@@ -1,0 +1,75 @@
+package com.dodo.dodoserver.domain.admin.nest.controller;
+
+import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminCommentController.class)
+@Import(SecurityConfig.class)
+class AdminCommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminNestService adminNestService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("어드민 댓글 삭제 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void deleteComment_success() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/admin/comments/1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
@@ -1,0 +1,142 @@
+package com.dodo.dodoserver.domain.admin.nest.controller;
+
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
+import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminNestController.class)
+@Import(SecurityConfig.class)
+class AdminNestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdminNestService adminNestService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("어드민 게시물 목록 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getNests_success() throws Exception {
+        // given
+        AdminNestResponseDto responseDto = AdminNestResponseDto.builder()
+                .nestId(1L)
+                .authorNickname("도도새")
+                .content("둥지 내용")
+                .createdAt(LocalDateTime.now())
+                .build();
+        Page<AdminNestResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1);
+        given(adminNestService.getNests(any(), any(), any(), any(), any())).willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/nests"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].authorNickname").value("도도새"));
+    }
+
+    @Test
+    @DisplayName("어드민 게시물 상세 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getNestDetail_success() throws Exception {
+        // given
+        AdminNestDetailResponseDto responseDto = AdminNestDetailResponseDto.builder()
+                .nestId(1L)
+                .title("제목")
+                .content("원본 본문")
+                .authorNickname("산책왕")
+                .latitude(37.2844)
+                .longitude(127.0442)
+                .build();
+        given(adminNestService.getNestDetail(1L)).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/nests/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content").value("원본 본문"));
+    }
+
+    @Test
+    @DisplayName("어드민 게시물 삭제 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void deleteNest_success() throws Exception {
+        // given
+        AdminNestDeleteRequestDto requestDto = new AdminNestDeleteRequestDto();
+        // Reflection이나 세터를 통해 reason 설정 (여기선 간단히)
+        
+        // when & then
+        mockMvc.perform(delete("/api/v1/admin/nests/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"운영 정책 위반\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
@@ -1,7 +1,6 @@
 package com.dodo.dodoserver.domain.admin.nest.controller;
 
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
-import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
@@ -32,7 +31,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -92,7 +90,7 @@ class AdminNestControllerTest {
                 .createdAt(LocalDateTime.now())
                 .build();
         Page<AdminNestResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1);
-        given(adminNestService.getNests(any(), any(), any(), any(), any())).willReturn(page);
+        given(adminNestService.getNestsForAdmin(any(), any(), any(), any(), any())).willReturn(page);
 
         // when & then
         mockMvc.perform(get("/api/v1/admin/nests"))
@@ -114,7 +112,7 @@ class AdminNestControllerTest {
                 .latitude(37.2844)
                 .longitude(127.0442)
                 .build();
-        given(adminNestService.getNestDetail(1L)).willReturn(responseDto);
+        given(adminNestService.getNestDetailForAdmin(1L)).willReturn(responseDto);
 
         // when & then
         mockMvc.perform(get("/api/v1/admin/nests/1"))
@@ -151,7 +149,7 @@ class AdminNestControllerTest {
                 .content("댓글")
                 .children(Collections.singletonList(child))
                 .build();
-        given(adminNestService.getNestComments(1L)).willReturn(Collections.singletonList(parent));
+        given(adminNestService.getNestCommentsForAdmin(1L)).willReturn(Collections.singletonList(parent));
 
         // when & then
         mockMvc.perform(get("/api/v1/admin/nests/1/comments"))

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
@@ -127,16 +127,37 @@ class AdminNestControllerTest {
     @DisplayName("어드민 게시물 삭제 성공 - 관리자 권한")
     @WithMockUserPrincipal(role = "ROLE_ADMIN")
     void deleteNest_success() throws Exception {
-        // given
-        AdminNestDeleteRequestDto requestDto = new AdminNestDeleteRequestDto();
-        // Reflection이나 세터를 통해 reason 설정 (여기선 간단히)
-        
-        // when & then
+        // ... (existing test)
         mockMvc.perform(delete("/api/v1/admin/nests/1")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"reason\":\"운영 정책 위반\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("어드민 둥지별 댓글 목록 조회 성공 - 트리 구조 검증")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getNestComments_success() throws Exception {
+        // given
+        AdminCommentResponseDto child = AdminCommentResponseDto.builder()
+                .commentId(2L)
+                .parentId(1L)
+                .content("대댓글")
+                .build();
+        AdminCommentResponseDto parent = AdminCommentResponseDto.builder()
+                .commentId(1L)
+                .content("댓글")
+                .children(Collections.singletonList(child))
+                .build();
+        given(adminNestService.getNestComments(1L)).willReturn(Collections.singletonList(parent));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/nests/1/comments"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].commentId").value(1))
+                .andExpect(jsonPath("$.data[0].children[0].commentId").value(2));
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -1,9 +1,7 @@
 package com.dodo.dodoserver.domain.admin.nest.service;
 
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
-import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
-import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
-import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.dao.*;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
@@ -44,6 +42,12 @@ class AdminNestServiceTest {
     private NestCategoryRepository nestCategoryRepository;
 
     @Mock
+    private NestReactionRepository nestReactionRepository;
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @Mock
     private PostcardRepository postcardRepository;
 
     @Mock
@@ -62,7 +66,7 @@ class AdminNestServiceTest {
     private JPAQueryFactory queryFactory;
 
     @Test
-    @DisplayName("둥지 삭제 성공 - FCM 알림 및 엽서 회수 포함")
+    @DisplayName("둥지 삭제 성공 - FCM 알림 및 소셜 데이터 정리 포함")
     void deleteNest_ForAdmin_success() {
         // given
         User creator = User.builder().id(1L).build();
@@ -70,9 +74,10 @@ class AdminNestServiceTest {
         UserDevice device = UserDevice.builder().fcmToken("token").build();
         AdminNestDeleteRequestDto requestDto = new AdminNestDeleteRequestDto();
         // Reflection을 통해 사유 설정 또는 JSON 역직렬화 흉내
-        
+
         given(nestRepository.findById(100L)).willReturn(Optional.of(nest));
         given(userDeviceRepository.findByUserId(1L)).willReturn(Collections.singletonList(device));
+        given(nestCommentRepository.findAllByNestIdIncludingDeletedNative(100L)).willReturn(Collections.emptyList());
 
         // when
         adminNestService.deleteNestForAdmin(100L, requestDto);
@@ -80,6 +85,7 @@ class AdminNestServiceTest {
         // then
         verify(fcmService, times(1)).sendNotification(any(NotificationEvent.class));
         verify(postcardRepository, times(1)).recoverSharedPostcardsByNest(nest);
+        verify(nestReactionRepository, times(1)).deleteByNest(nest);
         verify(nestCommentRepository, times(1)).deleteAllByNest(nest);
         verify(nestRepository, times(1)).delete(nest);
     }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -12,6 +12,8 @@ import com.dodo.dodoserver.domain.user.entity.UserDevice;
 import com.dodo.dodoserver.infrastructure.fcm.FcmService;
 import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +22,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -88,5 +93,34 @@ class AdminNestServiceTest {
         verify(nestReactionRepository, times(1)).deleteByNest(nest);
         verify(nestCommentRepository, times(1)).deleteAllByNest(nest);
         verify(nestRepository, times(1)).delete(nest);
+    }
+
+    @Test
+    @DisplayName("둥지 댓글 조회 실패 - 둥지가 존재하지 않거나 삭제된 경우")
+    void getNestComments_fail_nestNotFound() {
+        // given
+        given(nestRepository.existsById(100L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> adminNestService.getNestCommentsForAdmin(100L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NEST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("둥지 댓글 조회 성공 - 빈 목록 반환")
+    void getNestComments_success_emptyList() {
+        // given
+        given(nestRepository.existsById(100L)).willReturn(true);
+        given(nestCommentRepository.findAllByNestIdIncludingDeletedNative(100L)).willReturn(Collections.emptyList());
+
+        // when
+        var result = adminNestService.getNestCommentsForAdmin(100L);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(nestRepository, times(1)).existsById(100L);
+        verify(nestCommentRepository, times(1)).findAllByNestIdIncludingDeletedNative(100L);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -1,0 +1,86 @@
+package com.dodo.dodoserver.domain.admin.nest.service;
+
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
+import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.infrastructure.fcm.FcmService;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminNestServiceTest {
+
+    @InjectMocks
+    private AdminNestService adminNestService;
+
+    @Mock
+    private NestRepository nestRepository;
+
+    @Mock
+    private NestCommentRepository nestCommentRepository;
+
+    @Mock
+    private NestCategoryRepository nestCategoryRepository;
+
+    @Mock
+    private PostcardRepository postcardRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserDeviceRepository userDeviceRepository;
+
+    @Mock
+    private FcmService fcmService;
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @Test
+    @DisplayName("둥지 삭제 성공 - FCM 알림 및 엽서 회수 포함")
+    void deleteNest_success() {
+        // given
+        User creator = User.builder().id(1L).build();
+        Nest nest = Nest.builder().id(100L).creator(creator).build();
+        UserDevice device = UserDevice.builder().fcmToken("token").build();
+        AdminNestDeleteRequestDto requestDto = new AdminNestDeleteRequestDto();
+        // Reflection을 통해 사유 설정 또는 JSON 역직렬화 흉내
+        
+        given(nestRepository.findById(100L)).willReturn(Optional.of(nest));
+        given(userDeviceRepository.findByUserId(1L)).willReturn(Collections.singletonList(device));
+
+        // when
+        adminNestService.deleteNest(100L, requestDto);
+
+        // then
+        verify(fcmService, times(1)).sendNotification(any(NotificationEvent.class));
+        verify(postcardRepository, times(1)).recoverSharedPostcardsByNest(nest);
+        verify(nestCommentRepository, times(1)).deleteAllByNest(nest);
+        verify(nestRepository, times(1)).delete(nest);
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -63,7 +63,7 @@ class AdminNestServiceTest {
 
     @Test
     @DisplayName("둥지 삭제 성공 - FCM 알림 및 엽서 회수 포함")
-    void deleteNest_success() {
+    void deleteNest_ForAdmin_success() {
         // given
         User creator = User.builder().id(1L).build();
         Nest nest = Nest.builder().id(100L).creator(creator).build();
@@ -75,7 +75,7 @@ class AdminNestServiceTest {
         given(userDeviceRepository.findByUserId(1L)).willReturn(Collections.singletonList(device));
 
         // when
-        adminNestService.deleteNest(100L, requestDto);
+        adminNestService.deleteNestForAdmin(100L, requestDto);
 
         // then
         verify(fcmService, times(1)).sendNotification(any(NotificationEvent.class));

--- a/src/test/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportControllerTest.java
@@ -1,0 +1,123 @@
+package com.dodo.dodoserver.domain.admin.report.controller;
+
+import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.report.service.AdminReportService;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminReportController.class)
+@Import(SecurityConfig.class)
+class AdminReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminReportService adminReportService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("신고된 둥지 목록 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getReportedNests_success() throws Exception {
+        // given
+        AdminNestReportResponseDto responseDto = AdminNestReportResponseDto.builder()
+                .nestId(1L)
+                .authorNickname("산책왕")
+                .content("욕설 내용")
+                .reportCount(5)
+                .reasons(Collections.singletonList(ReportReason.ABUSE))
+                .status(ReportStatus.PENDING)
+                .build();
+        Page<AdminNestReportResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1);
+        given(adminReportService.getReportedNests(any(), any())).willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/reports/nests"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].authorNickname").value("산책왕"));
+    }
+
+    @Test
+    @DisplayName("신고 상세 정보 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getReportDetails_success() throws Exception {
+        // given
+        ReportDetailResponseDto responseDto = ReportDetailResponseDto.builder()
+                .targetType(ReportType.NEST)
+                .targetId(1L)
+                .stats(Map.of("pendingAbuseCount", 5L))
+                .otherReportContents(Collections.singletonList("기타 신고 내용"))
+                .build();
+        given(adminReportService.getReportDetails(eq(ReportType.NEST), eq(1L))).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/reports/details")
+                        .param("targetType", "NEST")
+                        .param("targetId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.stats.pendingAbuseCount").value(5));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportServiceTest.java
@@ -1,0 +1,81 @@
+package com.dodo.dodoserver.domain.admin.report.service;
+
+import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.entity.Report;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AdminReportServiceTest {
+
+    @InjectMocks
+    private AdminReportService adminReportService;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Test
+    @DisplayName("신고된 둥지 목록 조회 성공")
+    void getReportedNests_success() {
+        // given
+        AdminNestReportResponseDto responseDto = AdminNestReportResponseDto.builder()
+                .nestId(1L)
+                .authorNickname("도도새")
+                .build();
+        Page<AdminNestReportResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto));
+        given(reportRepository.findReportedNests(any(), any())).willReturn(page);
+
+        // when
+        Page<AdminNestReportResponseDto> result = adminReportService.getReportedNests(PageRequest.of(0, 10), "LATEST");
+
+        // then
+        assertEquals(1, result.getTotalElements());
+        assertEquals("도도새", result.getContent().get(0).getAuthorNickname());
+    }
+
+    @Test
+    @DisplayName("신고 상세 정보 조회 성공")
+    void getReportDetails_success() {
+        // given
+        Map<String, Long> stats = Map.of("pendingAbuseCount", 5L);
+        given(reportRepository.countPendingReportsByTarget(ReportType.NEST, 1L)).willReturn(stats);
+
+        Report report = Report.builder()
+                .reportType(ReportType.NEST)
+                .targetId(1L)
+                .reason(ReportReason.OTHER)
+                .content("기타 사유 상세")
+                .status(ReportStatus.PENDING)
+                .build();
+        given(reportRepository.findAll()).willReturn(Collections.singletonList(report));
+
+        // when
+        ReportDetailResponseDto result = adminReportService.getReportDetails(ReportType.NEST, 1L);
+
+        // then
+        assertEquals(5L, result.getStats().get("pendingAbuseCount"));
+        assertEquals(1, result.getOtherReportContents().size());
+        assertEquals("기타 사유 상세", result.getOtherReportContents().get(0));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -288,7 +288,7 @@ class NestServiceTest {
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
-        given(nestCommentRepository.findAllByNestWithUser(nest)).willReturn(List.of(comment));
+        given(nestCommentRepository.findAllByNestIdIncludingDeletedNative(nestId)).willReturn(List.of(comment));
         given(userProfileRepository.findAllByUserIn(any())).willReturn(new ArrayList<>());
         given(commentLikeRepository.findAllByUserAndCommentIn(any(), any())).willReturn(new ArrayList<>());
 

--- a/src/test/java/com/dodo/dodoserver/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/report/controller/ReportControllerTest.java
@@ -1,0 +1,111 @@
+package com.dodo.dodoserver.domain.report.controller;
+
+import com.dodo.dodoserver.domain.report.dto.ReportRequestDto;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.dodo.dodoserver.domain.report.service.ReportService;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportController.class)
+@Import(SecurityConfig.class)
+class ReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("신고 접수 성공 - 유저 권한")
+    @WithMockUserPrincipal(role = "ROLE_USER")
+    void createReport_success() throws Exception {
+        // given
+        ReportRequestDto requestDto = ReportRequestDto.builder()
+                .reportType(ReportType.NEST)
+                .targetId(1L)
+                .reason(ReportReason.ABUSE)
+                .content("욕설이 포함되어 있습니다.")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/v1/reports")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("신고 접수 실패 - 입력값 누락")
+    @WithMockUserPrincipal(role = "ROLE_USER")
+    void createReport_fail_invalidInput() throws Exception {
+        // given
+        ReportRequestDto requestDto = ReportRequestDto.builder()
+                .targetId(1L)
+                .build(); // reportType, reason 누락
+
+        // when & then
+        mockMvc.perform(post("/api/v1/reports")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("ERROR"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/report/service/ReportServiceTest.java
@@ -1,0 +1,107 @@
+package com.dodo.dodoserver.domain.report.service;
+
+import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.dto.ReportRequestDto;
+import com.dodo.dodoserver.domain.report.entity.Report;
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @InjectMocks
+    private ReportService reportService;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private NestRepository nestRepository;
+
+    @Mock
+    private NestCommentRepository nestCommentRepository;
+
+    @Mock
+    private PostcardRepository postcardRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("신고 생성 성공")
+    void createReport_success() {
+        // given
+        User reporter = User.builder().id(1L).nickname("신고자").build();
+        ReportRequestDto requestDto = ReportRequestDto.builder()
+                .reportType(ReportType.NEST)
+                .targetId(100L)
+                .reason(ReportReason.ABUSE)
+                .content("욕설")
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(reporter));
+        given(nestRepository.existsById(100L)).willReturn(true);
+
+        // when
+        reportService.createReport(1L, requestDto);
+
+        // then
+        verify(reportRepository, times(1)).save(any(Report.class));
+    }
+
+    @Test
+    @DisplayName("신고 생성 실패 - 대상이 존재하지 않음")
+    void createReport_fail_targetNotFound() {
+        // given
+        User reporter = User.builder().id(1L).nickname("신고자").build();
+        ReportRequestDto requestDto = ReportRequestDto.builder()
+                .reportType(ReportType.NEST)
+                .targetId(100L)
+                .reason(ReportReason.ABUSE)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(reporter));
+        given(nestRepository.existsById(100L)).willReturn(false);
+
+        // when & then
+        assertThrows(BusinessException.class, () -> reportService.createReport(1L, requestDto));
+    }
+
+    @Test
+    @DisplayName("신고 생성 실패 - 기타 사유 상세 내용 누락")
+    void createReport_fail_missingOtherContent() {
+        // given
+        User reporter = User.builder().id(1L).nickname("신고자").build();
+        ReportRequestDto requestDto = ReportRequestDto.builder()
+                .reportType(ReportType.NEST)
+                .targetId(100L)
+                .reason(ReportReason.OTHER)
+                .content("") // 빈 내용
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(reporter));
+        given(nestRepository.existsById(100L)).willReturn(true);
+
+        // when & then
+        assertThrows(BusinessException.class, () -> reportService.createReport(1L, requestDto));
+    }
+}


### PR DESCRIPTION
## 📌 개요 (Overview)
관리자 도메인의 게시물(둥지) 및 댓글 관리 기능과 신고 시스템의 전반적인 구현을 완료했습니다. 사용자 신고 접수부터 관리자의 상세 조회, 제재(삭제) 및 관련 데이터 정리 로직을 포함하고 있습니다.

## 🛠️ 작업 내용 (Changes)
   - 신고(Report) 도메인 구현
     - 사용자의 게시물/댓글 신고 접수 API 개발
     - 관리자용 신고 목록 조회 및 신고 사유별 통계 API 개발
   - 관리자 전용 게시물/댓글 관리 API
     - 게시물 및 댓글 목록 조회 (페이징 및 통계 정보 포함)
     - 관리자에 의한 강제 삭제 API 구현 및 삭제 시 FCM 알림 연동
     - 댓글 목록 조회 시 트리(대댓글) 구조로 반환하도록 리팩토링
   - 데이터 정합성 및 사이드 이펙트 처리
     - 게시물 삭제 시 연관된 엽서(Postcard), 댓글, 좋아요/싫어요(Reaction) 데이터 정리 로직 추가
     - 부모 댓글 삭제 시 자식 댓글까지 모두 삭제되는 Cascade 설정 문제 수정 (댓글 상태만 변경하도록 처리)
     - Querydsl 집계 시 발생할 수 있는 NPE 위험 요소 제거
   - 테스트 및 문서화
     - 관리자 게시물 관리 및 신고 기능에 대한 단위/통합 테스트 코드 작성
     - Swagger(OpenAPI 3)를 이용한 신규 API 문서화 (@Operation, @Tag 적용)




## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #54 

## 📝 추가 참고 사항 (Additional Notes)
   - 관리자가 게시물을 삭제할 경우, 해당 유저에게 삭제 사유가 포함된 FCM 알림이 즉시 발송됩니다.
   - 삭제된 둥지에 대한 댓글 조회 시 무결성 체크 로직이 추가되었습니다.

