### PR TITLE
Feat/66/admin nest detail fields

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminCommentResponseDto.java
@@ -12,10 +12,13 @@ import java.util.List;
 public class AdminCommentResponseDto {
     private Long commentId;
     private Long parentId;
+    private Long authorId;
     private String authorNickname;
+    private String profileImageUrl;
     private String content;
     private LocalDateTime createdAt;
     private boolean isDeleted;
     private long pendingReportCount;
+    private long likeCount;
     private List<AdminCommentResponseDto> children;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestDetailResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dto/AdminNestDetailResponseDto.java
@@ -13,12 +13,18 @@ public class AdminNestDetailResponseDto {
     private Long nestId;
     private String title;
     private String content;
+    private Long authorId;
     private String authorNickname;
+    private String profileImageUrl;
     private Double latitude;
     private Double longitude;
     private List<String> imageUrls;
     private List<Long> categoryIds;
     private List<String> categoryNames;
     private LocalDateTime createdAt;
+    private LocalDateTime firstReportedAt;
+    private LocalDateTime lastReportedAt;
+    private long likeCount;
+    private long dislikeCount;
     private boolean isDeleted;
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -147,6 +147,7 @@ public class AdminNestService {
         Map<Long, User> userMap = users.stream()
                 .collect(Collectors.toMap(User::getId, u -> u));
         Map<Long, String> profileImageUrlMap = userProfileRepository.findAllByUserIn(users).stream()
+                .filter(up -> up.getProfileImageUrl() != null)
                 .collect(Collectors.toMap(up -> up.getUser().getId(), UserProfile::getProfileImageUrl));
 
         // 3. 각 댓글별 대기(PENDING) 신고 수 일괄 조회

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -28,7 +28,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dodo.dodoserver.domain.user.dao.UserProfileRepository;
+import com.dodo.dodoserver.domain.user.entity.UserProfile;
+import com.dodo.dodoserver.domain.nest.entity.ReactionType;
+import com.querydsl.core.Tuple;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -36,6 +41,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.dodo.dodoserver.domain.report.entity.QReport.report;
+import static com.dodo.dodoserver.domain.nest.entity.QCommentLike.commentLike;
 import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
 
 @Service
@@ -51,6 +57,7 @@ public class AdminNestService {
     private final PostcardRepository postcardRepository;
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
     private final UserDeviceRepository userDeviceRepository;
     private final FcmService fcmService;
     private final JPAQueryFactory queryFactory;
@@ -79,17 +86,46 @@ public class AdminNestService {
                 .map(nc -> nc.getCategory().getName())
                 .collect(Collectors.toList());
 
+        // 신고 일시 조회 (Rejected 제외)
+        Tuple reportStats = queryFactory
+                .select(report.createdAt.min(), report.createdAt.max())
+                .from(report)
+                .where(
+                        report.reportType.eq(ReportType.NEST),
+                        report.targetId.eq(nestId),
+                        report.status.ne(ReportStatus.REJECTED)
+                )
+                .fetchOne();
+
+        LocalDateTime firstReportedAt = reportStats != null ? reportStats.get(report.createdAt.min()) : null;
+        LocalDateTime lastReportedAt = reportStats != null ? reportStats.get(report.createdAt.max()) : null;
+
+        // 좋아요/싫어요 수 조회
+        long likeCount = nestReactionRepository.countByNestAndReactionType(nest, ReactionType.LIKE);
+        long dislikeCount = nestReactionRepository.countByNestAndReactionType(nest, ReactionType.DISLIKE);
+
+        // 프로필 이미지 조회
+        String profileImageUrl = userProfileRepository.findByUser(nest.getCreator())
+                .map(UserProfile::getProfileImageUrl)
+                .orElse(null);
+
         return AdminNestDetailResponseDto.builder()
                 .nestId(nest.getId())
                 .title(nest.getTitle())
                 .content(nest.getContent())
+                .authorId(nest.getCreator().getId())
                 .authorNickname(nest.getCreator().getNickname())
+                .profileImageUrl(profileImageUrl)
                 .latitude(nest.getLocation() != null ? nest.getLocation().getLatitude() : 0.0)
                 .longitude(nest.getLocation() != null ? nest.getLocation().getLongitude() : 0.0)
                 .imageUrls(nest.getImages().stream().map(NestImage::getImageUrl).collect(Collectors.toList()))
                 .categoryIds(categoryIds)
                 .categoryNames(categoryNames)
                 .createdAt(nest.getCreatedAt())
+                .firstReportedAt(firstReportedAt)
+                .lastReportedAt(lastReportedAt)
+                .likeCount(likeCount)
+                .dislikeCount(dislikeCount)
                 .isDeleted(nest.getDeletedAt() != null)
                 .build();
     }
@@ -105,10 +141,13 @@ public class AdminNestService {
 
         if (allComments.isEmpty()) return List.of();
 
-        // 2. 유저 정보 일괄 조회 (Native Query 결과이므로 LAZY 로딩 방지)
+        // 2. 유저 및 프로필 정보 일괄 조회 (Native Query 결과이므로 LAZY 로딩 방지)
         List<Long> userIds = allComments.stream().map(c -> c.getUser().getId()).distinct().toList();
-        Map<Long, String> nicknameMap = userRepository.findAllById(userIds).stream()
-                .collect(Collectors.toMap(User::getId, User::getNickname));
+        List<User> users = userRepository.findAllById(userIds);
+        Map<Long, User> userMap = users.stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+        Map<Long, String> profileImageUrlMap = userProfileRepository.findAllByUserIn(users).stream()
+                .collect(Collectors.toMap(up -> up.getUser().getId(), UserProfile::getProfileImageUrl));
 
         // 3. 각 댓글별 대기(PENDING) 신고 수 일괄 조회
         List<Long> commentIds = allComments.stream().map(NestComment::getId).toList();
@@ -125,6 +164,16 @@ public class AdminNestService {
                 .stream()
                 .collect(Collectors.toMap(t -> t.get(report.targetId), t -> t.get(report.count())));
 
+        // 3.5 댓글 좋아요 수 일괄 조회
+        Map<Long, Long> likeCounts = queryFactory
+                .select(commentLike.comment.id, commentLike.count())
+                .from(commentLike)
+                .where(commentLike.comment.id.in(commentIds))
+                .groupBy(commentLike.comment.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(t -> t.get(commentLike.comment.id), t -> t.get(commentLike.count())));
+
         // 4. 부모 ID를 기준으로 그룹화 (트리 구조 생성용)
         Map<Long, List<NestComment>> childrenMap = allComments.stream()
                 .filter(c -> c.getParent() != null)
@@ -138,7 +187,7 @@ public class AdminNestService {
 
         // 6. 트리 구조 변환
         return topComments.stream()
-                .map(c -> convertToAdminCommentResponseDto(c, childrenMap, nicknameMap, pendingReportCounts))
+                .map(c -> convertToAdminCommentResponseDto(c, childrenMap, userMap, profileImageUrlMap, pendingReportCounts, likeCounts))
                 .collect(Collectors.toList());
     }
 
@@ -148,23 +197,30 @@ public class AdminNestService {
     private AdminCommentResponseDto convertToAdminCommentResponseDto(
             NestComment comment,
             Map<Long, List<NestComment>> childrenMap,
-            Map<Long, String> nicknameMap,
-            Map<Long, Long> pendingReportCounts) {
+            Map<Long, User> userMap,
+            Map<Long, String> profileImageUrlMap,
+            Map<Long, Long> pendingReportCounts,
+            Map<Long, Long> likeCounts) {
 
         List<NestComment> children = childrenMap.getOrDefault(comment.getId(), Collections.emptyList());
         // 대댓글은 생성순으로 정렬
         children.sort(Comparator.comparing(NestComment::getCreatedAt));
 
+        User author = userMap.get(comment.getUser().getId());
+
         return AdminCommentResponseDto.builder()
                 .commentId(comment.getId())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
-                .authorNickname(nicknameMap.getOrDefault(comment.getUser().getId(), "알 수 없음"))
+                .authorId(author != null ? author.getId() : null)
+                .authorNickname(author != null ? author.getNickname() : "알 수 없음")
+                .profileImageUrl(profileImageUrlMap.getOrDefault(comment.getUser().getId(), null))
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .isDeleted(comment.getDeletedAt() != null)
                 .pendingReportCount(pendingReportCounts.getOrDefault(comment.getId(), 0L))
+                .likeCount(likeCounts.getOrDefault(comment.getId(), 0L))
                 .children(children.stream()
-                        .map(child -> convertToAdminCommentResponseDto(child, childrenMap, nicknameMap, pendingReportCounts))
+                        .map(child -> convertToAdminCommentResponseDto(child, childrenMap, userMap, profileImageUrlMap, pendingReportCounts, likeCounts))
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/controller/AdminNestControllerTest.java
@@ -112,9 +112,13 @@ class AdminNestControllerTest {
                 .nestId(1L)
                 .title("제목")
                 .content("원본 본문")
+                .authorId(10L)
                 .authorNickname("산책왕")
+                .profileImageUrl("https://profile.url")
                 .latitude(37.2844)
                 .longitude(127.0442)
+                .likeCount(5)
+                .dislikeCount(1)
                 .build();
         given(adminNestService.getNestDetailForAdmin(1L)).willReturn(responseDto);
 
@@ -122,7 +126,11 @@ class AdminNestControllerTest {
         mockMvc.perform(get("/api/v1/admin/nests/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.content").value("원본 본문"));
+                .andExpect(jsonPath("$.data.content").value("원본 본문"))
+                .andExpect(jsonPath("$.data.authorId").value(10))
+                .andExpect(jsonPath("$.data.profileImageUrl").value("https://profile.url"))
+                .andExpect(jsonPath("$.data.likeCount").value(5))
+                .andExpect(jsonPath("$.data.dislikeCount").value(1));
     }
 
     @Test
@@ -146,11 +154,19 @@ class AdminNestControllerTest {
         AdminCommentResponseDto child = AdminCommentResponseDto.builder()
                 .commentId(2L)
                 .parentId(1L)
+                .authorId(11L)
+                .authorNickname("댓글러2")
+                .profileImageUrl("https://profile2.url")
                 .content("대댓글")
+                .likeCount(2)
                 .build();
         AdminCommentResponseDto parent = AdminCommentResponseDto.builder()
                 .commentId(1L)
+                .authorId(10L)
+                .authorNickname("댓글러1")
+                .profileImageUrl("https://profile1.url")
                 .content("댓글")
+                .likeCount(10)
                 .children(Collections.singletonList(child))
                 .build();
         given(adminNestService.getNestCommentsForAdmin(1L)).willReturn(Collections.singletonList(parent));
@@ -160,6 +176,11 @@ class AdminNestControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data[0].commentId").value(1))
-                .andExpect(jsonPath("$.data[0].children[0].commentId").value(2));
+                .andExpect(jsonPath("$.data[0].authorId").value(10))
+                .andExpect(jsonPath("$.data[0].profileImageUrl").value("https://profile1.url"))
+                .andExpect(jsonPath("$.data[0].likeCount").value(10))
+                .andExpect(jsonPath("$.data[0].children[0].commentId").value(2))
+                .andExpect(jsonPath("$.data[0].children[0].authorId").value(11))
+                .andExpect(jsonPath("$.data[0].children[0].likeCount").value(2));
     }
 }


### PR DESCRIPTION
## 📌 개요 (Overview)
 관리자용 둥지 상세 조회 및 댓글 목록 조회 API의 응답 필드 추가 및 로직 고도화. 운영 효율성을 위해 작성자 ID, 프로필 이미지, 신고 이력, 좋아요 수 등의 데이터를 추가함.

## 🛠️ 작업 내용 (Changes)
  1. 둥지 상세 조회 API
   - Endpoint: GET /api/v1/admin/nests/{nestId}
   - 변경 사항: 작성자 식별 및 운영 지표 확인을 위한 필드 추가.
   - 추가 필드:
       - authorId (Long): 둥지 작성자의 고유 ID.
       - profileImageUrl (String): 둥지 작성자의 프로필 이미지 URL (없을 시 null).
       - firstReportedAt (String/DateTime): 해당 둥지가 최초로 신고된 일시 (신고 이력 없을 시 null).
       - lastReportedAt (String/DateTime): 해당 둥지가 마지막으로 신고된 일시 (신고 이력 없을 시 null).
       - likeCount (Long): 둥지 좋아요 총 개수.
       - dislikeCount (Long): 둥지 싫어요 총 개수.

  2. 둥지별 댓글 목록 조회 API
   - Endpoint: GET /api/v1/admin/nests/{nestId}/comments
   - 변경 사항: 댓글 트리 구조 내 개별 댓글 객체에 작성자 정보 및 인터랙션 정보 추가.
   - 추가 필드:
       - authorId (Long): 댓글 작성자의 고유 ID.
       - profileImageUrl (String): 댓글 작성자의 프로필 이미지 URL (없을 시 null).
       - likeCount (Long): 해당 댓글이 받은 좋아요 총 개수.




## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #66 


