### PR TITLE
Feat/60/postcard report mgmt

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentController.java
@@ -1,14 +1,12 @@
 package com.dodo.dodoserver.domain.admin.nest.controller;
 
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Admin Comment", description = "관리자용 댓글 관리 API")
 @RestController
@@ -18,10 +16,12 @@ public class AdminCommentController {
 
     private final AdminNestService adminNestService;
 
-    @Operation(summary = "관리자 전용 댓글 삭제", description = "댓글을 소프트 삭제 처리합니다. 대댓글 구조를 유지하기 위해 논리 삭제만 수행합니다.")
+    @Operation(summary = "관리자 전용 댓글 삭제", description = "댓글을 소프트 삭제 처리하고 작성자에게 사유와 함께 알림을 발송합니다.")
     @DeleteMapping("/{commentId}")
-    public ApiResponseDto<Void> deleteComment(@PathVariable Long commentId) {
-        adminNestService.deleteCommentForAdmin(commentId);
+    public ApiResponseDto<Void> deleteComment(
+            @PathVariable Long commentId,
+            @RequestBody(required = false) AdminCommentDeleteRequestDto requestDto) {
+        adminNestService.deleteCommentForAdmin(commentId, requestDto != null ? requestDto : new AdminCommentDeleteRequestDto());
         return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentDeleteRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentDeleteRequestDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Schema(description = "관리자용 댓글 삭제 요청 DTO")
 public class AdminCommentDeleteRequestDto {
     @Schema(description = "삭제 사유 (미입력 시 기본 문구 사용)", example = "부적절한 내용 포함")

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentDeleteRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentDeleteRequestDto.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.admin.nest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "관리자용 댓글 삭제 요청 DTO")
+public class AdminCommentDeleteRequestDto {
+    @Schema(description = "삭제 사유 (미입력 시 기본 문구 사용)", example = "부적절한 내용 포함")
+    private String reason;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -207,6 +207,9 @@ public class AdminNestService {
 
         // 5. 둥지 소프트 삭제
         nestRepository.delete(nest);
+
+        // 6. 연관 신고 자동 처리 완료
+        reportRepository.updateStatusByTarget(ReportType.NEST, nestId, ReportStatus.PROCESSED);
     }
 
     @Transactional
@@ -237,5 +240,8 @@ public class AdminNestService {
 
         // 3. 하위 대댓글은 유지하고 해당 댓글만 소프트 삭제
         nestCommentRepository.delete(comment);
+
+        // 4. 연관 신고 자동 처리 완료
+        reportRepository.updateStatusByTarget(ReportType.COMMENT, commentId, ReportStatus.PROCESSED);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -180,7 +180,7 @@ public class AdminNestService {
                 .collect(Collectors.toList());
         
         if (!tokens.isEmpty()) {
-            String reason = (requestDto.getReason() == null || requestDto.getReason().isBlank()) 
+            String reason = (requestDto == null || requestDto.getReason() == null || requestDto.getReason().isBlank()) 
                     ? DEFAULT_NEST_DELETE_REASON 
                     : requestDto.getReason();
 
@@ -223,7 +223,7 @@ public class AdminNestService {
                 .collect(Collectors.toList());
 
         if (!tokens.isEmpty()) {
-            String reason = (requestDto.getReason() == null || requestDto.getReason().isBlank())
+            String reason = (requestDto == null || requestDto.getReason() == null || requestDto.getReason().isBlank())
                     ? DEFAULT_COMMENT_DELETE_REASON
                     : requestDto.getReason();
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.admin.nest.service;
 
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentResponseDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDetailResponseDto;
@@ -209,14 +210,32 @@ public class AdminNestService {
     }
 
     @Transactional
-    public void deleteCommentForAdmin(Long commentId) {
+    public void deleteCommentForAdmin(Long commentId, AdminCommentDeleteRequestDto requestDto) {
         NestComment comment = nestCommentRepository.findById(commentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 1. FCM 알림 발송
+        List<String> tokens = userDeviceRepository.findByUserId(comment.getUser().getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .collect(Collectors.toList());
+
+        if (!tokens.isEmpty()) {
+            String reason = (requestDto.getReason() == null || requestDto.getReason().isBlank())
+                    ? DEFAULT_COMMENT_DELETE_REASON
+                    : requestDto.getReason();
+
+            fcmService.sendNotification(new NotificationEvent(
+                    tokens,
+                    TITLE_COMMENT_DELETED,
+                    reason,
+                    Map.of(KEY_TYPE, TYPE_COMMENT_DELETED, KEY_COMMENT_ID, commentId.toString())
+            ));
+        }
         
-        // 1. 해당 댓글의 좋아요 데이터 정리 (하드 딜리트)
+        // 2. 해당 댓글의 좋아요 데이터 정리 (하드 딜리트)
         commentLikeRepository.deleteByComment(comment);
 
-        // 2. 하위 대댓글은 유지하고 해당 댓글만 소프트 삭제
+        // 3. 하위 대댓글은 유지하고 해당 댓글만 소프트 삭제
         nestCommentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardController.java
@@ -1,0 +1,31 @@
+package com.dodo.dodoserver.domain.admin.postcard.controller;
+
+import com.dodo.dodoserver.domain.admin.postcard.service.AdminPostcardService;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin Postcard", description = "관리자용 엽서 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/postcards")
+@RequiredArgsConstructor
+public class AdminPostcardController {
+
+    private final AdminPostcardService adminPostcardService;
+
+    @Operation(summary = "신고된 엽서 목록 조회", description = "신고가 접수된 엽서 목록을 집계하여 조회합니다. PENDING 또는 PROCESSED 상태인 데이터만 노출됩니다.")
+    @GetMapping("/reported")
+    public ApiResponseDto<Page<AdminPostcardReportResponseDto>> getReportedPostcards(
+            Pageable pageable,
+            @RequestParam(required = false) String sort) {
+        return ApiResponseDto.success(adminPostcardService.getReportedPostcards(pageable, sort));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardController.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.admin.postcard.controller;
 import com.dodo.dodoserver.domain.admin.postcard.dto.AdminPostcardDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.postcard.service.AdminPostcardService;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Admin Postcard", description = "관리자용 엽서 관리 API")
 @RestController
@@ -19,12 +22,13 @@ public class AdminPostcardController {
 
     private final AdminPostcardService adminPostcardService;
 
-    @Operation(summary = "신고된 엽서 목록 조회", description = "신고가 접수된 엽서 목록을 집계하여 조회합니다. PENDING 또는 PROCESSED 상태인 데이터만 노출됩니다.")
+    @Operation(summary = "신고된 엽서 목록 조회", description = "신고가 접수된 엽서 목록을 집계하여 조회합니다. statuses 파라미터로 PENDING, PROCESSED 필터링이 가능합니다.")
     @GetMapping("/reported")
     public ApiResponseDto<Page<AdminPostcardReportResponseDto>> getReportedPostcards(
             Pageable pageable,
+            @RequestParam(required = false) List<ReportStatus> statuses,
             @RequestParam(required = false) String sort) {
-        return ApiResponseDto.success(adminPostcardService.getReportedPostcards(pageable, sort));
+        return ApiResponseDto.success(adminPostcardService.getReportedPostcards(pageable, statuses, sort));
     }
 
     @Operation(summary = "관리자 전용 엽서 강제 삭제", description = "엽서를 소프트 삭제 처리하고 원작자에게 사유와 함께 알림을 발송합니다.")

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardController.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.admin.postcard.controller;
 
+import com.dodo.dodoserver.domain.admin.postcard.dto.AdminPostcardDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.postcard.service.AdminPostcardService;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
@@ -8,10 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Admin Postcard", description = "관리자용 엽서 관리 API")
 @RestController
@@ -27,5 +25,14 @@ public class AdminPostcardController {
             Pageable pageable,
             @RequestParam(required = false) String sort) {
         return ApiResponseDto.success(adminPostcardService.getReportedPostcards(pageable, sort));
+    }
+
+    @Operation(summary = "관리자 전용 엽서 강제 삭제", description = "엽서를 소프트 삭제 처리하고 원작자에게 사유와 함께 알림을 발송합니다.")
+    @DeleteMapping("/{postcardId}")
+    public ApiResponseDto<Void> deletePostcard(
+            @PathVariable Long postcardId,
+            @RequestBody(required = false) AdminPostcardDeleteRequestDto requestDto) {
+        adminPostcardService.deletePostcardForAdmin(postcardId, requestDto != null ? requestDto : new AdminPostcardDeleteRequestDto());
+        return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/dto/AdminPostcardDeleteRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/dto/AdminPostcardDeleteRequestDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Schema(description = "관리자용 엽서 삭제 요청 DTO")
 public class AdminPostcardDeleteRequestDto {
     @Schema(description = "삭제 사유 (미입력 시 기본 문구 사용)", example = "부적절한 내용 포함")

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/dto/AdminPostcardDeleteRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/dto/AdminPostcardDeleteRequestDto.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.admin.postcard.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "관리자용 엽서 삭제 요청 DTO")
+public class AdminPostcardDeleteRequestDto {
+    @Schema(description = "삭제 사유 (미입력 시 기본 문구 사용)", example = "부적절한 내용 포함")
+    private String reason;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
@@ -1,12 +1,27 @@
 package com.dodo.dodoserver.domain.admin.postcard.service;
 
+import com.dodo.dodoserver.domain.admin.postcard.dto.AdminPostcardDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import com.dodo.dodoserver.infrastructure.fcm.FcmService;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
 
 @Service
 @RequiredArgsConstructor
@@ -14,11 +29,44 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminPostcardService {
 
     private final ReportRepository reportRepository;
+    private final PostcardRepository postcardRepository;
+    private final UserDeviceRepository userDeviceRepository;
+    private final FcmService fcmService;
 
     /**
      * 신고된 엽서 목록 조회
      */
     public Page<AdminPostcardReportResponseDto> getReportedPostcards(Pageable pageable, String sort) {
         return reportRepository.findReportedPostcards(pageable, sort);
+    }
+
+    /**
+     * 관리자 전용 엽서 삭제 및 알림 발송
+     */
+    @Transactional
+    public void deletePostcardForAdmin(Long postcardId, AdminPostcardDeleteRequestDto requestDto) {
+        Postcard postcard = postcardRepository.findById(postcardId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POSTCARD_NOT_FOUND));
+
+        // 1. FCM 알림 발송
+        List<String> tokens = userDeviceRepository.findByUserId(postcard.getOriginalAuthor().getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .collect(Collectors.toList());
+
+        if (!tokens.isEmpty()) {
+            String reason = (requestDto.getReason() == null || requestDto.getReason().isBlank())
+                    ? DEFAULT_POSTCARD_DELETE_REASON
+                    : requestDto.getReason();
+
+            fcmService.sendNotification(new NotificationEvent(
+                    tokens,
+                    TITLE_POSTCARD_DELETED,
+                    reason,
+                    Map.of(KEY_TYPE, TYPE_POSTCARD_DELETED, KEY_POSTCARD_ID, postcardId.toString())
+            ));
+        }
+
+        // 2. 엽서 소프트 삭제
+        postcardRepository.delete(postcard);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDt
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
 import com.dodo.dodoserver.domain.user.entity.UserDevice;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -36,8 +37,8 @@ public class AdminPostcardService {
     /**
      * 신고된 엽서 목록 조회
      */
-    public Page<AdminPostcardReportResponseDto> getReportedPostcards(Pageable pageable, String sort) {
-        return reportRepository.findReportedPostcards(pageable, sort);
+    public Page<AdminPostcardReportResponseDto> getReportedPostcards(Pageable pageable, List<ReportStatus> statuses, String sort) {
+        return reportRepository.findReportedPostcards(pageable, statuses, sort);
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
@@ -56,7 +56,7 @@ public class AdminPostcardService {
                 .collect(Collectors.toList());
 
         if (!tokens.isEmpty()) {
-            String reason = (requestDto.getReason() == null || requestDto.getReason().isBlank())
+            String reason = (requestDto == null || requestDto.getReason() == null || requestDto.getReason().isBlank())
                     ? DEFAULT_POSTCARD_DELETE_REASON
                     : requestDto.getReason();
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
@@ -1,0 +1,24 @@
+package com.dodo.dodoserver.domain.admin.postcard.service;
+
+import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPostcardService {
+
+    private final ReportRepository reportRepository;
+
+    /**
+     * 신고된 엽서 목록 조회
+     */
+    public Page<AdminPostcardReportResponseDto> getReportedPostcards(Pageable pageable, String sort) {
+        return reportRepository.findReportedPostcards(pageable, sort);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardService.java
@@ -6,6 +6,7 @@ import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
 import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
 import com.dodo.dodoserver.domain.user.entity.UserDevice;
 import com.dodo.dodoserver.error.ErrorCode;
@@ -69,5 +70,8 @@ public class AdminPostcardService {
 
         // 2. 엽서 소프트 삭제
         postcardRepository.delete(postcard);
+
+        // 3. 연관 신고 자동 처리 완료
+        reportRepository.updateStatusByTarget(ReportType.POSTCARD, postcardId, ReportStatus.PROCESSED);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportController.java
@@ -2,19 +2,18 @@ package com.dodo.dodoserver.domain.admin.report.controller;
 
 import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminReportStatusUpdateRequestDto;
 import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.report.service.AdminReportService;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Admin Report", description = "관리자용 신고 관리 API")
 @RestController
@@ -46,5 +45,12 @@ public class AdminReportController {
             @RequestParam ReportType targetType,
             @RequestParam Long targetId) {
         return ApiResponseDto.success(adminReportService.getReportDetails(targetType, targetId));
+    }
+
+    @Operation(summary = "신고 상태 일괄 변경", description = "특정 타겟(둥지/댓글/엽서)에 대한 모든 대기 중인 신고 상태를 일괄 변경(처리 완료/반려)합니다.")
+    @PatchMapping("/status")
+    public ApiResponseDto<Void> updateReportStatus(@RequestBody @Valid AdminReportStatusUpdateRequestDto requestDto) {
+        adminReportService.updateReportStatus(requestDto);
+        return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.admin.report.dao;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +14,7 @@ import java.util.Map;
 public interface AdminReportRepositoryCustom {
     Page<AdminNestReportResponseDto> findReportedNests(Pageable pageable, String sort);
     Page<AdminCommentReportResponseDto> findReportedComments(Pageable pageable, String sort);
-    Page<AdminPostcardReportResponseDto> findReportedPostcards(Pageable pageable, String sort);
+    Page<AdminPostcardReportResponseDto> findReportedPostcards(Pageable pageable, List<ReportStatus> statuses, String sort);
     Map<String, Long> countPendingReportsByTarget(ReportType targetType, Long targetId);
     List<String> findOtherReportContents(ReportType targetType, Long targetId);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.admin.report.dao;
 
 import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,7 @@ import java.util.Map;
 public interface AdminReportRepositoryCustom {
     Page<AdminNestReportResponseDto> findReportedNests(Pageable pageable, String sort);
     Page<AdminCommentReportResponseDto> findReportedComments(Pageable pageable, String sort);
+    Page<AdminPostcardReportResponseDto> findReportedPostcards(Pageable pageable, String sort);
     Map<String, Long> countPendingReportsByTarget(ReportType targetType, Long targetId);
     List<String> findOtherReportContents(ReportType targetType, Long targetId);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
@@ -267,15 +267,10 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 ));
 
         Map<Long, Tuple> postcardInfoMap = queryFactory
-                .select(postcard.id, user.nickname, postcard.content, postcard.imageUrl, report.status)
+                .select(postcard.id, user.nickname, postcard.content, postcard.imageUrl)
                 .from(postcard)
                 .join(postcard.originalAuthor, user)
-                .join(report).on(report.targetId.eq(postcard.id).and(report.reportType.eq(ReportType.POSTCARD)))
-                .where(
-                        postcard.id.in(targetIds),
-                        report.status.ne(ReportStatus.REJECTED)
-                )
-                .groupBy(postcard.id, user.nickname, postcard.content, postcard.imageUrl, report.status)
+                .where(postcard.id.in(targetIds))
                 .fetch()
                 .stream()
                 .collect(Collectors.toMap(t -> t.get(postcard.id), t -> t, (oldV, newV) -> oldV));
@@ -284,6 +279,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
             Long id = t.get(report.targetId);
             Tuple info = postcardInfoMap.get(id);
             Long reportCount = t.get(report.targetId.count());
+            ReportStatus status = t.get(report.status.min());
 
             return AdminPostcardReportResponseDto.builder()
                     .postcardId(id)
@@ -294,7 +290,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                     .lastReportedAt(t.get(report.createdAt.max()))
                     .reportCount(reportCount != null ? reportCount : 0L)
                     .reasons(reasonMap.getOrDefault(id, Collections.emptyList()).stream().distinct().toList())
-                    .status(info != null ? info.get(report.status) : ReportStatus.PENDING)
+                    .status(status != null ? status : ReportStatus.PENDING)
                     .build();
         }).collect(Collectors.toList());
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.admin.report.dao;
 
 import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
 import com.dodo.dodoserver.domain.report.entity.ReportReason;
 import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 
 import static com.dodo.dodoserver.domain.nest.entity.QNest.nest;
 import static com.dodo.dodoserver.domain.nest.entity.QNestComment.nestComment;
+import static com.dodo.dodoserver.domain.postcard.entity.QPostcard.postcard;
 import static com.dodo.dodoserver.domain.report.entity.QReport.report;
 import static com.dodo.dodoserver.domain.user.entity.QUser.user;
 
@@ -205,6 +207,96 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
     }
 
     @Override
+    public Page<AdminPostcardReportResponseDto> findReportedPostcards(Pageable pageable, String sort) {
+        List<Tuple> results = queryFactory
+                .select(
+                        report.targetId,
+                        report.createdAt.min(),
+                        report.createdAt.max(),
+                        report.targetId.count(),
+                        report.status.min()
+                )
+                .from(report)
+                .leftJoin(postcard).on(report.targetId.eq(postcard.id).and(report.reportType.eq(ReportType.POSTCARD)))
+                .where(
+                        report.reportType.eq(ReportType.POSTCARD),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .groupBy(report.targetId, postcard.createdAt)
+                .orderBy(getPostcardOrderSpecifier(sort))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(report.targetId.countDistinct())
+                .from(report)
+                .where(
+                        report.reportType.eq(ReportType.POSTCARD),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .fetchOne();
+
+        if (results.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, total != null ? total : 0L);
+        }
+
+        List<Long> targetIds = results.stream()
+                .map(t -> t.get(report.targetId))
+                .collect(Collectors.toList());
+
+        Map<Long, List<ReportReason>> reasonMap = queryFactory
+                .select(report.targetId, report.reason)
+                .from(report)
+                .where(
+                        report.targetId.in(targetIds),
+                        report.reportType.eq(ReportType.POSTCARD),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .fetch()
+                .stream()
+                .filter(t -> t.get(report.targetId) != null && t.get(report.reason) != null)
+                .collect(Collectors.groupingBy(
+                        t -> t.get(report.targetId),
+                        Collectors.mapping(t -> t.get(report.reason), Collectors.toList())
+                ));
+
+        Map<Long, Tuple> postcardInfoMap = queryFactory
+                .select(postcard.id, user.nickname, postcard.content, postcard.imageUrl, report.status)
+                .from(postcard)
+                .join(postcard.originalAuthor, user)
+                .join(report).on(report.targetId.eq(postcard.id).and(report.reportType.eq(ReportType.POSTCARD)))
+                .where(
+                        postcard.id.in(targetIds),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .groupBy(postcard.id, user.nickname, postcard.content, postcard.imageUrl, report.status)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(t -> t.get(postcard.id), t -> t, (oldV, newV) -> oldV));
+
+        List<AdminPostcardReportResponseDto> content = results.stream().map(t -> {
+            Long id = t.get(report.targetId);
+            Tuple info = postcardInfoMap.get(id);
+            Long reportCount = t.get(report.targetId.count());
+
+            return AdminPostcardReportResponseDto.builder()
+                    .postcardId(id)
+                    .authorNickname(info != null ? info.get(user.nickname) : "알 수 없음")
+                    .content(info != null ? info.get(postcard.content) : "")
+                    .imageUrl(info != null ? info.get(postcard.imageUrl) : "")
+                    .firstReportedAt(t.get(report.createdAt.min()))
+                    .lastReportedAt(t.get(report.createdAt.max()))
+                    .reportCount(reportCount != null ? reportCount : 0L)
+                    .reasons(reasonMap.getOrDefault(id, Collections.emptyList()).stream().distinct().toList())
+                    .status(info != null ? info.get(report.status) : ReportStatus.PENDING)
+                    .build();
+        }).collect(Collectors.toList());
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    @Override
     public Map<String, Long> countPendingReportsByTarget(ReportType targetType, Long targetId) {
         List<Tuple> results = queryFactory
                 .select(report.reason, report.count())
@@ -268,6 +360,15 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
         return switch (sort) {
             case "REPORT_COUNT" -> new OrderSpecifier<>(Order.DESC, report.targetId.count());
             case "NEST_ID" -> new OrderSpecifier<>(Order.ASC, report.targetId); // 이 정렬은 조인이 필요할 수 있어 보완 필요
+            default -> new OrderSpecifier<>(Order.DESC, report.createdAt.max());
+        };
+    }
+
+    private OrderSpecifier<?> getPostcardOrderSpecifier(String sort) {
+        if (sort == null) return new OrderSpecifier<>(Order.DESC, report.createdAt.max());
+        return switch (sort) {
+            case "RECENT_REPORT" -> new OrderSpecifier<>(Order.DESC, report.createdAt.max());
+            case "RECENT_CREATED" -> new OrderSpecifier<>(Order.DESC, postcard.createdAt);
             default -> new OrderSpecifier<>(Order.DESC, report.createdAt.max());
         };
     }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
@@ -207,7 +207,12 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
     }
 
     @Override
-    public Page<AdminPostcardReportResponseDto> findReportedPostcards(Pageable pageable, String sort) {
+    public Page<AdminPostcardReportResponseDto> findReportedPostcards(Pageable pageable, List<ReportStatus> statuses, String sort) {
+        BooleanExpression statusPredicate = report.status.ne(ReportStatus.REJECTED);
+        if (statuses != null && !statuses.isEmpty()) {
+            statusPredicate = statusPredicate.and(report.status.in(statuses));
+        }
+
         List<Tuple> results = queryFactory
                 .select(
                         report.targetId,
@@ -220,7 +225,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 .leftJoin(postcard).on(report.targetId.eq(postcard.id).and(report.reportType.eq(ReportType.POSTCARD)))
                 .where(
                         report.reportType.eq(ReportType.POSTCARD),
-                        report.status.ne(ReportStatus.REJECTED)
+                        statusPredicate
                 )
                 .groupBy(report.targetId, postcard.createdAt)
                 .orderBy(getPostcardOrderSpecifier(sort))
@@ -233,7 +238,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 .from(report)
                 .where(
                         report.reportType.eq(ReportType.POSTCARD),
-                        report.status.ne(ReportStatus.REJECTED)
+                        statusPredicate
                 )
                 .fetchOne();
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminPostcardReportResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminPostcardReportResponseDto.java
@@ -1,0 +1,24 @@
+package com.dodo.dodoserver.domain.admin.report.dto;
+
+import com.dodo.dodoserver.domain.report.entity.ReportReason;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdminPostcardReportResponseDto {
+    private Long postcardId;
+    private String authorNickname;
+    private String content;
+    private String imageUrl;
+    private LocalDateTime firstReportedAt;
+    private LocalDateTime lastReportedAt;
+    private long reportCount;
+    private List<ReportReason> reasons;
+    private ReportStatus status;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminReportStatusUpdateRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminReportStatusUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package com.dodo.dodoserver.domain.admin.report.dto;
+
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자용 신고 상태 일괄 변경 요청 DTO")
+public class AdminReportStatusUpdateRequestDto {
+
+    @NotNull(message = "대상 타입을 지정해야 합니다.")
+    @Schema(description = "신고 대상 타입 (NEST, COMMENT, POSTCARD)", example = "NEST")
+    private ReportType targetType;
+
+    @NotNull(message = "대상 ID를 지정해야 합니다.")
+    @Schema(description = "신고 대상 콘텐츠의 ID", example = "1")
+    private Long targetId;
+
+    @NotNull(message = "변경할 상태를 지정해야 합니다.")
+    @Schema(description = "변경할 상태 (PROCESSED: 처리 완료, REJECTED: 반려)", example = "PROCESSED")
+    private ReportStatus newStatus;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportService.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.admin.report.service;
 
 import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminReportStatusUpdateRequestDto;
 import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
 import com.dodo.dodoserver.domain.report.entity.Report;
@@ -46,5 +47,14 @@ public class AdminReportService {
                 .stats(stats)
                 .otherReportContents(otherReportContents)
                 .build();
+    }
+
+    @Transactional
+    public void updateReportStatus(AdminReportStatusUpdateRequestDto requestDto) {
+        reportRepository.updateStatusByTarget(
+                requestDto.getTargetType(),
+                requestDto.getTargetId(),
+                requestDto.getNewStatus()
+        );
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
@@ -13,6 +13,6 @@ public interface ReportRepository extends JpaRepository<Report, Long>, AdminRepo
     boolean existsByReporterIdAndReportTypeAndTargetId(Long reporterId, ReportType reportType, Long targetId);
 
     @Modifying
-    @Query("UPDATE Report r SET r.status = :newStatus WHERE r.reportType = :reportType AND r.targetId = :targetId AND r.status = 'PENDING'")
+    @Query("UPDATE Report r SET r.status = :newStatus WHERE r.reportType = :reportType AND r.targetId = :targetId AND r.status = com.dodo.dodoserver.domain.report.entity.ReportStatus.PENDING")
     int updateStatusByTarget(@Param("reportType") ReportType reportType, @Param("targetId") Long targetId, @Param("newStatus") ReportStatus newStatus);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/report/dao/ReportRepository.java
@@ -2,9 +2,17 @@ package com.dodo.dodoserver.domain.report.dao;
 
 import com.dodo.dodoserver.domain.admin.report.dao.AdminReportRepositoryCustom;
 import com.dodo.dodoserver.domain.report.entity.Report;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long>, AdminReportRepositoryCustom {
     boolean existsByReporterIdAndReportTypeAndTargetId(Long reporterId, ReportType reportType, Long targetId);
+
+    @Modifying
+    @Query("UPDATE Report r SET r.status = :newStatus WHERE r.reportType = :reportType AND r.targetId = :targetId AND r.status = 'PENDING'")
+    int updateStatusByTarget(@Param("reportType") ReportType reportType, @Param("targetId") Long targetId, @Param("newStatus") ReportStatus newStatus);
 }

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -17,10 +17,16 @@ public final class NotificationConstants {
     public static final String TYPE_POSTCARD_EXCHANGED = "POSTCARD_EXCHANGED";
     public static final String TYPE_POSTCARD_LIKE = "POSTCARD_LIKE";
     public static final String TYPE_NEST_DELETED = "NEST_DELETED";
+    public static final String TYPE_POSTCARD_DELETED = "POSTCARD_DELETED";
+    public static final String TYPE_COMMENT_DELETED = "COMMENT_DELETED";
 
     // Message Templates
     public static final String TITLE_NEST_DELETED = "둥지 삭제 알림";
+    public static final String TITLE_POSTCARD_DELETED = "엽서 삭제 알림";
+    public static final String TITLE_COMMENT_DELETED = "댓글 삭제 알림";
     public static final String DEFAULT_NEST_DELETE_REASON = "커뮤니티 가이드라인 위반으로 인해 삭제되었습니다.";
+    public static final String DEFAULT_POSTCARD_DELETE_REASON = "커뮤니티 가이드라인 위반으로 인해 삭제되었습니다.";
+    public static final String DEFAULT_COMMENT_DELETE_REASON = "커뮤니티 가이드라인 위반으로 인해 삭제되었습니다.";
     public static final String TITLE_NEW_COMMENT = "둥지에 새 댓글이 달렸습니다!";
     public static final String BODY_NEW_COMMENT = "%s님이 댓글을 남겼습니다.";
     public static final String TITLE_NEW_REPLY = "내 댓글에 답글이 달렸습니다!";

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminCommentControllerTest.java
@@ -1,3 +1,5 @@
+package com.dodo.dodoserver.domain.admin.nest.controller;
+
 import com.dodo.dodoserver.domain.admin.nest.controller.AdminCommentController;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -1,8 +1,10 @@
 package com.dodo.dodoserver.domain.admin.nest.service;
 
+import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentDeleteRequestDto;
 import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
 import com.dodo.dodoserver.domain.nest.dao.*;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.NestComment;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
@@ -25,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.DEFAULT_COMMENT_DELETE_REASON;
 import static com.dodo.dodoserver.global.common.constants.NotificationConstants.DEFAULT_NEST_DELETE_REASON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -148,5 +151,49 @@ class AdminNestServiceTest {
         assertThat(result).isEmpty();
         verify(nestRepository, times(1)).existsById(100L);
         verify(nestCommentRepository, times(1)).findAllByNestId(100L);
+    }
+
+    @Test
+    @DisplayName("관리자 전용 댓글 삭제 성공 - FCM 알림 발송 포함")
+    void deleteCommentForAdmin_success() {
+        // given
+        User author = User.builder().id(1L).build();
+        NestComment comment = NestComment.builder().id(10L).user(author).build();
+        UserDevice device = UserDevice.builder().fcmToken("token").build();
+        AdminCommentDeleteRequestDto requestDto = mock(AdminCommentDeleteRequestDto.class);
+        given(requestDto.getReason()).willReturn("부적절한 댓글");
+
+        given(nestCommentRepository.findById(10L)).willReturn(Optional.of(comment));
+        given(userDeviceRepository.findByUserId(1L)).willReturn(Collections.singletonList(device));
+
+        // when
+        adminNestService.deleteCommentForAdmin(10L, requestDto);
+
+        // then
+        verify(fcmService, times(1)).sendNotification(argThat(event -> 
+                event.body().equals("부적절한 댓글")));
+        verify(commentLikeRepository, times(1)).deleteByComment(comment);
+        verify(nestCommentRepository, times(1)).delete(comment);
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 시 사유가 없으면 기본 사유로 알림 전송")
+    void deleteComment_useDefaultReason_whenReasonIsMissing() {
+        // given
+        User author = User.builder().id(1L).build();
+        NestComment comment = NestComment.builder().id(10L).user(author).build();
+        UserDevice device = UserDevice.builder().fcmToken("token").build();
+        AdminCommentDeleteRequestDto requestDto = new AdminCommentDeleteRequestDto();
+
+        given(nestCommentRepository.findById(10L)).willReturn(Optional.of(comment));
+        given(userDeviceRepository.findByUserId(1L)).willReturn(Collections.singletonList(device));
+
+        // when
+        adminNestService.deleteCommentForAdmin(10L, requestDto);
+
+        // then
+        verify(fcmService).sendNotification(argThat(event -> 
+            event.body().equals(DEFAULT_COMMENT_DELETE_REASON)
+        ));
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -7,6 +7,8 @@ import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.nest.entity.NestComment;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
@@ -100,6 +102,7 @@ class AdminNestServiceTest {
         verify(nestReactionRepository, times(1)).deleteByNest(nest);
         verify(nestCommentRepository, times(1)).deleteAllByNest(nest);
         verify(nestRepository, times(1)).delete(nest);
+        verify(reportRepository, times(1)).updateStatusByTarget(ReportType.NEST, 100L, ReportStatus.PROCESSED);
     }
 
     @Test
@@ -174,6 +177,7 @@ class AdminNestServiceTest {
                 event.body().equals("부적절한 댓글")));
         verify(commentLikeRepository, times(1)).deleteByComment(comment);
         verify(nestCommentRepository, times(1)).delete(comment);
+        verify(reportRepository, times(1)).updateStatusByTarget(ReportType.COMMENT, 10L, ReportStatus.PROCESSED);
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardControllerTest.java
@@ -79,7 +79,7 @@ class AdminPostcardControllerTest {
     }
 
     @Test
-    @DisplayName("신고된 엽서 목록 조회 성공 - 관리자 권한")
+    @DisplayName("신고된 엽서 목록 조회 성공 - 관리자 권한 및 상태 필터링")
     @WithMockUserPrincipal(role = "ROLE_ADMIN")
     void getReportedPostcards_success() throws Exception {
         // given
@@ -87,13 +87,14 @@ class AdminPostcardControllerTest {
                 .postcardId(1L)
                 .authorNickname("유저1")
                 .build();
-        given(adminPostcardService.getReportedPostcards(any(), any()))
+        given(adminPostcardService.getReportedPostcards(any(), any(), any()))
                 .willReturn(new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1));
 
         // when & then
         mockMvc.perform(get("/api/v1/admin/postcards/reported")
                         .param("page", "0")
                         .param("size", "10")
+                        .param("statuses", "PENDING,PROCESSED")
                         .param("sort", "RECENT_REPORT"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))

--- a/src/test/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardControllerTest.java
@@ -1,6 +1,8 @@
-import com.dodo.dodoserver.domain.admin.nest.controller.AdminCommentController;
-import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentDeleteRequestDto;
-import com.dodo.dodoserver.domain.admin.nest.service.AdminNestService;
+package com.dodo.dodoserver.domain.admin.postcard.controller;
+
+import com.dodo.dodoserver.domain.admin.postcard.dto.AdminPostcardDeleteRequestDto;
+import com.dodo.dodoserver.domain.admin.postcard.service.AdminPostcardService;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
 import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
 import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
@@ -19,24 +21,27 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(AdminCommentController.class)
+@WebMvcTest(AdminPostcardController.class)
 @Import(SecurityConfig.class)
-class AdminCommentControllerTest {
+class AdminPostcardControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -45,7 +50,7 @@ class AdminCommentControllerTest {
     private ObjectMapper objectMapper;
 
     @MockitoBean
-    private AdminNestService adminNestService;
+    private AdminPostcardService adminPostcardService;
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
@@ -74,20 +79,40 @@ class AdminCommentControllerTest {
     }
 
     @Test
-    @DisplayName("어드민 댓글 삭제 성공 - 관리자 권한 및 삭제 사유 포함")
+    @DisplayName("신고된 엽서 목록 조회 성공 - 관리자 권한")
     @WithMockUserPrincipal(role = "ROLE_ADMIN")
-    void deleteComment_success() throws Exception {
+    void getReportedPostcards_success() throws Exception {
         // given
-        AdminCommentDeleteRequestDto requestDto = new AdminCommentDeleteRequestDto();
+        AdminPostcardReportResponseDto responseDto = AdminPostcardReportResponseDto.builder()
+                .postcardId(1L)
+                .authorNickname("유저1")
+                .build();
+        given(adminPostcardService.getReportedPostcards(any(), any()))
+                .willReturn(new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1));
 
         // when & then
-        mockMvc.perform(delete("/api/v1/admin/comments/1")
+        mockMvc.perform(get("/api/v1/admin/postcards/reported")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "RECENT_REPORT"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].authorNickname").value("유저1"));
+    }
+
+    @Test
+    @DisplayName("관리자 전용 엽서 삭제 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void deletePostcard_success() throws Exception {
+        // given
+        AdminPostcardDeleteRequestDto requestDto = new AdminPostcardDeleteRequestDto();
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/admin/postcards/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto))
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"));
-
-        verify(adminNestService).deleteCommentForAdmin(eq(1L), any());
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
@@ -1,0 +1,112 @@
+package com.dodo.dodoserver.domain.admin.postcard.service;
+
+import com.dodo.dodoserver.domain.admin.postcard.dto.AdminPostcardDeleteRequestDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDto;
+import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
+import com.dodo.dodoserver.domain.postcard.entity.Postcard;
+import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.infrastructure.fcm.FcmService;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.DEFAULT_POSTCARD_DELETE_REASON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminPostcardServiceTest {
+
+    @InjectMocks
+    private AdminPostcardService adminPostcardService;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private PostcardRepository postcardRepository;
+
+    @Mock
+    private UserDeviceRepository userDeviceRepository;
+
+    @Mock
+    private FcmService fcmService;
+
+    @Test
+    @DisplayName("신고된 엽서 목록 조회 성공")
+    void getReportedPostcards_success() {
+        // given
+        AdminPostcardReportResponseDto responseDto = AdminPostcardReportResponseDto.builder()
+                .postcardId(1L)
+                .authorNickname("유저1")
+                .build();
+        Page<AdminPostcardReportResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto));
+        given(reportRepository.findReportedPostcards(any(), any())).willReturn(page);
+
+        // when
+        Page<AdminPostcardReportResponseDto> result = adminPostcardService.getReportedPostcards(PageRequest.of(0, 10), "RECENT_REPORT");
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getAuthorNickname()).isEqualTo("유저1");
+    }
+
+    @Test
+    @DisplayName("관리자 전용 엽서 삭제 성공 - FCM 알림 및 소프트 삭제")
+    void deletePostcardForAdmin_success() {
+        // given
+        User author = User.builder().id(1L).build();
+        Postcard postcard = Postcard.builder().id(100L).originalAuthor(author).build();
+        UserDevice device = UserDevice.builder().fcmToken("token").build();
+        AdminPostcardDeleteRequestDto requestDto = mock(AdminPostcardDeleteRequestDto.class);
+        given(requestDto.getReason()).willReturn("삭제 사유");
+
+        given(postcardRepository.findById(100L)).willReturn(Optional.of(postcard));
+        given(userDeviceRepository.findByUserId(1L)).willReturn(Collections.singletonList(device));
+
+        // when
+        adminPostcardService.deletePostcardForAdmin(100L, requestDto);
+
+        // then
+        verify(fcmService, times(1)).sendNotification(argThat(event -> 
+                event.body().equals("삭제 사유")));
+        verify(postcardRepository, times(1)).delete(postcard);
+    }
+
+    @Test
+    @DisplayName("엽서 삭제 시 사유가 없으면 기본 사유로 알림 전송")
+    void deletePostcard_useDefaultReason_whenReasonIsMissing() {
+        // given
+        User author = User.builder().id(1L).build();
+        Postcard postcard = Postcard.builder().id(100L).originalAuthor(author).build();
+        UserDevice device = UserDevice.builder().fcmToken("token").build();
+        AdminPostcardDeleteRequestDto requestDto = new AdminPostcardDeleteRequestDto();
+
+        given(postcardRepository.findById(100L)).willReturn(Optional.of(postcard));
+        given(userDeviceRepository.findByUserId(1L)).willReturn(Collections.singletonList(device));
+
+        // when
+        adminPostcardService.deletePostcardForAdmin(100L, requestDto);
+
+        // then
+        verify(fcmService).sendNotification(argThat(event -> 
+            event.body().equals(DEFAULT_POSTCARD_DELETE_REASON)
+        ));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
@@ -6,6 +6,7 @@ import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
 import com.dodo.dodoserver.domain.report.entity.ReportStatus;
+import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.domain.user.entity.UserDevice;
@@ -88,6 +89,7 @@ class AdminPostcardServiceTest {
         verify(fcmService, times(1)).sendNotification(argThat(event -> 
                 event.body().equals("삭제 사유")));
         verify(postcardRepository, times(1)).delete(postcard);
+        verify(reportRepository, times(1)).updateStatusByTarget(ReportType.POSTCARD, 100L, ReportStatus.PROCESSED);
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.admin.report.dto.AdminPostcardReportResponseDt
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.entity.Postcard;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
+import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.domain.user.entity.UserDevice;
@@ -49,7 +50,7 @@ class AdminPostcardServiceTest {
     private FcmService fcmService;
 
     @Test
-    @DisplayName("신고된 엽서 목록 조회 성공")
+    @DisplayName("신고된 엽서 목록 조회 성공 - 상태 필터링 포함")
     void getReportedPostcards_success() {
         // given
         AdminPostcardReportResponseDto responseDto = AdminPostcardReportResponseDto.builder()
@@ -57,10 +58,10 @@ class AdminPostcardServiceTest {
                 .authorNickname("유저1")
                 .build();
         Page<AdminPostcardReportResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto));
-        given(reportRepository.findReportedPostcards(any(), any())).willReturn(page);
+        given(reportRepository.findReportedPostcards(any(), any(), any())).willReturn(page);
 
         // when
-        Page<AdminPostcardReportResponseDto> result = adminPostcardService.getReportedPostcards(PageRequest.of(0, 10), "RECENT_REPORT");
+        Page<AdminPostcardReportResponseDto> result = adminPostcardService.getReportedPostcards(PageRequest.of(0, 10), Collections.singletonList(ReportStatus.PENDING), "RECENT_REPORT");
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);

--- a/src/test/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/report/controller/AdminReportControllerTest.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.admin.report.controller;
 
 import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminReportStatusUpdateRequestDto;
 import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
 import com.dodo.dodoserver.domain.admin.report.service.AdminReportService;
 import com.dodo.dodoserver.domain.report.entity.ReportReason;
@@ -28,11 +29,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Map;
 
@@ -40,7 +41,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -50,6 +53,9 @@ class AdminReportControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private AdminReportService adminReportService;
@@ -123,5 +129,26 @@ class AdminReportControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.stats.pendingAbuseCount").value(5));
+    }
+
+    @Test
+    @DisplayName("신고 상태 일괄 변경 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void updateReportStatus_success() throws Exception {
+        // given
+        AdminReportStatusUpdateRequestDto requestDto = AdminReportStatusUpdateRequestDto.builder()
+                .targetType(ReportType.NEST)
+                .targetId(1L)
+                .newStatus(ReportStatus.PROCESSED)
+                .build();
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/admin/reports/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(adminReportService).updateReportStatus(any(AdminReportStatusUpdateRequestDto.class));
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/report/service/AdminReportServiceTest.java
@@ -2,10 +2,9 @@ package com.dodo.dodoserver.domain.admin.report.service;
 
 import com.dodo.dodoserver.domain.admin.report.dto.AdminCommentReportResponseDto;
 import com.dodo.dodoserver.domain.admin.report.dto.AdminNestReportResponseDto;
+import com.dodo.dodoserver.domain.admin.report.dto.AdminReportStatusUpdateRequestDto;
 import com.dodo.dodoserver.domain.admin.report.dto.ReportDetailResponseDto;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
-import com.dodo.dodoserver.domain.report.entity.Report;
-import com.dodo.dodoserver.domain.report.entity.ReportReason;
 import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +24,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AdminReportServiceTest {
@@ -71,5 +71,22 @@ class AdminReportServiceTest {
         assertEquals(5L, result.getStats().get("pendingAbuseCount"));
         assertEquals(1, result.getOtherReportContents().size());
         assertEquals("기타 사유 상세", result.getOtherReportContents().get(0));
+    }
+
+    @Test
+    @DisplayName("신고 상태 일괄 업데이트 성공")
+    void updateReportStatus_success() {
+        // given
+        AdminReportStatusUpdateRequestDto requestDto = AdminReportStatusUpdateRequestDto.builder()
+                .targetType(ReportType.NEST)
+                .targetId(1L)
+                .newStatus(ReportStatus.REJECTED)
+                .build();
+
+        // when
+        adminReportService.updateReportStatus(requestDto);
+
+        // then
+        verify(reportRepository).updateStatusByTarget(ReportType.NEST, 1L, ReportStatus.REJECTED);
     }
 }


### PR DESCRIPTION
## 📌 개요 (Overview)
관리자 도메인의 신고 처리 시스템을 개선하고, 엽서(Postcard) 관리 및 신고 반려 기능을 추가했습니다. 콘텐츠 삭제 시 신고 상태가 자동으로 업데이트되도록 연동하여 운영 효율성을 높였습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - 신고 자동 처리 로직 구현
     - 둥지(Nest), 댓글(Comment), 엽서(Postcard) 관리자 삭제 시, 연관된 모든 대기 중(PENDING)인 신고를 PROCESSED(처리 완료)로 자동 변경.
     - ReportRepository에 @Modifying 벌크 업데이트 쿼리를 추가하여 대량 데이터 처리 성능 최적화.
   - 신고 상태 수동 변경 API 추가
     - 콘텐츠를 삭제하지 않고도 신고를 반려(REJECTED)하거나 처리 완료할 수 있는 API 개발.
     - PATCH /api/v1/admin/reports/status 엔드포인트 및 관련 DTO/Service 로직 구현.
   - 엽서 관리 기능 강화
     - 신고된 엽서 목록 조회(GET /api/v1/admin/postcards/reported) 및 강제 삭제 API 구현.
   - 테스트 및 검증
     - 신규 API에 대한 컨트롤러/서비스 단위 테스트 추가.
     - 콘텐츠 삭제 시 신고 상태 연동에 대한 비즈니스 로직 검증 완료.


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #60 

## 📝 추가 참고 사항 (Additional Notes)
  아래 API들을 호출하여 콘텐츠를 삭제하면, 관련 신고들을 따로 처리할 필요 없이 서버에서 자동으로 PROCESSED 상태로 업데이트합니다.

   * 둥지 삭제: DELETE /api/v1/admin/nests/{nestId}
   * 댓글 삭제: DELETE /api/v1/admin/nests/comments/{commentId} (추가된 엔드포인트)
