### PR TITLE
Feat/64/add ismine field

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/CommentResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/CommentResponseDto.java
@@ -19,6 +19,7 @@ public class CommentResponseDto {
     private LocalDateTime createdAt;
     private Long likeCount;
     private boolean isLiked;
+    private boolean isMine;
     private List<CommentResponseDto> children;
 
     public static CommentResponseDto from(NestComment comment) {
@@ -30,6 +31,7 @@ public class CommentResponseDto {
                 .createdAt(comment.getCreatedAt())
                 .likeCount(comment.getLikeCount())
                 .isLiked(false)
+                .isMine(false)
                 .children(comment.getChildren().stream()
                         .map(CommentResponseDto::from)
                         .collect(Collectors.toList()))

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDetailResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dto/NestDetailResponseDto.java
@@ -36,4 +36,5 @@ public class NestDetailResponseDto {
     // 엽서 정보
     private boolean hasPostcard;
     private Long postcardId;
+    private boolean isMine;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -406,6 +406,7 @@ public class NestService {
                 .myReaction(myReaction)
                 .hasPostcard(sharedPostcard != null)
                 .postcardId(sharedPostcard != null ? sharedPostcard.getId() : null)
+                .isMine(nest.getCreator().equals(user))
                 .build();
     }
 
@@ -450,7 +451,7 @@ public class NestService {
 
         Set<Long> finalLikedCommentIds = likedCommentIds; // 람다 Effectively Final
         return topComments.stream()
-                .map(c -> convertToCommentResponseDto(c, childrenMap, profileImageMap, finalLikedCommentIds))
+                .map(c -> convertToCommentResponseDto(c, childrenMap, profileImageMap, finalLikedCommentIds, currentUserId))
                 .collect(Collectors.toList());
     }
 
@@ -472,16 +473,18 @@ public class NestService {
      * DTO 변환 (Map을 활용하여 LAZY 로딩 차단)
      */
     private CommentResponseDto convertToCommentResponseDto(
-            NestComment comment, 
-            Map<Long, List<NestComment>> childrenMap, 
-            Map<Long, String> profileImageMap, 
-            Set<Long> likedCommentIds) {
-        
+            NestComment comment,
+            Map<Long, List<NestComment>> childrenMap,
+            Map<Long, String> profileImageMap,
+            Set<Long> likedCommentIds,
+            Long currentUserId) {
+
         List<NestComment> children = childrenMap.getOrDefault(comment.getId(), Collections.emptyList());
         // 대댓글은 생성순으로 정렬
         children.sort(Comparator.comparing(NestComment::getCreatedAt));
 
         boolean isDeleted = comment.getDeletedAt() != null;
+        boolean isMine = !isDeleted && currentUserId != null && comment.getUser().getId().equals(currentUserId);
 
         return CommentResponseDto.builder()
                 .id(comment.getId())
@@ -491,8 +494,9 @@ public class NestService {
                 .createdAt(comment.getCreatedAt())
                 .likeCount(isDeleted ? 0L : comment.getLikeCount())
                 .isLiked(!isDeleted && likedCommentIds.contains(comment.getId()))
+                .isMine(isMine)
                 .children(children.stream()
-                        .map(child -> convertToCommentResponseDto(child, childrenMap, profileImageMap, likedCommentIds))
+                        .map(child -> convertToCommentResponseDto(child, childrenMap, profileImageMap, likedCommentIds, currentUserId))
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -406,7 +406,7 @@ public class NestService {
                 .myReaction(myReaction)
                 .hasPostcard(sharedPostcard != null)
                 .postcardId(sharedPostcard != null ? sharedPostcard.getId() : null)
-                .isMine(nest.getCreator().equals(user))
+                .isMine(nest.getCreator().getId().equals(user.getId()))
                 .build();
     }
 

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -255,6 +255,7 @@ class NestServiceTest {
         assertThat(response.getContent()).isEqualTo("내용");
         assertThat(response.isUnlocked()).isFalse();
         assertThat(response.getMyReaction()).isNull();
+        assertThat(response.isMine()).isFalse();
         verify(redisViewCountService).incrementViewCount(nestId, user.getId());
     }
 
@@ -277,6 +278,7 @@ class NestServiceTest {
 
         assertThat(response.getId()).isEqualTo(nestId);
         assertThat(response.getMyReaction()).isEqualTo(ReactionType.LIKE);
+        assertThat(response.isMine()).isTrue();
     }
 
     @Test
@@ -296,6 +298,7 @@ class NestServiceTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getContent()).isEqualTo("댓글");
+        assertThat(result.get(0).isMine()).isTrue();
     }
 
     @Test
@@ -332,6 +335,7 @@ class NestServiceTest {
         assertThat(response.getProfileImageUrl()).isNull();
         assertThat(response.getLikeCount()).isEqualTo(0L);
         assertThat(response.isLiked()).isFalse();
+        assertThat(response.isMine()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
  둥지 및 댓글 상세 조회 시, 현재 요청을 보낸 사용자가 작성자인지 여부를 판단하기 위한 isMine 필드를 추가했습니다. 이를 통해 클라이언트에서 본인 작성물에 대한 수정/삭제 버튼 노출 여부를 제어할 수 있습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - DTO 필드 추가:
     - NestDetailResponseDto: boolean isMine 필드 추가
     - CommentResponseDto: boolean isMine 필드 추가
   - 서비스 로직 반영 (NestService):
     - getNestDetail: 둥지 작성자와 요청자 일치 여부 매핑
     - getCommentsByNestId: 댓글/대댓글 작성자와 요청자 일치 여부 매핑 (삭제된 댓글은 false 고정)
   - 테스트 코드 보강:
     - NestServiceTest: 상세 조회 및 댓글 조회 시 isMine 필드의 정상 반환 여부 검증 케이스 추가
   - API 명세 업데이트:
     - nest_api_spec.md, api_full_list.md에 isMine 필드 정보 반영


## 📸 스크린샷 / 결과 (Screenshots / Results)

``` json
  1. 둥지 상세 정보 조회
   - Endpoint: GET /api/v1/nests/{id}
   - 변경 사항: 응답 데이터(NestDetailResponseDto)에 isMine 필드 추가
   - 응답 스펙 (Data):

   1 {
   2   "id": 1,
   3   "title": "둥지 제목",
   4   "content": "상세 내용",
   5   ...
   6   "isUnlocked": true,
   7   "isMine": true  // 추가: 요청한 유저가 작성자인지 여부
   8 }

  2. 둥지 댓글 리스트 조회
   - Endpoint: GET /api/v1/nests/{id}/comments
   - 변경 사항: 응답 데이터(CommentResponseDto)에 isMine 필드 추가 (대댓글 포함)
   - 응답 스펙 (Data List):

    1 [
    2   {
    3     "id": 10,
    4     "content": "댓글 내용",
    5     "nickname": "작성자",
    6     ...
    7     "isLiked": false,
    8     "isMine": true, // 추가: 요청한 유저가 댓글 작성자인지 여부
    9     "children": [
   10       {
   11         "id": 11,
   12         "content": "대댓글 내용",
   13         "isMine": false, // 대댓글에도 적용
   14         ...
   15       }
   16     ]
   17   }
   18 ]
```


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #64

## 📝 추가 참고 사항 (Additional Notes)
isMine 필드는 기본형 boolean으로 선언되어 있어, Jackson의 Java Bean 규약에 따라 실제 JSON 응답에서는 mine으로 직렬화됩니다. 이는 프로젝트 내 isAd, isUnlocked 등 기존 필드와 동일한 동작 방식입니다.