### PR TITLE
feat/#57: 웹 관리자 페이지용 구글 OAuth 로그인 분기 처리 지원

### DIFF
--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -7,15 +7,21 @@ import com.dodo.dodoserver.domain.auth.dto.TokenResponseDto;
 import com.dodo.dodoserver.domain.auth.service.AuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
 
 /*
   소셜 로그인(OAuth2)이 최종 성공했을 때 실행되는 핸들러
@@ -36,6 +42,12 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final SanctionHistoryRepository sanctionHistoryRepository;
     private final ObjectMapper objectMapper;
 
+    private static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+
+    /**
+     * OAuth2 로그인이 성공했을 때 호출되는 메인 핸들러 메서드
+     * 쿠키 존재 여부에 따라 웹(리다이렉트)과 앱(JSON) 응답을 분기합니다.
+     */
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
@@ -43,9 +55,21 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         User user = userRepository.findById(principal.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // 제재 여부 확인
+        Optional<String> redirectUri = getRedirectUriFromCookie(request);
+
+        // 웹 로그인 시도 시 관리자 권한 확인
+        if (redirectUri.isPresent() && !"ROLE_ADMIN".equals(principal.getRole())) {
+            handleWebErrorResponse(request, response, ErrorCode.HANDLE_ACCESS_DENIED, redirectUri.get());
+            return;
+        }
+
+        // 제재된 사용자인 경우 각 환경에 맞는 에러 응답 반환
         if (isSanctioned(user)) {
-            sendSanctionResponse(response, user);
+            if (redirectUri.isPresent()) {
+                handleWebSanctionResponse(request, response, user, redirectUri.get());
+            } else {
+                sendSanctionResponse(response, user);
+            }
             return;
         }
         
@@ -55,32 +79,102 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String refreshToken = tokenProvider.createRefreshToken(user.getEmail());
         authService.saveRefreshToken(user.getId(), refreshToken);
 
+        // 웹 요청(쿠키 있음)과 앱 요청(쿠키 없음)에 따른 성공 응답 처리
+        if (redirectUri.isPresent()) {
+            handleWebSuccessResponse(request, response, accessToken, refreshToken, user, role, redirectUri.get());
+        } else {
+            sendAppSuccessResponse(response, accessToken, refreshToken, user, role);
+        }
+    }
+
+    /**
+     * 클라이언트(웹)가 보낸 리다이렉트 대상 주소 쿠키를 추출합니다.
+     */
+    private Optional<String> getRedirectUriFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> REDIRECT_URI_PARAM_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .map(value -> URLDecoder.decode(value, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * 웹 관리자 페이지를 위한 성공 응답 처리: 쿼리 파라미터에 토큰을 실어 리다이렉트합니다.
+     */
+    private void handleWebSuccessResponse(HttpServletRequest request, HttpServletResponse response, String accessToken, String refreshToken, User user, String role, String targetUrl) throws IOException {
+        String url = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("status", "SUCCESS")
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .queryParam("onboarded", user.isOnboarded())
+                .queryParam("role", role)
+                .build().toUriString();
+
+        clearRedirectCookie(request, response);
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    /**
+     * 웹 관리자 페이지를 위한 일반 에러 응답 처리: 쿼리 파라미터에 에러 정보를 실어 리다이렉트합니다.
+     */
+    private void handleWebErrorResponse(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode, String targetUrl) throws IOException {
+        String url = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("status", "ERROR")
+                .queryParam("code", errorCode.getCode())
+                .queryParam("reason", errorCode.getMessage())
+                .build().toUriString();
+
+        clearRedirectCookie(request, response);
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    /**
+     * 안드로이드 앱을 위한 성공 응답 처리: 기존 규격대로 JSON 데이터를 반환합니다.
+     */
+    private void sendAppSuccessResponse(HttpServletResponse response, String accessToken, String refreshToken, User user, String role) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
 
-        // TokenResponseDto 생성 시 isOnboarded 값을 함께 전달
         String result = objectMapper.writeValueAsString(ApiResponseDto.success(
-            TokenResponseDto.of(accessToken, refreshToken, 1800L, user.isOnboarded(), role)
+                TokenResponseDto.of(accessToken, refreshToken, 1800L, user.isOnboarded(), role)
         ));
 
         response.getWriter().write(result);
     }
 
+    /**
+     * 사용자가 현재 제재 상태인지 확인합니다.
+     */
     private boolean isSanctioned(User user) {
         return user.getSanctionedUntil() != null && 
                user.getSanctionedUntil().isAfter(LocalDateTime.now());
     }
 
+    /**
+     * 웹 관리자 페이지를 위한 제재 에러 응답 처리: 쿼리 파라미터에 제재 정보를 실어 리다이렉트합니다.
+     */
+    private void handleWebSanctionResponse(HttpServletRequest request, HttpServletResponse response, User user, String targetUrl) throws IOException {
+        String reason = getLatestSanctionReason(user);
+        String url = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("status", "ERROR")
+                .queryParam("code", ErrorCode.USER_SANCTIONED.getCode())
+                .queryParam("reason", reason)
+                .queryParam("sanctionedUntil", user.getSanctionedUntil().toString())
+                .build().toUriString();
+
+        clearRedirectCookie(request, response);
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    /**
+     * 안드로이드 앱을 위한 제재 에러 응답 처리: 기존 규격대로 JSON 에러 데이터를 반환합니다.
+     */
     private void sendSanctionResponse(HttpServletResponse response, User user) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(ErrorCode.USER_SANCTIONED.getStatus().value());
 
-        // 가장 최근의 제재 사유 조회
-        String reason = sanctionHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId())
-                .stream()
-                .findFirst()
-                .map(SanctionHistory::getReason)
-                .orElse("사유가 등록되지 않았습니다.");
+        String reason = getLatestSanctionReason(user);
 
         ApiResponseDto<UserSanctionErrorResponseDto> errorResponse = ApiResponseDto.error(
             ErrorCode.USER_SANCTIONED.getCode(),
@@ -92,5 +186,27 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         );
 
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+
+    /**
+     * 사용자의 가장 최근 제재 사유를 조회합니다.
+     */
+    private String getLatestSanctionReason(User user) {
+        return sanctionHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId())
+                .stream()
+                .findFirst()
+                .map(SanctionHistory::getReason)
+                .orElse("사유가 등록되지 않았습니다.");
+    }
+
+    /**
+     * 사용이 끝난 리다이렉트용 쿠키를 브라우저에서 삭제합니다.
+     */
+    private void clearRedirectCookie(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = new Cookie(REDIRECT_URI_PARAM_COOKIE_NAME, null);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 }


### PR DESCRIPTION
## 📌 개요 (Overview)
기존 안드로이드 네이티브 앱용으로 설계된 구글 OAuth 로그인 로직을 유지하면서, 리액트 기반 웹 관리자 페이지에서도 동일한 백엔드 로직을 재사용하여 로그인이 가능하도록 호환성을 지원합니다.


## 🛠️ 작업 내용 (Changes)
  1. 백엔드 인증 핸들러 분기 처리 (OAuth2AuthenticationSuccessHandler)
   - 웹 요청 식별: 클라이언트가 전송한 redirect_uri 쿠키 존재 여부에 따라 웹/앱 요청을 구분합니다.
   - 동적 리다이렉트 구현: 웹 요청인 경우, 쿠키에 담긴 주소로 accessToken, refreshToken 등 인증 정보를 쿼리 파라미터에 실어 302 리다이렉트합니다.
   - 관리자 권한 검증: 웹 로그인은 오직 ROLE_ADMIN 권한을 가진 사용자만 가능하도록 제한 로직을 추가했습니다. (일반 유저 시도 시 G004 에러 반환)
   - 보안 및 정리: 리다이렉트 완료 후 사용된 redirect_uri 쿠키를 즉시 삭제 처리하여 보안을 강화했습니다.
   
     2. 안드로이드 호환성 유지
   - redirect_uri 쿠키가 없는 요청은 기존과 동일하게 순수 JSON 응답을 반환하므로, 기존 앱 클라이언트 코드 수정이 전혀 필요 없습니다.

## 📸 스크린샷 / 결과 (Screenshots / Results)
UI 변경사항이나 API 테스트 결과(Postman, Swagger 등)를 캡처하여 첨부해 주세요. (권장)


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #57 


