### PR TITLE
Feat/57/web oauth redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ service-account.json
 **/service-account.json
 /src/main/resources/firebase/
 /GEMINI.md
+
+### react test ###
+/react-test/

--- a/src/main/java/com/dodo/dodoserver/DodoServerApplication.java
+++ b/src/main/java/com/dodo/dodoserver/DodoServerApplication.java
@@ -2,9 +2,11 @@ package com.dodo.dodoserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class DodoServerApplication {
 

--- a/src/main/java/com/dodo/dodoserver/global/config/AppProperties.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/AppProperties.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import org.springframework.stereotype.Component;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,7 +14,7 @@ import java.util.List;
  * 애플리케이션 전용 설정 프로퍼티 클래스
  * application.yml의 'app' 프리픽스를 가진 설정들을 매핑
  */
-@Configuration
+@Component
 @ConfigurationProperties(prefix = "app")
 @Getter
 @Setter

--- a/src/main/java/com/dodo/dodoserver/global/config/AppProperties.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/AppProperties.java
@@ -1,0 +1,27 @@
+package com.dodo.dodoserver.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 애플리케이션 전용 설정 프로퍼티 클래스
+ * application.yml의 'app' 프리픽스를 가진 설정들을 매핑
+ */
+@Configuration
+@ConfigurationProperties(prefix = "app")
+@Getter
+@Setter
+public class AppProperties {
+    private final OAuth2 oauth2 = new OAuth2();
+
+    @Getter
+    @Setter
+    public static class OAuth2 {
+        private List<String> authorizedRedirectUris = new ArrayList<>();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.security.web.session.DisableEncodeUrlFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -79,7 +79,7 @@ public class SecurityConfig {
 				.successHandler(oauth2AuthenticationSuccessHandler)
 			)
 
-			.addFilterBefore(oauth2RedirectUriFilter, DisableEncodeUrlFilter.class)
+			.addFilterBefore(oauth2RedirectUriFilter, OAuth2AuthorizationRequestRedirectFilter.class)
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();

--- a/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
 import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.OAuth2RedirectUriFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -30,6 +32,7 @@ public class SecurityConfig {
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final OAuth2RedirectUriFilter oauth2RedirectUriFilter;
 	private final CorsConfigurationSource corsConfigurationSource;
 	private final ObjectMapper objectMapper;
 
@@ -76,6 +79,7 @@ public class SecurityConfig {
 				.successHandler(oauth2AuthenticationSuccessHandler)
 			)
 
+			.addFilterBefore(oauth2RedirectUriFilter, DisableEncodeUrlFilter.class)
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();

--- a/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
 import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.OAuth2RedirectUriFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class SecurityConfig {
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final OAuth2RedirectUriFilter oauth2RedirectUriFilter;
 	private final CorsConfigurationSource corsConfigurationSource;
 	private final ObjectMapper objectMapper;
 
@@ -76,7 +78,8 @@ public class SecurityConfig {
 				.successHandler(oauth2AuthenticationSuccessHandler)
 			)
 
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(oauth2RedirectUriFilter, JwtAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -5,13 +5,13 @@ import com.dodo.dodoserver.error.exception.BusinessException;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import com.dodo.dodoserver.domain.auth.dto.TokenResponseDto;
 import com.dodo.dodoserver.domain.auth.service.AuthService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -23,7 +23,6 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 /*
@@ -41,12 +40,10 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private final JwtTokenProvider tokenProvider;
     private final AuthService authService;
-    private final UserRepository userRepository; // 추가: 유저 조회를 위함
+    private final UserRepository userRepository;
     private final SanctionHistoryRepository sanctionHistoryRepository;
     private final ObjectMapper objectMapper;
-
-    @Value("${app.oauth2.authorized-redirect-uris}")
-    private List<String> authorizedRedirectUris;
+    private final AppProperties appProperties;
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
@@ -240,7 +237,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
      * 요청된 URI가 허용된 패턴 중 하나와 일치하는지 확인합니다. (Open Redirect 및 토큰 탈취 방어)
      */
     private boolean isAuthorizedRedirectUri(String uri) {
-        return authorizedRedirectUris.stream()
+        return appProperties.getOauth2().getAuthorizedRedirectUris().stream()
                 .anyMatch(pattern -> pathMatcher.match(pattern, uri));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -11,9 +11,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -21,6 +23,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /*
@@ -41,6 +44,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final UserRepository userRepository; // 추가: 유저 조회를 위함
     private final SanctionHistoryRepository sanctionHistoryRepository;
     private final ObjectMapper objectMapper;
+
+    @Value("${app.oauth2.authorized-redirect-uris}")
+    private List<String> authorizedRedirectUris;
+
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     private static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
 
@@ -103,6 +111,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
      * 웹 관리자 페이지를 위한 성공 응답 처리: 쿼리 파라미터에 토큰을 실어 리다이렉트합니다.
      */
     private void handleWebSuccessResponse(HttpServletRequest request, HttpServletResponse response, String accessToken, String refreshToken, User user, String role, String targetUrl) throws IOException {
+        if (!isAuthorizedRedirectUri(targetUrl)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized redirect URI");
+            return;
+        }
+
         String url = UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("status", "SUCCESS")
                 .queryParam("accessToken", accessToken)
@@ -120,6 +133,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
      * 웹 관리자 페이지를 위한 일반 에러 응답 처리: 쿼리 파라미터에 에러 정보를 실어 리다이렉트합니다.
      */
     private void handleWebErrorResponse(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode, String targetUrl) throws IOException {
+        if (!isAuthorizedRedirectUri(targetUrl)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized redirect URI");
+            return;
+        }
+
         String url = UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("status", "ERROR")
                 .queryParam("code", errorCode.getCode())
@@ -157,6 +175,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
      * 웹 관리자 페이지를 위한 제재 에러 응답 처리: 쿼리 파라미터에 제재 정보를 실어 리다이렉트합니다.
      */
     private void handleWebSanctionResponse(HttpServletRequest request, HttpServletResponse response, User user, String targetUrl) throws IOException {
+        if (!isAuthorizedRedirectUri(targetUrl)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized redirect URI");
+            return;
+        }
+
         String reason = getLatestSanctionReason(user);
         String url = UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("status", "ERROR")
@@ -211,5 +234,13 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         cookie.setHttpOnly(true);
         cookie.setMaxAge(0);
         response.addCookie(cookie);
+    }
+
+    /**
+     * 요청된 URI가 허용된 패턴 중 하나와 일치하는지 확인합니다. (Open Redirect 및 토큰 탈취 방어)
+     */
+    private boolean isAuthorizedRedirectUri(String uri) {
+        return authorizedRedirectUris.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, uri));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -109,6 +109,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .queryParam("refreshToken", refreshToken)
                 .queryParam("onboarded", user.isOnboarded())
                 .queryParam("role", role)
+                .encode()
                 .build().toUriString();
 
         clearRedirectCookie(request, response);
@@ -123,6 +124,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .queryParam("status", "ERROR")
                 .queryParam("code", errorCode.getCode())
                 .queryParam("reason", errorCode.getMessage())
+                .encode()
                 .build().toUriString();
 
         clearRedirectCookie(request, response);
@@ -161,6 +163,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .queryParam("code", ErrorCode.USER_SANCTIONED.getCode())
                 .queryParam("reason", reason)
                 .queryParam("sanctionedUntil", user.getSanctionedUntil().toString())
+                .encode()
                 .build().toUriString();
 
         clearRedirectCookie(request, response);

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -7,15 +7,21 @@ import com.dodo.dodoserver.domain.auth.dto.TokenResponseDto;
 import com.dodo.dodoserver.domain.auth.service.AuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
 
 /*
   소셜 로그인(OAuth2)이 최종 성공했을 때 실행되는 핸들러
@@ -36,6 +42,12 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final SanctionHistoryRepository sanctionHistoryRepository;
     private final ObjectMapper objectMapper;
 
+    private static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+
+    /**
+     * OAuth2 로그인이 성공했을 때 호출되는 메인 핸들러 메서드
+     * 쿠키 존재 여부에 따라 웹(리다이렉트)과 앱(JSON) 응답을 분기합니다.
+     */
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
@@ -43,9 +55,21 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         User user = userRepository.findById(principal.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // 제재 여부 확인
+        Optional<String> redirectUri = getRedirectUriFromCookie(request);
+
+        // 웹 로그인 시도 시 관리자 권한 확인
+        if (redirectUri.isPresent() && !"ROLE_ADMIN".equals(principal.getRole())) {
+            handleWebErrorResponse(request, response, ErrorCode.HANDLE_ACCESS_DENIED, redirectUri.get());
+            return;
+        }
+
+        // 제재된 사용자인 경우 각 환경에 맞는 에러 응답 반환
         if (isSanctioned(user)) {
-            sendSanctionResponse(response, user);
+            if (redirectUri.isPresent()) {
+                handleWebSanctionResponse(request, response, user, redirectUri.get());
+            } else {
+                sendSanctionResponse(response, user);
+            }
             return;
         }
         
@@ -55,32 +79,102 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String refreshToken = tokenProvider.createRefreshToken(user.getEmail());
         authService.saveRefreshToken(user.getId(), refreshToken);
 
+        // 웹 요청(쿠키 있음)과 앱 요청(쿠키 없음)에 따른 성공 응답 처리
+        if (redirectUri.isPresent()) {
+            handleWebSuccessResponse(request, response, accessToken, refreshToken, user, role, redirectUri.get());
+        } else {
+            sendAppSuccessResponse(response, accessToken, refreshToken, user, role);
+        }
+    }
+
+    /**
+     * 클라이언트(웹)가 보낸 리다이렉트 대상 주소 쿠키를 추출합니다.
+     */
+    private Optional<String> getRedirectUriFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> REDIRECT_URI_PARAM_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .map(value -> URLDecoder.decode(value, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * 웹 관리자 페이지를 위한 성공 응답 처리: 쿼리 파라미터에 토큰을 실어 리다이렉트합니다.
+     */
+    private void handleWebSuccessResponse(HttpServletRequest request, HttpServletResponse response, String accessToken, String refreshToken, User user, String role, String targetUrl) throws IOException {
+        String url = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("status", "SUCCESS")
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .queryParam("onboarded", user.isOnboarded())
+                .queryParam("role", role)
+                .build().toUriString();
+
+        clearRedirectCookie(request, response);
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    /**
+     * 웹 관리자 페이지를 위한 일반 에러 응답 처리: 쿼리 파라미터에 에러 정보를 실어 리다이렉트합니다.
+     */
+    private void handleWebErrorResponse(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode, String targetUrl) throws IOException {
+        String url = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("status", "ERROR")
+                .queryParam("code", errorCode.getCode())
+                .queryParam("reason", errorCode.getMessage())
+                .build().toUriString();
+
+        clearRedirectCookie(request, response);
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    /**
+     * 안드로이드 앱을 위한 성공 응답 처리: 기존 규격대로 JSON 데이터를 반환합니다.
+     */
+    private void sendAppSuccessResponse(HttpServletResponse response, String accessToken, String refreshToken, User user, String role) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
 
-        // TokenResponseDto 생성 시 isOnboarded 값을 함께 전달
         String result = objectMapper.writeValueAsString(ApiResponseDto.success(
-            TokenResponseDto.of(accessToken, refreshToken, 1800L, user.isOnboarded(), role)
+                TokenResponseDto.of(accessToken, refreshToken, 1800L, user.isOnboarded(), role)
         ));
 
         response.getWriter().write(result);
     }
 
+    /**
+     * 사용자가 현재 제재 상태인지 확인합니다.
+     */
     private boolean isSanctioned(User user) {
         return user.getSanctionedUntil() != null && 
                user.getSanctionedUntil().isAfter(LocalDateTime.now());
     }
 
+    /**
+     * 웹 관리자 페이지를 위한 제재 에러 응답 처리: 쿼리 파라미터에 제재 정보를 실어 리다이렉트합니다.
+     */
+    private void handleWebSanctionResponse(HttpServletRequest request, HttpServletResponse response, User user, String targetUrl) throws IOException {
+        String reason = getLatestSanctionReason(user);
+        String url = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("status", "ERROR")
+                .queryParam("code", ErrorCode.USER_SANCTIONED.getCode())
+                .queryParam("reason", reason)
+                .queryParam("sanctionedUntil", user.getSanctionedUntil().toString())
+                .build().toUriString();
+
+        clearRedirectCookie(request, response);
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    /**
+     * 안드로이드 앱을 위한 제재 에러 응답 처리: 기존 규격대로 JSON 에러 데이터를 반환합니다.
+     */
     private void sendSanctionResponse(HttpServletResponse response, User user) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(ErrorCode.USER_SANCTIONED.getStatus().value());
 
-        // 가장 최근의 제재 사유 조회
-        String reason = sanctionHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId())
-                .stream()
-                .findFirst()
-                .map(SanctionHistory::getReason)
-                .orElse("사유가 등록되지 않았습니다.");
+        String reason = getLatestSanctionReason(user);
 
         ApiResponseDto<UserSanctionErrorResponseDto> errorResponse = ApiResponseDto.error(
             ErrorCode.USER_SANCTIONED.getCode(),
@@ -92,5 +186,27 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         );
 
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+
+    /**
+     * 사용자의 가장 최근 제재 사유를 조회합니다.
+     */
+    private String getLatestSanctionReason(User user) {
+        return sanctionHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId())
+                .stream()
+                .findFirst()
+                .map(SanctionHistory::getReason)
+                .orElse("사유가 등록되지 않았습니다.");
+    }
+
+    /**
+     * 사용이 끝난 리다이렉트용 쿠키를 브라우저에서 삭제합니다.
+     */
+    private void clearRedirectCookie(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = new Cookie(REDIRECT_URI_PARAM_COOKIE_NAME, null);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
@@ -1,21 +1,20 @@
 package com.dodo.dodoserver.global.security;
 
+import com.dodo.dodoserver.global.config.AppProperties;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 /**
  * OAuth2 인증 시작 시 쿼리 파라미터로 전달된 redirect_uri를 쿠키에 저장하는 필터입니다.
@@ -23,14 +22,13 @@ import java.util.List;
  */
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class OAuth2RedirectUriFilter extends OncePerRequestFilter {
 
     private static final String REDIRECT_URI_PARAM = "redirect_uri";
     private static final String AUTHORIZATION_ENDPOINT_PREFIX = "/oauth2/authorization/";
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
-
-    @Value("${app.oauth2.authorized-redirect-uris}")
-    private List<String> authorizedRedirectUris;
+    private final AppProperties appProperties;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -62,7 +60,7 @@ public class OAuth2RedirectUriFilter extends OncePerRequestFilter {
      * AntPathMatcher를 사용하여 요청된 URI가 허용된 패턴 중 하나와 일치하는지 확인합니다.
      */
     private boolean isAuthorizedRedirectUri(String uri) {
-        return authorizedRedirectUris.stream()
+        return appProperties.getOauth2().getAuthorizedRedirectUris().stream()
                 .anyMatch(pattern -> pathMatcher.match(pattern, uri));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
@@ -1,0 +1,47 @@
+package com.dodo.dodoserver.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * OAuth2 인증 시작 시 쿼리 파라미터로 전달된 redirect_uri를 쿠키에 저장하는 필터입니다.
+ * 이를 통해 도메인이 다른 프론트엔드 환경에서도 동적 리다이렉트가 가능해집니다.
+ */
+@Component
+public class OAuth2RedirectUriFilter extends OncePerRequestFilter {
+
+    private static final String REDIRECT_URI_PARAM = "redirect_uri";
+    private static final String AUTHORIZATION_ENDPOINT_PREFIX = "/oauth2/authorization/";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        
+        // 1. OAuth2 인증 시작 요청인지 확인 (예: /oauth2/authorization/google)
+        if (request.getRequestURI().startsWith(AUTHORIZATION_ENDPOINT_PREFIX)) {
+            String redirectUri = request.getParameter(REDIRECT_URI_PARAM);
+            
+            // 2. redirect_uri 파라미터가 존재하면 쿠키에 저장
+            if (redirectUri != null && !redirectUri.isBlank()) {
+                Cookie cookie = new Cookie(REDIRECT_URI_PARAM, URLEncoder.encode(redirectUri, StandardCharsets.UTF_8));
+                cookie.setPath("/");
+                cookie.setHttpOnly(true);
+                cookie.setMaxAge(300); // 5분간 유효
+                
+                // 도메인이 다른 웹 환경에서 전달된 파라미터를 백엔드 도메인의 쿠키로 굽습니다.
+                response.addCookie(cookie);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
@@ -49,6 +49,8 @@ public class OAuth2RedirectUriFilter extends OncePerRequestFilter {
                     response.addCookie(cookie);
                 } else {
                     log.warn("Unauthorized redirect_uri attempted: {}", redirectUri);
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized redirect URI");
+                    return; // 비인가 주소인 경우 여기서 즉시 중단
                 }
             }
         }

--- a/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
+++ b/src/main/java/com/dodo/dodoserver/global/security/OAuth2RedirectUriFilter.java
@@ -5,43 +5,64 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import org.springframework.util.AntPathMatcher;
 
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 /**
  * OAuth2 인증 시작 시 쿼리 파라미터로 전달된 redirect_uri를 쿠키에 저장하는 필터입니다.
- * 이를 통해 도메인이 다른 프론트엔드 환경에서도 동적 리다이렉트가 가능해집니다.
+ * AntPathMatcher를 사용하여 와일드카드가 포함된 패턴 기반 검증을 지원합니다.
  */
 @Component
+@Slf4j
 public class OAuth2RedirectUriFilter extends OncePerRequestFilter {
 
     private static final String REDIRECT_URI_PARAM = "redirect_uri";
     private static final String AUTHORIZATION_ENDPOINT_PREFIX = "/oauth2/authorization/";
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Value("${app.oauth2.authorized-redirect-uris}")
+    private List<String> authorizedRedirectUris;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         
-        // 1. OAuth2 인증 시작 요청인지 확인 (예: /oauth2/authorization/google)
+        // 1. OAuth2 인증 시작 요청인지 확인
         if (request.getRequestURI().startsWith(AUTHORIZATION_ENDPOINT_PREFIX)) {
             String redirectUri = request.getParameter(REDIRECT_URI_PARAM);
             
-            // 2. redirect_uri 파라미터가 존재하면 쿠키에 저장
+            // 2. redirect_uri 파라미터가 존재하면 패턴 검증 후 쿠키에 저장
             if (redirectUri != null && !redirectUri.isBlank()) {
-                Cookie cookie = new Cookie(REDIRECT_URI_PARAM, URLEncoder.encode(redirectUri, StandardCharsets.UTF_8));
-                cookie.setPath("/");
-                cookie.setHttpOnly(true);
-                cookie.setMaxAge(300); // 5분간 유효
-                
-                // 도메인이 다른 웹 환경에서 전달된 파라미터를 백엔드 도메인의 쿠키로 굽습니다.
-                response.addCookie(cookie);
+                if (isAuthorizedRedirectUri(redirectUri)) {
+                    Cookie cookie = new Cookie(REDIRECT_URI_PARAM, URLEncoder.encode(redirectUri, StandardCharsets.UTF_8));
+                    cookie.setPath("/");
+                    cookie.setHttpOnly(true);
+                    cookie.setMaxAge(300);
+                    
+                    response.addCookie(cookie);
+                } else {
+                    log.warn("Unauthorized redirect_uri attempted: {}", redirectUri);
+                }
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    /**
+     * AntPathMatcher를 사용하여 요청된 URI가 허용된 패턴 중 하나와 일치하는지 확인합니다.
+     */
+    private boolean isAuthorizedRedirectUri(String uri) {
+        return authorizedRedirectUris.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, uri));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,13 @@ jwt:
     access: ${JWT_EXPIRATION_ACCESS}
     refresh: ${JWT_EXPIRATION_REFRESH}
 
+app:
+  oauth2:
+    authorized-redirect-uris:
+      - http://localhost:3000/admin/login/callback
+      - https://sw-capstone-frontend-*-jeonguihoons-projects.vercel.app/admin/login/callback
+      - https://sw-capstone-frontend.vercel.app/admin/login/callback
+
 logging:
   level:
     org.springframework.web: INFO

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.dodo.dodoserver.domain.admin.nest.controller;
 
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -50,6 +51,9 @@ class AdminCommentControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
@@ -4,6 +4,7 @@ import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -66,6 +67,9 @@ class AdminNestControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/notice/controller/AdminNoticeControllerTest.java
@@ -4,6 +4,7 @@ import com.dodo.dodoserver.domain.admin.notice.dto.NoticeRequestDto;
 import com.dodo.dodoserver.domain.admin.notice.service.AdminNoticeService;
 import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
 import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -62,6 +63,9 @@ class AdminNoticeControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportControllerTest.java
@@ -7,6 +7,7 @@ import com.dodo.dodoserver.domain.admin.report.service.AdminReportService;
 import com.dodo.dodoserver.domain.report.entity.ReportReason;
 import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -64,6 +65,9 @@ class AdminReportControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminControllerTest.java
@@ -7,6 +7,7 @@ import com.dodo.dodoserver.domain.admin.user.entity.SanctionType;
 import com.dodo.dodoserver.domain.admin.user.service.AdminService;
 import com.dodo.dodoserver.domain.user.entity.Role;
 import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -69,6 +70,9 @@ class AdminControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminEmailWhitelistControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminEmailWhitelistControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.admin.user.controller;
 import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistRequestDto;
 import com.dodo.dodoserver.domain.admin.user.dto.AdminEmailWhitelistResponseDto;
 import com.dodo.dodoserver.domain.admin.user.service.AdminEmailWhitelistService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -60,6 +61,9 @@ class AdminEmailWhitelistControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/auth/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.auth.controller;
 import com.dodo.dodoserver.domain.auth.dto.TokenReissueRequestDto;
 import com.dodo.dodoserver.domain.auth.dto.TokenResponseDto;
 import com.dodo.dodoserver.domain.auth.service.AuthService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -58,6 +59,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/category/controller/CategoryControllerTest.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.category.controller;
 
 import com.dodo.dodoserver.domain.category.dto.CategoryResponseDto;
 import com.dodo.dodoserver.domain.category.service.CategoryService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
 import com.dodo.dodoserver.global.security.JwtTokenProvider;
@@ -56,6 +57,9 @@ class CategoryControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     /**
      * JwtAuthenticationFilter를 MockitoBean으로 주입하면 실제 필터 로직이 실행되지 않음.

--- a/src/test/java/com/dodo/dodoserver/domain/mypage/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/mypage/controller/MyPageControllerTest.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.mypage.controller;
 
 import com.dodo.dodoserver.domain.mypage.dto.*;
 import com.dodo.dodoserver.domain.mypage.service.MyPageService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -57,6 +58,9 @@ class MyPageControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestDraftControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestDraftControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.nest.controller;
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.dto.NestDraftPublishRequestDto;
 import com.dodo.dodoserver.domain.nest.service.NestDraftService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -60,6 +61,9 @@ class NestDraftControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestGpsControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestGpsControllerTest.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.nest.controller;
 
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.service.NestService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -62,6 +63,9 @@ class NestGpsControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/controller/NestPostControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.nest.controller;
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.entity.ReactionType;
 import com.dodo.dodoserver.domain.nest.service.NestService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -61,6 +62,9 @@ class NestPostControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/notice/controller/NoticeControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.notice.controller;
 import com.dodo.dodoserver.domain.notice.dto.NoticeResponseDto;
 import com.dodo.dodoserver.domain.notice.entity.NoticeCategory;
 import com.dodo.dodoserver.domain.notice.service.NoticeService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -55,6 +56,9 @@ class NoticeControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/report/controller/ReportControllerTest.java
@@ -4,6 +4,7 @@ import com.dodo.dodoserver.domain.report.dto.ReportRequestDto;
 import com.dodo.dodoserver.domain.report.entity.ReportReason;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.domain.report.service.ReportService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -58,6 +59,9 @@ class ReportControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/DeviceControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/DeviceControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.user.controller;
 import com.dodo.dodoserver.domain.user.dto.DeviceRequestDto;
 import com.dodo.dodoserver.domain.user.entity.DeviceType;
 import com.dodo.dodoserver.domain.user.service.UserDeviceService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +58,9 @@ class DeviceControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.user.dto.ProfileUpdateRequestDto;
 import com.dodo.dodoserver.domain.user.dto.UserProfileResponseDto;
 import com.dodo.dodoserver.domain.user.service.UserService;
 import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -60,6 +61,9 @@ class UserControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/user/controller/UserInterestControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.user.controller;
 import com.dodo.dodoserver.domain.category.dto.CategoryResponseDto;
 import com.dodo.dodoserver.domain.user.dto.UserInterestRequestDto;
 import com.dodo.dodoserver.domain.user.service.UserInterestService;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
 import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
@@ -60,6 +61,9 @@ class UserInterestControllerTest {
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
 
     @BeforeEach
     void setUp() throws ServletException, IOException {

--- a/src/test/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,216 @@
+package com.dodo.dodoserver.global.security;
+
+import com.dodo.dodoserver.domain.admin.user.dao.SanctionHistoryRepository;
+import com.dodo.dodoserver.domain.admin.user.entity.SanctionHistory;
+import com.dodo.dodoserver.domain.auth.service.AuthService;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.Role;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2AuthenticationSuccessHandlerTest {
+
+    @InjectMocks
+    private OAuth2AuthenticationSuccessHandler successHandler;
+
+    @Mock
+    private JwtTokenProvider tokenProvider;
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SanctionHistoryRepository sanctionHistoryRepository;
+
+    @Mock
+    private RedirectStrategy redirectStrategy;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    private User user;
+    private UserPrincipal principal;
+    private final String AUTHORIZED_REDIRECT_URI = "http://localhost:3000/admin/login/callback";
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .nickname("tester")
+                .role(Role.ADMIN)
+                .build();
+
+        principal = UserPrincipal.create(1L, "test@example.com", "ROLE_ADMIN");
+
+        // ReflectionTestUtils를 사용하여 @Value 필드 주입
+        ReflectionTestUtils.setField(successHandler, "authorizedRedirectUris", List.of(AUTHORIZED_REDIRECT_URI));
+        
+        // RedirectStrategy 설정 (getRedirectStrategy().sendRedirect() 호출 대응)
+        successHandler.setRedirectStrategy(redirectStrategy);
+    }
+
+    @Test
+    @DisplayName("앱 요청 시 (쿠키 없음) JSON 응답을 반환한다")
+    void onAuthenticationSuccess_AppRequest_ReturnsJson() throws IOException {
+        // given
+        when(authentication.getPrincipal()).thenReturn(principal);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(request.getCookies()).thenReturn(null);
+        when(tokenProvider.createAccessToken(anyLong(), anyString(), anyString())).thenReturn("access-token");
+        when(tokenProvider.createRefreshToken(anyString())).thenReturn("refresh-token");
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        // when
+        successHandler.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        verify(response).setContentType("application/json;charset=UTF-8");
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        String body = stringWriter.toString();
+        assertTrue(body.contains("access-token"));
+        assertTrue(body.contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    @DisplayName("관리자 웹 로그인 성공 시 리다이렉트한다")
+    void onAuthenticationSuccess_WebAdminRequest_RedirectsToTargetUrl() throws IOException {
+        // given
+        when(authentication.getPrincipal()).thenReturn(principal);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        
+        Cookie redirectCookie = new Cookie("redirect_uri", AUTHORIZED_REDIRECT_URI);
+        when(request.getCookies()).thenReturn(new Cookie[]{redirectCookie});
+        
+        when(tokenProvider.createAccessToken(anyLong(), anyString(), anyString())).thenReturn("access-token");
+        when(tokenProvider.createRefreshToken(anyString())).thenReturn("refresh-token");
+
+        // when
+        successHandler.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(redirectStrategy).sendRedirect(eq(request), eq(response), captor.capture());
+        String url = captor.getValue();
+        assertTrue(url.contains("status=SUCCESS"));
+        assertTrue(url.contains("accessToken=access-token"));
+        assertTrue(url.contains("role=ROLE_ADMIN"));
+        
+        // 쿠키 삭제 확인
+        verify(response).addCookie(argThat(cookie -> 
+            "redirect_uri".equals(cookie.getName()) && cookie.getMaxAge() == 0
+        ));
+    }
+
+    @Test
+    @DisplayName("일반 유저가 웹 로그인 시도 시 권한 에러와 함께 리다이렉트한다")
+    void onAuthenticationSuccess_WebUserRequest_RedirectsWithError() throws IOException {
+        // given
+        UserPrincipal userPrincipal = UserPrincipal.create(1L, "user@example.com", "ROLE_USER");
+        when(authentication.getPrincipal()).thenReturn(userPrincipal);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        
+        Cookie redirectCookie = new Cookie("redirect_uri", AUTHORIZED_REDIRECT_URI);
+        when(request.getCookies()).thenReturn(new Cookie[]{redirectCookie});
+
+        // when
+        successHandler.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(redirectStrategy).sendRedirect(eq(request), eq(response), captor.capture());
+        String url = captor.getValue();
+        assertTrue(url.contains("status=ERROR"));
+        assertTrue(url.contains("code=" + ErrorCode.HANDLE_ACCESS_DENIED.getCode()));
+    }
+
+    @Test
+    @DisplayName("제재된 유저가 웹 로그인 시도 시 제재 정보와 함께 리다이렉트한다")
+    void onAuthenticationSuccess_WebSanctinedUserRequest_RedirectsWithSanctionInfo() throws IOException {
+        // given
+        user.setSanctionedUntil(LocalDateTime.now().plusDays(7));
+        when(authentication.getPrincipal()).thenReturn(principal);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        
+        Cookie redirectCookie = new Cookie("redirect_uri", AUTHORIZED_REDIRECT_URI);
+        when(request.getCookies()).thenReturn(new Cookie[]{redirectCookie});
+
+        SanctionHistory history = SanctionHistory.builder()
+                .reason("부적절한 게시글 작성")
+                .build();
+        when(sanctionHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
+                .thenReturn(List.of(history));
+
+        // when
+        successHandler.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(redirectStrategy).sendRedirect(eq(request), eq(response), captor.capture());
+        String url = captor.getValue();
+        assertTrue(url.contains("status=ERROR"));
+        assertTrue(url.contains("code=" + ErrorCode.USER_SANCTIONED.getCode()));
+        assertTrue(url.contains("reason="));
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 리다이렉트 URI 쿠키 발견 시 403 에러를 반환한다")
+    void onAuthenticationSuccess_WebUnauthorizedRedirectUri_ReturnsForbidden() throws IOException {
+        // given
+        when(authentication.getPrincipal()).thenReturn(principal);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        
+        Cookie redirectCookie = new Cookie("redirect_uri", "http://malicious-site.com");
+        when(request.getCookies()).thenReturn(new Cookie[]{redirectCookie});
+
+        // when
+        successHandler.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), anyString());
+        verify(redirectStrategy, never()).sendRedirect(any(), any(), anyString());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/dodo/dodoserver/global/security/OAuth2AuthenticationSuccessHandlerTest.java
@@ -7,6 +7,7 @@ import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.Role;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.global.config.AppProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,7 +23,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.RedirectStrategy;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -57,6 +57,9 @@ class OAuth2AuthenticationSuccessHandlerTest {
     private RedirectStrategy redirectStrategy;
 
     @Spy
+    private AppProperties appProperties = new AppProperties();
+
+    @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock
@@ -83,10 +86,10 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
         principal = UserPrincipal.create(1L, "test@example.com", "ROLE_ADMIN");
 
-        // ReflectionTestUtils를 사용하여 @Value 필드 주입
-        ReflectionTestUtils.setField(successHandler, "authorizedRedirectUris", List.of(AUTHORIZED_REDIRECT_URI));
+        // AppProperties 설정
+        appProperties.getOauth2().getAuthorizedRedirectUris().add(AUTHORIZED_REDIRECT_URI);
         
-        // RedirectStrategy 설정 (getRedirectStrategy().sendRedirect() 호출 대응)
+        // RedirectStrategy 설정
         successHandler.setRedirectStrategy(redirectStrategy);
     }
 


### PR DESCRIPTION
## 📌 개요 (Overview)
 기존 안드로이드 네이티브 앱 전용이었던 구글 OAuth 로그인 로직을 확장하여, 리액트 기반 웹 관리자 페이지에서도 안전하고 유연하게 로그인을 처리할 수 있도록 개선했습니다. 특히, 프론트엔드와 백엔드의 도메인이 다른 환경에서도 동적 리다이렉트가 정상 작동하도록 보안 및 아키텍처를 보강했습니다.

## 🛠️ 작업 내용 (Changes)
  1. 동적 리다이렉트 URI 필터 추가 (OAuth2RedirectUriFilter)
   - 도메인 격리 문제 해결: 프론트엔드에서 직접 쿠키를 굽지 않고, 인증 시작 시 쿼리 파라미터(redirect_uri)로 주소를 전달받습니다.
   - 백엔드 도메인 쿠키 발급: 전달받은 주소를 백엔드 도메인의 보안 쿠키(HttpOnly)로 저장하여, 인증 완료 후 브라우저 정책에 방해받지 않고 프론트엔드로 정확히 리다이렉트할 수 있도록 구현했습니다.

  2. 인증 성공 핸들러 분기 및 고도화 (OAuth2AuthenticationSuccessHandler)
   - 응답 분기 로직: redirect_uri 쿠키 여부에 따라 App(JSON 반환)과 Web(302 리다이렉트) 응답을 자동 분기합니다.
   - 웹 관리자 권한 제어: 웹을 통한 로그인은 오직 ROLE_ADMIN 권한 소유자만 가능하도록 제한했습니다. 일반 유저 시도 시 G004(접근 권한 없음) 에러와 함께 리다이렉트됩니다.
   - 보안 강화: 인증 완료 직후 사용된 리다이렉트 쿠키를 즉시 파기하여 일회성 사용을 보장합니다.

  3. 보안 및 예외 처리
   - 유저 제재(U006) 시에도 웹 환경에서는 콜백 URL로 제재 사유와 만료일을 포함하여 리다이렉트하도록 예외 응답을 고도화했습니다.
   - 모든 주요 로직에 상세 주석을 추가하여 유지보수성을 높였습니다.

  4. 통합 테스트 환경 구축 (/react-test)
   - Vite와 Zustand를 활용한 독립적인 리액트 테스트 앱을 추가했습니다.
   - 백엔드로부터 전달받은 accessToken과 refreshToken을 전역 상태로 저장하고 관리하는 실제 연동 예시를 포함합니다.


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #57 

## 📝 추가 참고 사항 (Additional Notes)
   - XSS 방지: 리액트 예시 코드에서 토큰을 localStorage 대신 메모리(Zustand)에 저장하도록 구현 가이드를 제시했습니다.
   - CSRF/도메인 정책: 백엔드 도메인에서 쿠키를 직접 관리함으로써 브라우저의 도메인 정책을 준수하면서도 유연한 리다이렉트를 지원합니다
