### PR TITLE
Feat/61/admin statistics: 어드민 대시보드 통계 API 

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.admin.statistics.controller;
 
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.service.AdminStatisticsService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
@@ -20,5 +21,10 @@ public class AdminStatisticsController {
     @GetMapping("/summary")
     public ApiResponseDto<AdminSummaryResponseDto> getSummaryStats() {
         return ApiResponseDto.success(adminStatisticsService.getSummaryStats());
+    }
+
+    @GetMapping("/postcards/ratio")
+    public ApiResponseDto<AdminPostcardRatioResponseDto> getPostcardRatioStats() {
+        return ApiResponseDto.success(adminStatisticsService.getPostcardRatioStats());
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
@@ -2,13 +2,17 @@ package com.dodo.dodoserver.domain.admin.statistics.controller;
 
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.service.AdminStatisticsService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +30,11 @@ public class AdminStatisticsController {
     @GetMapping("/postcards/ratio")
     public ApiResponseDto<AdminPostcardRatioResponseDto> getPostcardRatioStats() {
         return ApiResponseDto.success(adminStatisticsService.getPostcardRatioStats());
+    }
+
+    @GetMapping("/trends")
+    public ApiResponseDto<List<AdminTrendResponseDto>> getTrafficTrends(
+            @RequestParam(defaultValue = "7") int days) {
+        return ApiResponseDto.success(adminStatisticsService.getTrafficTrends(days));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
@@ -6,12 +6,13 @@ import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.service.AdminStatisticsService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -27,13 +28,16 @@ public class AdminStatisticsController {
     }
 
     @GetMapping("/postcards/ratio")
-    public ApiResponseDto<AdminPostcardRatioResponseDto> getPostcardRatioStats() {
-        return ApiResponseDto.success(adminStatisticsService.getPostcardRatioStats());
+    public ApiResponseDto<AdminPostcardRatioResponseDto> getPostcardRatioStats(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        return ApiResponseDto.success(adminStatisticsService.getPostcardRatioStats(startDate, endDate));
     }
 
     @GetMapping("/trends")
     public ApiResponseDto<List<AdminTrendResponseDto>> getTrafficTrends(
-            @RequestParam(defaultValue = "7") int days) {
-        return ApiResponseDto.success(adminStatisticsService.getTrafficTrends(days));
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        return ApiResponseDto.success(adminStatisticsService.getTrafficTrends(startDate, endDate));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
@@ -5,6 +5,8 @@ import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.service.AdminStatisticsService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDate;
 import java.util.List;
 
+@Tag(name = "Admin Statistics", description = "관리자 대시보드 통계 분석 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/statistics")
@@ -22,11 +25,13 @@ public class AdminStatisticsController {
 
     private final AdminStatisticsService adminStatisticsService;
 
+    @Operation(summary = "어드민 현황판 요약 통계", description = "전체 및 당일 생성된 둥지, 댓글, 엽서의 개수를 반환합니다.")
     @GetMapping("/summary")
     public ApiResponseDto<AdminSummaryResponseDto> getSummaryStats() {
         return ApiResponseDto.success(adminStatisticsService.getSummaryStats());
     }
 
+    @Operation(summary = "엽서 교환 프로세스 효율(비율) 분석", description = "특정 기간 동안 생성된 엽서 대비 교환 완료된 엽서의 비율을 분석합니다.")
     @GetMapping("/postcards/ratio")
     public ApiResponseDto<AdminPostcardRatioResponseDto> getPostcardRatioStats(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -34,6 +39,7 @@ public class AdminStatisticsController {
         return ApiResponseDto.success(adminStatisticsService.getPostcardRatioStats(startDate, endDate));
     }
 
+    @Operation(summary = "차트 시각화용 트래픽 트렌드", description = "특정 기간 동안의 일별 생성 트렌드 데이터를 배열 형태로 반환합니다. 데이터가 없는 날짜는 0으로 보정되어 반환됩니다.")
     @GetMapping("/trends")
     public ApiResponseDto<List<AdminTrendResponseDto>> getTrafficTrends(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
@@ -17,7 +17,6 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/statistics")
-@PreAuthorize("hasRole('ADMIN')")
 public class AdminStatisticsController {
 
     private final AdminStatisticsService adminStatisticsService;

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsController.java
@@ -1,0 +1,24 @@
+package com.dodo.dodoserver.domain.admin.statistics.controller;
+
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+import com.dodo.dodoserver.domain.admin.statistics.service.AdminStatisticsService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/statistics")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminStatisticsController {
+
+    private final AdminStatisticsService adminStatisticsService;
+
+    @GetMapping("/summary")
+    public ApiResponseDto<AdminSummaryResponseDto> getSummaryStats() {
+        return ApiResponseDto.success(adminStatisticsService.getSummaryStats());
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.dodo.dodoserver.domain.admin.statistics.dao;
+
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+
+public interface AdminStatisticsRepositoryCustom {
+    AdminSummaryResponseDto getSummaryStats();
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
@@ -1,7 +1,9 @@
 package com.dodo.dodoserver.domain.admin.statistics.dao;
 
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
 
 public interface AdminStatisticsRepositoryCustom {
     AdminSummaryResponseDto getSummaryStats();
+    AdminPostcardRatioResponseDto getPostcardRatioStats();
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
@@ -2,8 +2,15 @@ package com.dodo.dodoserver.domain.admin.statistics.dao;
 
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+import com.querydsl.core.Tuple;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface AdminStatisticsRepositoryCustom {
     AdminSummaryResponseDto getSummaryStats();
     AdminPostcardRatioResponseDto getPostcardRatioStats();
+    List<Tuple> getNestTrend(LocalDateTime start, LocalDateTime end);
+    List<Tuple> getCommentTrend(LocalDateTime start, LocalDateTime end);
+    List<Tuple> getPostcardTrend(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryCustom.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface AdminStatisticsRepositoryCustom {
     AdminSummaryResponseDto getSummaryStats();
-    AdminPostcardRatioResponseDto getPostcardRatioStats();
+    AdminPostcardRatioResponseDto getPostcardRatioStats(LocalDateTime start, LocalDateTime end);
     List<Tuple> getNestTrend(LocalDateTime start, LocalDateTime end);
     List<Tuple> getCommentTrend(LocalDateTime start, LocalDateTime end);
     List<Tuple> getPostcardTrend(LocalDateTime start, LocalDateTime end);

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
@@ -81,20 +81,24 @@ public class AdminStatisticsRepositoryImpl implements AdminStatisticsRepositoryC
     }
 
     @Override
-    public AdminPostcardRatioResponseDto getPostcardRatioStats() {
+    public AdminPostcardRatioResponseDto getPostcardRatioStats(LocalDateTime start, LocalDateTime end) {
         QPostcard postcard = QPostcard.postcard;
 
         Long totalGenerated = queryFactory
                 .select(postcard.count())
                 .from(postcard)
-                .where(postcard.deletedAt.isNull())
+                .where(postcard.deletedAt.isNull(),
+                        start != null ? postcard.createdAt.goe(start) : null,
+                        end != null ? postcard.createdAt.loe(end) : null)
                 .fetchOne();
 
         Long totalDelivered = queryFactory
                 .select(postcard.count())
                 .from(postcard)
                 .where(postcard.isExchanged.isTrue(),
-                        postcard.deletedAt.isNull())
+                        postcard.deletedAt.isNull(),
+                        start != null ? postcard.createdAt.goe(start) : null,
+                        end != null ? postcard.createdAt.loe(end) : null)
                 .fetchOne();
 
         return AdminPostcardRatioResponseDto.builder()

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
@@ -59,8 +59,7 @@ public class AdminStatisticsRepositoryImpl implements AdminStatisticsRepositoryC
         Long totalPostcards = queryFactory
                 .select(postcard.count())
                 .from(postcard)
-                .where(postcard.isExchanged.isTrue(),
-                        postcard.deletedAt.isNull())
+                .where(postcard.deletedAt.isNull())
                 .fetchOne();
 
         Long todayPostcards = queryFactory

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.admin.statistics.dao;
 
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
 import com.dodo.dodoserver.domain.nest.entity.QNest;
 import com.dodo.dodoserver.domain.nest.entity.QNestComment;
@@ -72,6 +73,29 @@ public class AdminStatisticsRepositoryImpl implements AdminStatisticsRepositoryC
                 .todayComments(todayComments != null ? todayComments : 0L)
                 .totalPostcards(totalPostcards != null ? totalPostcards : 0L)
                 .todayPostcards(todayPostcards != null ? todayPostcards : 0L)
+                .build();
+    }
+
+    @Override
+    public AdminPostcardRatioResponseDto getPostcardRatioStats() {
+        QPostcard postcard = QPostcard.postcard;
+
+        Long totalGenerated = queryFactory
+                .select(postcard.count())
+                .from(postcard)
+                .where(postcard.deletedAt.isNull())
+                .fetchOne();
+
+        Long totalDelivered = queryFactory
+                .select(postcard.count())
+                .from(postcard)
+                .where(postcard.isExchanged.isTrue(),
+                        postcard.deletedAt.isNull())
+                .fetchOne();
+
+        return AdminPostcardRatioResponseDto.builder()
+                .totalGenerated(totalGenerated != null ? totalGenerated : 0L)
+                .totalDelivered(totalDelivered != null ? totalDelivered : 0L)
                 .build();
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
@@ -5,12 +5,16 @@ import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
 import com.dodo.dodoserver.domain.nest.entity.QNest;
 import com.dodo.dodoserver.domain.nest.entity.QNestComment;
 import com.dodo.dodoserver.domain.postcard.entity.QPostcard;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -97,5 +101,47 @@ public class AdminStatisticsRepositoryImpl implements AdminStatisticsRepositoryC
                 .totalGenerated(totalGenerated != null ? totalGenerated : 0L)
                 .totalDelivered(totalDelivered != null ? totalDelivered : 0L)
                 .build();
+    }
+
+    @Override
+    public List<Tuple> getNestTrend(LocalDateTime start, LocalDateTime end) {
+        QNest nest = QNest.nest;
+        StringTemplate formattedDate = Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d')", nest.createdAt);
+
+        return queryFactory
+                .select(formattedDate, nest.count())
+                .from(nest)
+                .where(nest.createdAt.between(start, end),
+                        nest.deletedAt.isNull())
+                .groupBy(formattedDate)
+                .fetch();
+    }
+
+    @Override
+    public List<Tuple> getCommentTrend(LocalDateTime start, LocalDateTime end) {
+        QNestComment comment = QNestComment.nestComment;
+        StringTemplate formattedDate = Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d')", comment.createdAt);
+
+        return queryFactory
+                .select(formattedDate, comment.count())
+                .from(comment)
+                .where(comment.createdAt.between(start, end),
+                        comment.deletedAt.isNull())
+                .groupBy(formattedDate)
+                .fetch();
+    }
+
+    @Override
+    public List<Tuple> getPostcardTrend(LocalDateTime start, LocalDateTime end) {
+        QPostcard postcard = QPostcard.postcard;
+        StringTemplate formattedDate = Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d')", postcard.createdAt);
+
+        return queryFactory
+                .select(formattedDate, postcard.count())
+                .from(postcard)
+                .where(postcard.createdAt.between(start, end),
+                        postcard.deletedAt.isNull())
+                .groupBy(formattedDate)
+                .fetch();
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.dodo.dodoserver.domain.nest.entity.QNest;
 import com.dodo.dodoserver.domain.nest.entity.QNestComment;
 import com.dodo.dodoserver.domain.postcard.entity.QPostcard;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -30,44 +31,51 @@ public class AdminStatisticsRepositoryImpl implements AdminStatisticsRepositoryC
 
         LocalDateTime todayStart = LocalDate.now().atStartOfDay();
 
-        Long totalNests = queryFactory
-                .select(nest.count())
+        Tuple nestStats = queryFactory
+                .select(
+                        nest.count(),
+                        new CaseBuilder()
+                                .when(nest.createdAt.goe(todayStart))
+                                .then(1L)
+                                .otherwise(0L)
+                                .sum()
+                )
                 .from(nest)
                 .where(nest.deletedAt.isNull())
                 .fetchOne();
 
-        Long todayNests = queryFactory
-                .select(nest.count())
-                .from(nest)
-                .where(nest.createdAt.goe(todayStart),
-                        nest.deletedAt.isNull())
-                .fetchOne();
-
-        Long totalComments = queryFactory
-                .select(comment.count())
+        Tuple commentStats = queryFactory
+                .select(
+                        comment.count(),
+                        new CaseBuilder()
+                                .when(comment.createdAt.goe(todayStart))
+                                .then(1L)
+                                .otherwise(0L)
+                                .sum()
+                )
                 .from(comment)
                 .where(comment.deletedAt.isNull())
                 .fetchOne();
 
-        Long todayComments = queryFactory
-                .select(comment.count())
-                .from(comment)
-                .where(comment.createdAt.goe(todayStart),
-                        comment.deletedAt.isNull())
-                .fetchOne();
-
-        Long totalPostcards = queryFactory
-                .select(postcard.count())
+        Tuple postcardStats = queryFactory
+                .select(
+                        postcard.count(),
+                        new CaseBuilder()
+                                .when(postcard.createdAt.goe(todayStart))
+                                .then(1L)
+                                .otherwise(0L)
+                                .sum()
+                )
                 .from(postcard)
                 .where(postcard.deletedAt.isNull())
                 .fetchOne();
 
-        Long todayPostcards = queryFactory
-                .select(postcard.count())
-                .from(postcard)
-                .where(postcard.createdAt.goe(todayStart),
-                        postcard.deletedAt.isNull())
-                .fetchOne();
+        Long totalNests = nestStats != null ? nestStats.get(0, Long.class) : 0L;
+        Long todayNests = nestStats != null ? nestStats.get(1, Long.class) : 0L;
+        Long totalComments = commentStats != null ? commentStats.get(0, Long.class) : 0L;
+        Long todayComments = commentStats != null ? commentStats.get(1, Long.class) : 0L;
+        Long totalPostcards = postcardStats != null ? postcardStats.get(0, Long.class) : 0L;
+        Long todayPostcards = postcardStats != null ? postcardStats.get(1, Long.class) : 0L;
 
         return AdminSummaryResponseDto.builder()
                 .totalNests(totalNests != null ? totalNests : 0L)

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dao/AdminStatisticsRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.dodo.dodoserver.domain.admin.statistics.dao;
+
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+import com.dodo.dodoserver.domain.nest.entity.QNest;
+import com.dodo.dodoserver.domain.nest.entity.QNestComment;
+import com.dodo.dodoserver.domain.postcard.entity.QPostcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminStatisticsRepositoryImpl implements AdminStatisticsRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public AdminSummaryResponseDto getSummaryStats() {
+        QNest nest = QNest.nest;
+        QNestComment comment = QNestComment.nestComment;
+        QPostcard postcard = QPostcard.postcard;
+
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+
+        Long totalNests = queryFactory
+                .select(nest.count())
+                .from(nest)
+                .where(nest.deletedAt.isNull())
+                .fetchOne();
+
+        Long todayNests = queryFactory
+                .select(nest.count())
+                .from(nest)
+                .where(nest.createdAt.goe(todayStart),
+                        nest.deletedAt.isNull())
+                .fetchOne();
+
+        Long totalComments = queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.deletedAt.isNull())
+                .fetchOne();
+
+        Long todayComments = queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.createdAt.goe(todayStart),
+                        comment.deletedAt.isNull())
+                .fetchOne();
+
+        Long totalPostcards = queryFactory
+                .select(postcard.count())
+                .from(postcard)
+                .where(postcard.isExchanged.isTrue(),
+                        postcard.deletedAt.isNull())
+                .fetchOne();
+
+        Long todayPostcards = queryFactory
+                .select(postcard.count())
+                .from(postcard)
+                .where(postcard.createdAt.goe(todayStart),
+                        postcard.deletedAt.isNull())
+                .fetchOne();
+
+        return AdminSummaryResponseDto.builder()
+                .totalNests(totalNests != null ? totalNests : 0L)
+                .todayNests(todayNests != null ? todayNests : 0L)
+                .totalComments(totalComments != null ? totalComments : 0L)
+                .todayComments(todayComments != null ? todayComments : 0L)
+                .totalPostcards(totalPostcards != null ? totalPostcards : 0L)
+                .todayPostcards(todayPostcards != null ? todayPostcards : 0L)
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dto/AdminPostcardRatioResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dto/AdminPostcardRatioResponseDto.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.admin.statistics.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminPostcardRatioResponseDto {
+    private Long totalGenerated;
+    private Long totalDelivered;
+    private Double deliveryRatio;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dto/AdminSummaryResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dto/AdminSummaryResponseDto.java
@@ -1,0 +1,17 @@
+package com.dodo.dodoserver.domain.admin.statistics.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminSummaryResponseDto {
+    private Long totalNests;
+    private Long todayNests;
+    private Long totalComments;
+    private Long todayComments;
+    private Long totalPostcards;
+    private Long todayPostcards;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dto/AdminTrendResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/dto/AdminTrendResponseDto.java
@@ -1,0 +1,26 @@
+package com.dodo.dodoserver.domain.admin.statistics.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminTrendResponseDto {
+    private LocalDate date;
+    private Long nestCount;
+    private Long commentCount;
+    private Long postcardCount;
+
+    public static AdminTrendResponseDto empty(LocalDate date) {
+        return AdminTrendResponseDto.builder()
+                .date(date)
+                .nestCount(0L)
+                .commentCount(0L)
+                .postcardCount(0L)
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
@@ -4,6 +4,8 @@ import com.dodo.dodoserver.domain.admin.statistics.dao.AdminStatisticsRepository
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,12 +25,15 @@ import java.util.TreeMap;
 public class AdminStatisticsService {
 
     private final AdminStatisticsRepositoryCustom adminStatisticsRepository;
+    private static final int MAX_TREND_DAYS = 365;
 
     public AdminSummaryResponseDto getSummaryStats() {
         return adminStatisticsRepository.getSummaryStats();
     }
 
     public AdminPostcardRatioResponseDto getPostcardRatioStats(LocalDate startDate, LocalDate endDate) {
+        validateDateRange(startDate, endDate);
+
         LocalDateTime start = startDate != null ? startDate.atStartOfDay() : null;
         LocalDateTime end = endDate != null ? endDate.atTime(23, 59, 59) : null;
         AdminPostcardRatioResponseDto stats = adminStatisticsRepository.getPostcardRatioStats(start, end);
@@ -50,6 +56,8 @@ public class AdminStatisticsService {
             startDate = endDate.minusDays(6); // 기본값 최근 7일
         }
 
+        validateDateRange(startDate, endDate);
+
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTime = endDate.atTime(23, 59, 59);
 
@@ -67,6 +75,17 @@ public class AdminStatisticsService {
         bindPostcardTrends(trendMap, startDateTime, endDateTime);
 
         return new ArrayList<>(trendMap.values());
+    }
+
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null) {
+            if (startDate.isAfter(endDate)) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+            if (ChronoUnit.DAYS.between(startDate, endDate) > MAX_TREND_DAYS) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
     }
 
     private void bindNestTrends(Map<LocalDate, AdminTrendResponseDto> trendMap, LocalDateTime start, LocalDateTime end) {

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
@@ -1,0 +1,19 @@
+package com.dodo.dodoserver.domain.admin.statistics.service;
+
+import com.dodo.dodoserver.domain.admin.statistics.dao.AdminStatisticsRepositoryCustom;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminStatisticsService {
+
+    private final AdminStatisticsRepositoryCustom adminStatisticsRepository;
+
+    public AdminSummaryResponseDto getSummaryStats() {
+        return adminStatisticsRepository.getSummaryStats();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
@@ -3,9 +3,18 @@ package com.dodo.dodoserver.domain.admin.statistics.service;
 import com.dodo.dodoserver.domain.admin.statistics.dao.AdminStatisticsRepositoryCustom;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
+import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 @Service
 @RequiredArgsConstructor
@@ -29,5 +38,60 @@ public class AdminStatisticsService {
 
         stats.setDeliveryRatio(ratio);
         return stats;
+    }
+
+    public List<AdminTrendResponseDto> getTrafficTrends(int days) {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(days - 1);
+
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atTime(23, 59, 59);
+
+        // 결과 맵 초기화 (날짜 순서 보장을 위해 TreeMap 사용)
+        Map<LocalDate, AdminTrendResponseDto> trendMap = new TreeMap<>();
+        for (int i = 0; i < days; i++) {
+            LocalDate date = startDate.plusDays(i);
+            trendMap.put(date, AdminTrendResponseDto.empty(date));
+        }
+
+        // 각 도메인별 데이터 조회 및 바인딩
+        bindNestTrends(trendMap, startDateTime, endDateTime);
+        bindCommentTrends(trendMap, startDateTime, endDateTime);
+        bindPostcardTrends(trendMap, startDateTime, endDateTime);
+
+        return new ArrayList<>(trendMap.values());
+    }
+
+    private void bindNestTrends(Map<LocalDate, AdminTrendResponseDto> trendMap, LocalDateTime start, LocalDateTime end) {
+        List<Tuple> nestTrends = adminStatisticsRepository.getNestTrend(start, end);
+        for (Tuple tuple : nestTrends) {
+            LocalDate date = LocalDate.parse(tuple.get(0, String.class));
+            Long count = tuple.get(1, Long.class);
+            if (trendMap.containsKey(date)) {
+                trendMap.get(date).setNestCount(count != null ? count : 0L);
+            }
+        }
+    }
+
+    private void bindCommentTrends(Map<LocalDate, AdminTrendResponseDto> trendMap, LocalDateTime start, LocalDateTime end) {
+        List<Tuple> commentTrends = adminStatisticsRepository.getCommentTrend(start, end);
+        for (Tuple tuple : commentTrends) {
+            LocalDate date = LocalDate.parse(tuple.get(0, String.class));
+            Long count = tuple.get(1, Long.class);
+            if (trendMap.containsKey(date)) {
+                trendMap.get(date).setCommentCount(count != null ? count : 0L);
+            }
+        }
+    }
+
+    private void bindPostcardTrends(Map<LocalDate, AdminTrendResponseDto> trendMap, LocalDateTime start, LocalDateTime end) {
+        List<Tuple> postcardTrends = adminStatisticsRepository.getPostcardTrend(start, end);
+        for (Tuple tuple : postcardTrends) {
+            LocalDate date = LocalDate.parse(tuple.get(0, String.class));
+            Long count = tuple.get(1, Long.class);
+            if (trendMap.containsKey(date)) {
+                trendMap.get(date).setPostcardCount(count != null ? count : 0L);
+            }
+        }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
@@ -1,6 +1,7 @@
 package com.dodo.dodoserver.domain.admin.statistics.service;
 
 import com.dodo.dodoserver.domain.admin.statistics.dao.AdminStatisticsRepositoryCustom;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,5 +16,18 @@ public class AdminStatisticsService {
 
     public AdminSummaryResponseDto getSummaryStats() {
         return adminStatisticsRepository.getSummaryStats();
+    }
+
+    public AdminPostcardRatioResponseDto getPostcardRatioStats() {
+        AdminPostcardRatioResponseDto stats = adminStatisticsRepository.getPostcardRatioStats();
+
+        double ratio = 0.0;
+        if (stats.getTotalGenerated() > 0) {
+            ratio = (stats.getTotalDelivered() / (double) stats.getTotalGenerated()) * 100;
+            ratio = Math.round(ratio * 100) / 100.0; // 소수점 둘째 자리까지 반올림
+        }
+
+        stats.setDeliveryRatio(ratio);
+        return stats;
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsService.java
@@ -27,8 +27,10 @@ public class AdminStatisticsService {
         return adminStatisticsRepository.getSummaryStats();
     }
 
-    public AdminPostcardRatioResponseDto getPostcardRatioStats() {
-        AdminPostcardRatioResponseDto stats = adminStatisticsRepository.getPostcardRatioStats();
+    public AdminPostcardRatioResponseDto getPostcardRatioStats(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime start = startDate != null ? startDate.atStartOfDay() : null;
+        LocalDateTime end = endDate != null ? endDate.atTime(23, 59, 59) : null;
+        AdminPostcardRatioResponseDto stats = adminStatisticsRepository.getPostcardRatioStats(start, end);
 
         double ratio = 0.0;
         if (stats.getTotalGenerated() > 0) {
@@ -40,18 +42,23 @@ public class AdminStatisticsService {
         return stats;
     }
 
-    public List<AdminTrendResponseDto> getTrafficTrends(int days) {
-        LocalDate endDate = LocalDate.now();
-        LocalDate startDate = endDate.minusDays(days - 1);
+    public List<AdminTrendResponseDto> getTrafficTrends(LocalDate startDate, LocalDate endDate) {
+        if (endDate == null) {
+            endDate = LocalDate.now();
+        }
+        if (startDate == null) {
+            startDate = endDate.minusDays(6); // 기본값 최근 7일
+        }
 
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTime = endDate.atTime(23, 59, 59);
 
         // 결과 맵 초기화 (날짜 순서 보장을 위해 TreeMap 사용)
         Map<LocalDate, AdminTrendResponseDto> trendMap = new TreeMap<>();
-        for (int i = 0; i < days; i++) {
-            LocalDate date = startDate.plusDays(i);
-            trendMap.put(date, AdminTrendResponseDto.empty(date));
+        LocalDate current = startDate;
+        while (!current.isAfter(endDate)) {
+            trendMap.put(current, AdminTrendResponseDto.empty(current));
+            current = current.plusDays(1);
         }
 
         // 각 도메인별 데이터 조회 및 바인딩

--- a/src/test/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsControllerTest.java
@@ -96,10 +96,12 @@ class AdminStatisticsControllerTest {
                 .totalDelivered(20L)
                 .deliveryRatio(20.0)
                 .build();
-        given(adminStatisticsService.getPostcardRatioStats()).willReturn(response);
+        given(adminStatisticsService.getPostcardRatioStats(any(), any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/v1/admin/statistics/postcards/ratio"))
+        mockMvc.perform(get("/api/v1/admin/statistics/postcards/ratio")
+                        .param("startDate", "2026-05-01")
+                        .param("endDate", "2026-05-31"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.deliveryRatio").value(20.0));
@@ -110,10 +112,12 @@ class AdminStatisticsControllerTest {
     @WithMockUserPrincipal(role = "ROLE_ADMIN")
     void getTrafficTrends_Success() throws Exception {
         // given
-        given(adminStatisticsService.getTrafficTrends(7)).willReturn(Collections.emptyList());
+        given(adminStatisticsService.getTrafficTrends(any(), any())).willReturn(Collections.emptyList());
 
         // when & then
-        mockMvc.perform(get("/api/v1/admin/statistics/trends").param("days", "7"))
+        mockMvc.perform(get("/api/v1/admin/statistics/trends")
+                        .param("startDate", "2026-05-01")
+                        .param("endDate", "2026-05-07"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data").isArray());

--- a/src/test/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/statistics/controller/AdminStatisticsControllerTest.java
@@ -1,0 +1,129 @@
+package com.dodo.dodoserver.domain.admin.statistics.controller;
+
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminSummaryResponseDto;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
+import com.dodo.dodoserver.domain.admin.statistics.service.AdminStatisticsService;
+import com.dodo.dodoserver.global.config.AppProperties;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminStatisticsController.class)
+@Import(SecurityConfig.class)
+class AdminStatisticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminStatisticsService adminStatisticsService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("통계 요약 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getSummaryStats_Success() throws Exception {
+        // given
+        AdminSummaryResponseDto response = AdminSummaryResponseDto.builder()
+                .totalNests(100L)
+                .todayNests(10L)
+                .build();
+        given(adminStatisticsService.getSummaryStats()).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/statistics/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.totalNests").value(100));
+    }
+
+    @Test
+    @DisplayName("엽서 교환 비율 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getPostcardRatioStats_Success() throws Exception {
+        // given
+        AdminPostcardRatioResponseDto response = AdminPostcardRatioResponseDto.builder()
+                .totalGenerated(100L)
+                .totalDelivered(20L)
+                .deliveryRatio(20.0)
+                .build();
+        given(adminStatisticsService.getPostcardRatioStats()).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/statistics/postcards/ratio"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.deliveryRatio").value(20.0));
+    }
+
+    @Test
+    @DisplayName("트래픽 트렌드 조회 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getTrafficTrends_Success() throws Exception {
+        // given
+        given(adminStatisticsService.getTrafficTrends(7)).willReturn(Collections.emptyList());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/statistics/trends").param("days", "7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    @DisplayName("통계 조회 실패 - 권한 없음 (USER)")
+    @WithMockUserPrincipal(role = "ROLE_USER")
+    void getSummaryStats_Forbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/statistics/summary"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsServiceTest.java
@@ -3,6 +3,8 @@ package com.dodo.dodoserver.domain.admin.statistics.service;
 import com.dodo.dodoserver.domain.admin.statistics.dao.AdminStatisticsRepositoryCustom;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
 import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
 import com.querydsl.core.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -104,5 +107,31 @@ class AdminStatisticsServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getNestCount()).isEqualTo(10L);
         assertThat(result.get(0).getDate()).isEqualTo(today);
+    }
+
+    @Test
+    @DisplayName("날짜 유효성 검증 - 시작일이 종료일보다 이후인 경우 예외 발생")
+    void validateDateRange_InvalidOrder() {
+        // given
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.minusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> adminStatisticsService.getTrafficTrends(startDate, endDate))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+    }
+
+    @Test
+    @DisplayName("날짜 유효성 검증 - 조회 기간이 365일을 초과하는 경우 예외 발생")
+    void validateDateRange_ExceedMaxRange() {
+        // given
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.plusDays(366);
+
+        // when & then
+        assertThatThrownBy(() -> adminStatisticsService.getTrafficTrends(startDate, endDate))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_INPUT_VALUE.getMessage());
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsServiceTest.java
@@ -37,10 +37,10 @@ class AdminStatisticsServiceTest {
                 .totalGenerated(100L)
                 .totalDelivered(25L)
                 .build();
-        given(adminStatisticsRepository.getPostcardRatioStats()).willReturn(mockDto);
+        given(adminStatisticsRepository.getPostcardRatioStats(any(), any())).willReturn(mockDto);
 
         // when
-        AdminPostcardRatioResponseDto result = adminStatisticsService.getPostcardRatioStats();
+        AdminPostcardRatioResponseDto result = adminStatisticsService.getPostcardRatioStats(null, null);
 
         // then
         assertThat(result.getDeliveryRatio()).isEqualTo(25.0);
@@ -54,10 +54,10 @@ class AdminStatisticsServiceTest {
                 .totalGenerated(0L)
                 .totalDelivered(0L)
                 .build();
-        given(adminStatisticsRepository.getPostcardRatioStats()).willReturn(mockDto);
+        given(adminStatisticsRepository.getPostcardRatioStats(any(), any())).willReturn(mockDto);
 
         // when
-        AdminPostcardRatioResponseDto result = adminStatisticsService.getPostcardRatioStats();
+        AdminPostcardRatioResponseDto result = adminStatisticsService.getPostcardRatioStats(null, null);
 
         // then
         assertThat(result.getDeliveryRatio()).isEqualTo(0.0);
@@ -67,26 +67,27 @@ class AdminStatisticsServiceTest {
     @DisplayName("트래픽 트렌드 조회 - 데이터가 없는 날짜는 0으로 채워짐")
     void getTrafficTrends_FillEmptyDates() {
         // given
-        int days = 7;
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(6);
         given(adminStatisticsRepository.getNestTrend(any(), any())).willReturn(Collections.emptyList());
         given(adminStatisticsRepository.getCommentTrend(any(), any())).willReturn(Collections.emptyList());
         given(adminStatisticsRepository.getPostcardTrend(any(), any())).willReturn(Collections.emptyList());
 
         // when
-        List<AdminTrendResponseDto> result = adminStatisticsService.getTrafficTrends(days);
+        List<AdminTrendResponseDto> result = adminStatisticsService.getTrafficTrends(startDate, endDate);
 
         // then
-        assertThat(result).hasSize(days);
+        assertThat(result).hasSize(7);
         assertThat(result.get(0).getNestCount()).isEqualTo(0L);
-        assertThat(result.get(days - 1).getDate()).isEqualTo(LocalDate.now());
+        assertThat(result.get(6).getDate()).isEqualTo(LocalDate.now());
     }
 
     @Test
     @DisplayName("트래픽 트렌드 조회 - 데이터 바인딩 검증")
     void getTrafficTrends_DataBinding() {
         // given
-        int days = 1;
-        String todayStr = LocalDate.now().toString();
+        LocalDate today = LocalDate.now();
+        String todayStr = today.toString();
         
         Tuple mockTuple = mock(Tuple.class);
         given(mockTuple.get(0, String.class)).willReturn(todayStr);
@@ -97,11 +98,11 @@ class AdminStatisticsServiceTest {
         given(adminStatisticsRepository.getPostcardTrend(any(), any())).willReturn(Collections.emptyList());
 
         // when
-        List<AdminTrendResponseDto> result = adminStatisticsService.getTrafficTrends(days);
+        List<AdminTrendResponseDto> result = adminStatisticsService.getTrafficTrends(today, today);
 
         // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getNestCount()).isEqualTo(10L);
-        assertThat(result.get(0).getDate()).isEqualTo(LocalDate.now());
+        assertThat(result.get(0).getDate()).isEqualTo(today);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/statistics/service/AdminStatisticsServiceTest.java
@@ -1,0 +1,107 @@
+package com.dodo.dodoserver.domain.admin.statistics.service;
+
+import com.dodo.dodoserver.domain.admin.statistics.dao.AdminStatisticsRepositoryCustom;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminPostcardRatioResponseDto;
+import com.dodo.dodoserver.domain.admin.statistics.dto.AdminTrendResponseDto;
+import com.querydsl.core.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class AdminStatisticsServiceTest {
+
+    @Mock
+    private AdminStatisticsRepositoryCustom adminStatisticsRepository;
+
+    @InjectMocks
+    private AdminStatisticsService adminStatisticsService;
+
+    @Test
+    @DisplayName("엽서 교환 비율 계산 - 정상 케이스")
+    void getPostcardRatioStats_Success() {
+        // given
+        AdminPostcardRatioResponseDto mockDto = AdminPostcardRatioResponseDto.builder()
+                .totalGenerated(100L)
+                .totalDelivered(25L)
+                .build();
+        given(adminStatisticsRepository.getPostcardRatioStats()).willReturn(mockDto);
+
+        // when
+        AdminPostcardRatioResponseDto result = adminStatisticsService.getPostcardRatioStats();
+
+        // then
+        assertThat(result.getDeliveryRatio()).isEqualTo(25.0);
+    }
+
+    @Test
+    @DisplayName("엽서 교환 비율 계산 - 생성된 엽서가 0개일 때")
+    void getPostcardRatioStats_ZeroGenerated() {
+        // given
+        AdminPostcardRatioResponseDto mockDto = AdminPostcardRatioResponseDto.builder()
+                .totalGenerated(0L)
+                .totalDelivered(0L)
+                .build();
+        given(adminStatisticsRepository.getPostcardRatioStats()).willReturn(mockDto);
+
+        // when
+        AdminPostcardRatioResponseDto result = adminStatisticsService.getPostcardRatioStats();
+
+        // then
+        assertThat(result.getDeliveryRatio()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("트래픽 트렌드 조회 - 데이터가 없는 날짜는 0으로 채워짐")
+    void getTrafficTrends_FillEmptyDates() {
+        // given
+        int days = 7;
+        given(adminStatisticsRepository.getNestTrend(any(), any())).willReturn(Collections.emptyList());
+        given(adminStatisticsRepository.getCommentTrend(any(), any())).willReturn(Collections.emptyList());
+        given(adminStatisticsRepository.getPostcardTrend(any(), any())).willReturn(Collections.emptyList());
+
+        // when
+        List<AdminTrendResponseDto> result = adminStatisticsService.getTrafficTrends(days);
+
+        // then
+        assertThat(result).hasSize(days);
+        assertThat(result.get(0).getNestCount()).isEqualTo(0L);
+        assertThat(result.get(days - 1).getDate()).isEqualTo(LocalDate.now());
+    }
+
+    @Test
+    @DisplayName("트래픽 트렌드 조회 - 데이터 바인딩 검증")
+    void getTrafficTrends_DataBinding() {
+        // given
+        int days = 1;
+        String todayStr = LocalDate.now().toString();
+        
+        Tuple mockTuple = mock(Tuple.class);
+        given(mockTuple.get(0, String.class)).willReturn(todayStr);
+        given(mockTuple.get(1, Long.class)).willReturn(10L);
+        
+        given(adminStatisticsRepository.getNestTrend(any(), any())).willReturn(List.of(mockTuple));
+        given(adminStatisticsRepository.getCommentTrend(any(), any())).willReturn(Collections.emptyList());
+        given(adminStatisticsRepository.getPostcardTrend(any(), any())).willReturn(Collections.emptyList());
+
+        // when
+        List<AdminTrendResponseDto> result = adminStatisticsService.getTrafficTrends(days);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getNestCount()).isEqualTo(10L);
+        assertThat(result.get(0).getDate()).isEqualTo(LocalDate.now());
+    }
+}


### PR DESCRIPTION
## 📌 개요 (Overview)
  어드민 대시보드 기능을 위한 통계 분석 API 3종을 구현하였습니다. 코드 리뷰를 통해 제기된 성능 최적화(DB 조회 횟수 감소) 및 방어적 프로그래밍(날짜 유효성 검증) 사항을 모두 반영하여 안정성과 효율성을 높였습니다.

## 🛠️ 작업 내용 (Changes)
   - 어드민 통계 API 구현
       - GET /api/v1/admin/statistics/summary: 전체 및 당일 생성량 요약 정보 제공
       - GET /api/v1/admin/statistics/postcards/ratio: 엽서 생성 대비 교환 완료 비율 분석
       - GET /api/v1/admin/statistics/trends: 일별 트래픽 추이 배열 제공 (Gap Filling 처리 완료)
   - 성능 최적화 (Code Review 반영)
       - getSummaryStats 메서드에서 Querydsl CaseBuilder를 이용한 조건부 집계(Conditional Aggregation)를 적용하여 DB 조회 횟수를 6회에서 3회로 최적화했습니다.
   - 방어적 프로그래밍 및 유효성 검증 (Code Review 반영)
       - 시작일이 종료일보다 이후인 경우에 대한 예외 처리 추가
       - 과도한 자원 소모 방지를 위해 최대 조회 기간을 365일(1년)로 제한하는 검증 로직 추가
   - 문서화 및 보안
       - Swagger @Tag, @Operation 어노테이션을 사용하여 리액트 개발자를 위한 상세 가이드 작성
       - /api/v1/admin/** 경로에 대한 ROLE_ADMIN 인가 체계 유지
   - 테스트 및 검증
       - AdminStatisticsServiceTest: 비율 계산, 날짜 보정 로직 및 유효성 검증 테스트
       - AdminStatisticsControllerTest: 권한 및 응답 규격 테스트
       - 프로젝트 전체 테스트(./gradlew test) 통과 확인



## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #61 

