### PR TITLE
Feat/69/inquiry

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/controller/AdminInquiryController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/controller/AdminInquiryController.java
@@ -1,0 +1,48 @@
+package com.dodo.dodoserver.domain.admin.inquiry.controller;
+
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.InquiryAnswerRequestDto;
+import com.dodo.dodoserver.domain.admin.inquiry.service.AdminInquiryService;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin Inquiry API", description = "관리자 1:1 문의 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/inquiries")
+@RequiredArgsConstructor
+public class AdminInquiryController {
+
+    private final AdminInquiryService adminInquiryService;
+
+    @Operation(summary = "문의 리스트 조회 (필터링 포함)")
+    @GetMapping
+    public ApiResponseDto<Page<AdminInquiryResponseDto>> getInquiries(
+            @RequestParam(required = false) InquiryStatus status,
+            Pageable pageable) {
+        return ApiResponseDto.success(adminInquiryService.getInquiries(status, pageable));
+    }
+
+    @Operation(summary = "문의 상세 조회")
+    @GetMapping("/{inquiryId}")
+    public ApiResponseDto<AdminInquiryDetailResponseDto> getInquiryDetail(@PathVariable Long inquiryId) {
+        return ApiResponseDto.success(adminInquiryService.getInquiryDetail(inquiryId));
+    }
+
+    @Operation(summary = "문의 답변 등록")
+    @PostMapping("/{inquiryId}/answer")
+    public ApiResponseDto<Void> answerInquiry(
+            @PathVariable Long inquiryId,
+            @Valid @RequestBody InquiryAnswerRequestDto requestDto) {
+        adminInquiryService.answerInquiry(inquiryId, requestDto);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dao/AdminInquiryRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dao/AdminInquiryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.dodo.dodoserver.domain.admin.inquiry.dao;
+
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryResponseDto;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AdminInquiryRepositoryCustom {
+    Page<AdminInquiryResponseDto> findInquiriesForAdmin(InquiryStatus status, Pageable pageable);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dao/AdminInquiryRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dao/AdminInquiryRepositoryCustomImpl.java
@@ -1,0 +1,76 @@
+package com.dodo.dodoserver.domain.admin.inquiry.dao;
+
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryResponseDto;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.dodo.dodoserver.domain.inquiry.entity.QInquiry.inquiry;
+import static com.dodo.dodoserver.domain.user.entity.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminInquiryRepositoryCustomImpl implements AdminInquiryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AdminInquiryResponseDto> findInquiriesForAdmin(InquiryStatus status, Pageable pageable) {
+        List<AdminInquiryResponseDto> content = queryFactory
+                .select(Projections.constructor(AdminInquiryResponseDto.class,
+                        inquiry.id,
+                        user.id,
+                        user.nickname,
+                        inquiry.type,
+                        inquiry.type.stringValue(), // Enum의 description 대신 stringValue() 사용 후 DTO에서 처리하거나 Projections 조정 필요
+                        inquiry.title,
+                        inquiry.status,
+                        inquiry.status.stringValue(),
+                        inquiry.createdAt,
+                        inquiry.answeredAt
+                ))
+                .from(inquiry)
+                .join(inquiry.user, user)
+                .where(statusEq(status))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(inquiry.createdAt.desc())
+                .fetch();
+
+        // Projections.constructor는 필드 순서와 타입을 맞춰야 함. 
+        // AdminInquiryResponseDto를 Projections.constructor에 맞게 수정하거나 직접 맵핑 권장.
+        // 여기서는 QBean이나 직접 fetch 후 mapping 방식을 사용하겠음.
+
+        List<AdminInquiryResponseDto> mappedContent = queryFactory
+                .selectFrom(inquiry)
+                .join(inquiry.user, user).fetchJoin()
+                .where(statusEq(status))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(inquiry.createdAt.desc())
+                .fetch()
+                .stream()
+                .map(AdminInquiryResponseDto::from)
+                .toList();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(inquiry.count())
+                .from(inquiry)
+                .where(statusEq(status));
+
+        return PageableExecutionUtils.getPage(mappedContent, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression statusEq(InquiryStatus status) {
+        return status != null ? inquiry.status.eq(status) : null;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dao/AdminInquiryRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dao/AdminInquiryRepositoryCustomImpl.java
@@ -26,31 +26,6 @@ public class AdminInquiryRepositoryCustomImpl implements AdminInquiryRepositoryC
     @Override
     public Page<AdminInquiryResponseDto> findInquiriesForAdmin(InquiryStatus status, Pageable pageable) {
         List<AdminInquiryResponseDto> content = queryFactory
-                .select(Projections.constructor(AdminInquiryResponseDto.class,
-                        inquiry.id,
-                        user.id,
-                        user.nickname,
-                        inquiry.type,
-                        inquiry.type.stringValue(), // Enum의 description 대신 stringValue() 사용 후 DTO에서 처리하거나 Projections 조정 필요
-                        inquiry.title,
-                        inquiry.status,
-                        inquiry.status.stringValue(),
-                        inquiry.createdAt,
-                        inquiry.answeredAt
-                ))
-                .from(inquiry)
-                .join(inquiry.user, user)
-                .where(statusEq(status))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(inquiry.createdAt.desc())
-                .fetch();
-
-        // Projections.constructor는 필드 순서와 타입을 맞춰야 함. 
-        // AdminInquiryResponseDto를 Projections.constructor에 맞게 수정하거나 직접 맵핑 권장.
-        // 여기서는 QBean이나 직접 fetch 후 mapping 방식을 사용하겠음.
-
-        List<AdminInquiryResponseDto> mappedContent = queryFactory
                 .selectFrom(inquiry)
                 .join(inquiry.user, user).fetchJoin()
                 .where(statusEq(status))
@@ -67,7 +42,7 @@ public class AdminInquiryRepositoryCustomImpl implements AdminInquiryRepositoryC
                 .from(inquiry)
                 .where(statusEq(status));
 
-        return PageableExecutionUtils.getPage(mappedContent, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
     private BooleanExpression statusEq(InquiryStatus status) {

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dto/AdminInquiryDetailResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dto/AdminInquiryDetailResponseDto.java
@@ -1,0 +1,43 @@
+package com.dodo.dodoserver.domain.admin.inquiry.dto;
+
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminInquiryDetailResponseDto {
+    private Long id;
+    private Long userId;
+    private String userNickname;
+    private InquiryType type;
+    private String typeDescription;
+    private String title;
+    private String content;
+    private String answer;
+    private InquiryStatus status;
+    private String statusDescription;
+    private LocalDateTime createdAt;
+    private LocalDateTime answeredAt;
+
+    public static AdminInquiryDetailResponseDto from(Inquiry inquiry) {
+        return AdminInquiryDetailResponseDto.builder()
+                .id(inquiry.getId())
+                .userId(inquiry.getUser().getId())
+                .userNickname(inquiry.getUser().getNickname())
+                .type(inquiry.getType())
+                .typeDescription(inquiry.getType().getDescription())
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .answer(inquiry.getAnswer())
+                .status(inquiry.getStatus())
+                .statusDescription(inquiry.getStatus().getDescription())
+                .createdAt(inquiry.getCreatedAt())
+                .answeredAt(inquiry.getAnsweredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dto/AdminInquiryResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dto/AdminInquiryResponseDto.java
@@ -1,0 +1,39 @@
+package com.dodo.dodoserver.domain.admin.inquiry.dto;
+
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminInquiryResponseDto {
+    private Long id;
+    private Long userId;
+    private String userNickname;
+    private InquiryType type;
+    private String typeDescription;
+    private String title;
+    private InquiryStatus status;
+    private String statusDescription;
+    private LocalDateTime createdAt;
+    private LocalDateTime answeredAt;
+
+    public static AdminInquiryResponseDto from(Inquiry inquiry) {
+        return AdminInquiryResponseDto.builder()
+                .id(inquiry.getId())
+                .userId(inquiry.getUser().getId())
+                .userNickname(inquiry.getUser().getNickname())
+                .type(inquiry.getType())
+                .typeDescription(inquiry.getType().getDescription())
+                .title(inquiry.getTitle())
+                .status(inquiry.getStatus())
+                .statusDescription(inquiry.getStatus().getDescription())
+                .createdAt(inquiry.getCreatedAt())
+                .answeredAt(inquiry.getAnsweredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dto/InquiryAnswerRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/dto/InquiryAnswerRequestDto.java
@@ -1,0 +1,15 @@
+package com.dodo.dodoserver.domain.admin.inquiry.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class InquiryAnswerRequestDto {
+    @NotBlank(message = "답변 내용은 필수입니다.")
+    private String answer;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/service/AdminInquiryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/service/AdminInquiryService.java
@@ -1,0 +1,43 @@
+package com.dodo.dodoserver.domain.admin.inquiry.service;
+
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.InquiryAnswerRequestDto;
+import com.dodo.dodoserver.domain.inquiry.dao.InquiryRepository;
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminInquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    public Page<AdminInquiryResponseDto> getInquiries(InquiryStatus status, Pageable pageable) {
+        return inquiryRepository.findInquiriesForAdmin(status, pageable);
+    }
+
+    public AdminInquiryDetailResponseDto getInquiryDetail(Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        return AdminInquiryDetailResponseDto.from(inquiry);
+    }
+
+    @Transactional
+    public void answerInquiry(Long inquiryId, InquiryAnswerRequestDto requestDto) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        
+        inquiry.addAnswer(requestDto.getAnswer());
+        
+        // TODO: FCM 발송 로직 (Phase 4에서 구현 예정)
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/service/AdminInquiryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/inquiry/service/AdminInquiryService.java
@@ -6,6 +6,7 @@ import com.dodo.dodoserver.domain.admin.inquiry.dto.InquiryAnswerRequestDto;
 import com.dodo.dodoserver.domain.inquiry.dao.InquiryRepository;
 import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
 import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.domain.inquiry.service.InquiryNotificationService;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminInquiryService {
 
     private final InquiryRepository inquiryRepository;
+    private final InquiryNotificationService inquiryNotificationService;
 
     public Page<AdminInquiryResponseDto> getInquiries(InquiryStatus status, Pageable pageable) {
         return inquiryRepository.findInquiriesForAdmin(status, pageable);
@@ -38,6 +40,7 @@ public class AdminInquiryService {
         
         inquiry.addAnswer(requestDto.getAnswer());
         
-        // TODO: FCM 발송 로직 (Phase 4에서 구현 예정)
+        // FCM 발송 (이벤트 발행 방식)
+        inquiryNotificationService.sendInquiryAnswerNotification(inquiry);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/controller/InquiryController.java
@@ -27,7 +27,7 @@ public class InquiryController {
     public ApiResponseDto<InquiryResponseDto> createInquiry(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody InquiryRequestDto requestDto) {
-        return ApiResponseDto.success(inquiryService.createInquiry(userPrincipal.getUser(), requestDto));
+        return ApiResponseDto.success(inquiryService.createInquiry(userPrincipal.getId(), requestDto));
     }
 
     @Operation(summary = "내 문의 리스트 조회")
@@ -35,7 +35,7 @@ public class InquiryController {
     public ApiResponseDto<Page<InquiryResponseDto>> getMyInquiries(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             Pageable pageable) {
-        return ApiResponseDto.success(inquiryService.getMyInquiries(userPrincipal.getUser(), pageable));
+        return ApiResponseDto.success(inquiryService.getMyInquiries(userPrincipal.getId(), pageable));
     }
 
     @Operation(summary = "문의 수정")
@@ -44,7 +44,7 @@ public class InquiryController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long inquiryId,
             @Valid @RequestBody InquiryRequestDto requestDto) {
-        return ApiResponseDto.success(inquiryService.updateInquiry(userPrincipal.getUser(), inquiryId, requestDto));
+        return ApiResponseDto.success(inquiryService.updateInquiry(userPrincipal.getId(), inquiryId, requestDto));
     }
 
     @Operation(summary = "문의 삭제")
@@ -52,7 +52,7 @@ public class InquiryController {
     public ApiResponseDto<Void> deleteInquiry(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long inquiryId) {
-        inquiryService.deleteInquiry(userPrincipal.getUser(), inquiryId);
+        inquiryService.deleteInquiry(userPrincipal.getId(), inquiryId);
         return ApiResponseDto.success(null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/controller/InquiryController.java
@@ -1,0 +1,58 @@
+package com.dodo.dodoserver.domain.inquiry.controller;
+
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryRequestDto;
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryResponseDto;
+import com.dodo.dodoserver.domain.inquiry.service.InquiryService;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Inquiry API", description = "사용자 1:1 문의 API")
+@RestController
+@RequestMapping("/api/v1/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    @Operation(summary = "1:1 문의 등록")
+    @PostMapping
+    public ApiResponseDto<InquiryResponseDto> createInquiry(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody InquiryRequestDto requestDto) {
+        return ApiResponseDto.success(inquiryService.createInquiry(userPrincipal.getUser(), requestDto));
+    }
+
+    @Operation(summary = "내 문의 리스트 조회")
+    @GetMapping("/me")
+    public ApiResponseDto<Page<InquiryResponseDto>> getMyInquiries(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            Pageable pageable) {
+        return ApiResponseDto.success(inquiryService.getMyInquiries(userPrincipal.getUser(), pageable));
+    }
+
+    @Operation(summary = "문의 수정")
+    @PutMapping("/{inquiryId}")
+    public ApiResponseDto<InquiryResponseDto> updateInquiry(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long inquiryId,
+            @Valid @RequestBody InquiryRequestDto requestDto) {
+        return ApiResponseDto.success(inquiryService.updateInquiry(userPrincipal.getUser(), inquiryId, requestDto));
+    }
+
+    @Operation(summary = "문의 삭제")
+    @DeleteMapping("/{inquiryId}")
+    public ApiResponseDto<Void> deleteInquiry(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long inquiryId) {
+        inquiryService.deleteInquiry(userPrincipal.getUser(), inquiryId);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/dao/InquiryRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/dao/InquiryRepository.java
@@ -1,0 +1,13 @@
+package com.dodo.dodoserver.domain.inquiry.dao;
+
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+    Page<Inquiry> findAllByUser(User user, Pageable pageable);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/dao/InquiryRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/dao/InquiryRepository.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.inquiry.dao;
 
+import com.dodo.dodoserver.domain.admin.inquiry.dao.AdminInquiryRepositoryCustom;
 import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -8,6 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+public interface InquiryRepository extends JpaRepository<Inquiry, Long>, AdminInquiryRepositoryCustom {
     Page<Inquiry> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/dto/InquiryRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/dto/InquiryRequestDto.java
@@ -1,0 +1,24 @@
+package com.dodo.dodoserver.domain.inquiry.dto;
+
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class InquiryRequestDto {
+
+    @NotNull(message = "문의 종류는 필수입니다.")
+    private InquiryType type;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/dto/InquiryResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/dto/InquiryResponseDto.java
@@ -1,0 +1,39 @@
+package com.dodo.dodoserver.domain.inquiry.dto;
+
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InquiryResponseDto {
+    private Long id;
+    private InquiryType type;
+    private String typeDescription;
+    private String title;
+    private String content;
+    private String answer;
+    private InquiryStatus status;
+    private String statusDescription;
+    private LocalDateTime createdAt;
+    private LocalDateTime answeredAt;
+
+    public static InquiryResponseDto from(Inquiry inquiry) {
+        return InquiryResponseDto.builder()
+                .id(inquiry.getId())
+                .type(inquiry.getType())
+                .typeDescription(inquiry.getType().getDescription())
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .answer(inquiry.getAnswer())
+                .status(inquiry.getStatus())
+                .statusDescription(inquiry.getStatus().getDescription())
+                .createdAt(inquiry.getCreatedAt())
+                .answeredAt(inquiry.getAnsweredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/entity/Inquiry.java
@@ -1,0 +1,106 @@
+package com.dodo.dodoserver.domain.inquiry.entity;
+
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.SQLDelete;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "inquiries")
+@EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE inquiries SET deleted_at = NOW() WHERE id = ?")
+@FilterDef(name = "inquiryFilter")
+@Filter(name = "inquiryFilter", condition = "deleted_at IS NULL")
+public class Inquiry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InquiryType type;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(columnDefinition = "TEXT")
+    private String answer;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    @Column(nullable = false)
+    private InquiryStatus status = InquiryStatus.PENDING;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "answered_at")
+    private LocalDateTime answeredAt;
+
+    /**
+     * 문의 수정
+     */
+    public void update(InquiryType type, String title, String content) {
+        validateNotCompleted();
+        this.type = type;
+        this.title = title;
+        this.content = content;
+    }
+
+    /**
+     * 삭제 시 검증
+     */
+    public void validateForDelete() {
+        validateNotCompleted();
+    }
+
+    /**
+     * 관리자 답변 등록
+     */
+    public void addAnswer(String answer) {
+        this.answer = answer;
+        this.status = InquiryStatus.COMPLETED;
+        this.answeredAt = LocalDateTime.now();
+    }
+
+    private void validateNotCompleted() {
+        if (this.status == InquiryStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.CANNOT_MODIFY_COMPLETED_INQUIRY);
+        }
+    }
+
+    public void validateOwner(User user) {
+        if (!this.user.getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.NOT_INQUIRY_OWNER);
+        }
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/entity/InquiryStatus.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/entity/InquiryStatus.java
@@ -1,0 +1,13 @@
+package com.dodo.dodoserver.domain.inquiry.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InquiryStatus {
+    PENDING("대기"),
+    COMPLETED("처리 완료");
+
+    private final String description;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/entity/InquiryType.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/entity/InquiryType.java
@@ -1,0 +1,15 @@
+package com.dodo.dodoserver.domain.inquiry.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InquiryType {
+    ACCOUNT("계정"),
+    BUG("오류/버그"),
+    SUGGESTION("기능 건의"),
+    BUSINESS("비즈니스");
+
+    private final String description;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/service/InquiryNotificationService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/service/InquiryNotificationService.java
@@ -1,0 +1,62 @@
+package com.dodo.dodoserver.domain.inquiry.service;
+
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
+
+/**
+ * 1:1 문의 관련 알림 발행 로직을 전담하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class InquiryNotificationService {
+
+    private final UserDeviceRepository userDeviceRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 문의 답변 등록 알림 발행
+     */
+    public void sendInquiryAnswerNotification(Inquiry inquiry) {
+        User targetUser = inquiry.getUser();
+        List<String> fcmTokens = getFcmTokens(targetUser);
+
+        if (fcmTokens.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> data = new HashMap<>();
+        data.put(KEY_TYPE, TYPE_INQUIRY_ANSWERED);
+        data.put(KEY_INQUIRY_ID, inquiry.getId().toString());
+
+        eventPublisher.publishEvent(new NotificationEvent(
+                fcmTokens,
+                TITLE_INQUIRY_ANSWERED,
+                BODY_INQUIRY_ANSWERED,
+                data
+        ));
+        
+        log.info("문의 답변 알림 이벤트 발행 완료: TargetUser={}, InquiryId={}", targetUser.getEmail(), inquiry.getId());
+    }
+
+    private List<String> getFcmTokens(User targetUser) {
+        return userDeviceRepository.findByUserId(targetUser.getId()).stream()
+                .map(UserDevice::getFcmToken)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/service/InquiryService.java
@@ -4,6 +4,7 @@ import com.dodo.dodoserver.domain.inquiry.dao.InquiryRepository;
 import com.dodo.dodoserver.domain.inquiry.dto.InquiryRequestDto;
 import com.dodo.dodoserver.domain.inquiry.dto.InquiryResponseDto;
 import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
@@ -19,9 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class InquiryService {
 
     private final InquiryRepository inquiryRepository;
+    private final UserRepository userRepository;
 
     @Transactional
-    public InquiryResponseDto createInquiry(User user, InquiryRequestDto requestDto) {
+    public InquiryResponseDto createInquiry(Long userId, InquiryRequestDto requestDto) {
+        User user = findUserById(userId);
         Inquiry inquiry = Inquiry.builder()
                 .user(user)
                 .type(requestDto.getType())
@@ -32,13 +35,15 @@ public class InquiryService {
         return InquiryResponseDto.from(inquiryRepository.save(inquiry));
     }
 
-    public Page<InquiryResponseDto> getMyInquiries(User user, Pageable pageable) {
+    public Page<InquiryResponseDto> getMyInquiries(Long userId, Pageable pageable) {
+        User user = findUserById(userId);
         return inquiryRepository.findAllByUser(user, pageable)
                 .map(InquiryResponseDto::from);
     }
 
     @Transactional
-    public InquiryResponseDto updateInquiry(User user, Long inquiryId, InquiryRequestDto requestDto) {
+    public InquiryResponseDto updateInquiry(Long userId, Long inquiryId, InquiryRequestDto requestDto) {
+        User user = findUserById(userId);
         Inquiry inquiry = findById(inquiryId);
         inquiry.validateOwner(user);
         inquiry.update(requestDto.getType(), requestDto.getTitle(), requestDto.getContent());
@@ -47,7 +52,8 @@ public class InquiryService {
     }
 
     @Transactional
-    public void deleteInquiry(User user, Long inquiryId) {
+    public void deleteInquiry(Long userId, Long inquiryId) {
+        User user = findUserById(userId);
         Inquiry inquiry = findById(inquiryId);
         inquiry.validateOwner(user);
         inquiry.validateForDelete();
@@ -58,5 +64,10 @@ public class InquiryService {
     private Inquiry findById(Long id) {
         return inquiryRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/inquiry/service/InquiryService.java
@@ -1,0 +1,62 @@
+package com.dodo.dodoserver.domain.inquiry.service;
+
+import com.dodo.dodoserver.domain.inquiry.dao.InquiryRepository;
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryRequestDto;
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryResponseDto;
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Transactional
+    public InquiryResponseDto createInquiry(User user, InquiryRequestDto requestDto) {
+        Inquiry inquiry = Inquiry.builder()
+                .user(user)
+                .type(requestDto.getType())
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .build();
+
+        return InquiryResponseDto.from(inquiryRepository.save(inquiry));
+    }
+
+    public Page<InquiryResponseDto> getMyInquiries(User user, Pageable pageable) {
+        return inquiryRepository.findAllByUser(user, pageable)
+                .map(InquiryResponseDto::from);
+    }
+
+    @Transactional
+    public InquiryResponseDto updateInquiry(User user, Long inquiryId, InquiryRequestDto requestDto) {
+        Inquiry inquiry = findById(inquiryId);
+        inquiry.validateOwner(user);
+        inquiry.update(requestDto.getType(), requestDto.getTitle(), requestDto.getContent());
+
+        return InquiryResponseDto.from(inquiry);
+    }
+
+    @Transactional
+    public void deleteInquiry(User user, Long inquiryId) {
+        Inquiry inquiry = findById(inquiryId);
+        inquiry.validateOwner(user);
+        inquiry.validateForDelete();
+
+        inquiryRepository.delete(inquiry);
+    }
+
+    private Inquiry findById(Long id) {
+        return inquiryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -66,7 +66,12 @@ public enum ErrorCode {
 
     // Whitelist (W)
     WHITELIST_NOT_FOUND(HttpStatus.NOT_FOUND, "W001", "화이트리스트 정보를 찾을 수 없습니다."),
-    DUPLICATE_WHITELIST_EMAIL(HttpStatus.BAD_REQUEST, "W002", "이미 화이트리스트에 등록된 이메일입니다.");
+    DUPLICATE_WHITELIST_EMAIL(HttpStatus.BAD_REQUEST, "W002", "이미 화이트리스트에 등록된 이메일입니다."),
+
+    // Inquiry (IQ)
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "IQ001", "문의사항을 찾을 수 없습니다."),
+    NOT_INQUIRY_OWNER(HttpStatus.FORBIDDEN, "IQ002", "해당 문의사항에 대한 권한이 없습니다."),
+    CANNOT_MODIFY_COMPLETED_INQUIRY(HttpStatus.BAD_REQUEST, "IQ003", "처리 완료된 문의는 수정하거나 삭제할 수 없습니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -8,6 +8,7 @@ public final class NotificationConstants {
     public static final String KEY_NEST_ID = "nestId";
     public static final String KEY_COMMENT_ID = "commentId";
     public static final String KEY_POSTCARD_ID = "postcardId";
+    public static final String KEY_INQUIRY_ID = "inquiryId";
 
     // Type Values
     public static final String TYPE_COMMENT = "COMMENT";
@@ -19,6 +20,7 @@ public final class NotificationConstants {
     public static final String TYPE_NEST_DELETED = "NEST_DELETED";
     public static final String TYPE_POSTCARD_DELETED = "POSTCARD_DELETED";
     public static final String TYPE_COMMENT_DELETED = "COMMENT_DELETED";
+    public static final String TYPE_INQUIRY_ANSWERED = "INQUIRY_ANSWERED";
 
     // Message Templates
     public static final String TITLE_NEST_DELETED = "둥지 삭제 알림";
@@ -39,6 +41,8 @@ public final class NotificationConstants {
     public static final String BODY_POSTCARD_EXCHANGED = "누군가 %s둥지에서 당신의 엽서를 가져갔어요!";
     public static final String TITLE_POSTCARD_LIKE = "내 엽서에 리액션이 달렸어요!";
     public static final String BODY_POSTCARD_LIKE = "%s님이 회원님의 엽서에 '%s'라고 반응했습니다.";
+    public static final String TITLE_INQUIRY_ANSWERED = "문의 답변 등록 알림";
+    public static final String BODY_INQUIRY_ANSWERED = "문의하신 내용에 답변이 등록되었습니다.";
 
     private NotificationConstants() {
     }

--- a/src/main/java/com/dodo/dodoserver/global/config/SoftDeleteFilterAspect.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SoftDeleteFilterAspect.java
@@ -33,7 +33,7 @@ public class SoftDeleteFilterAspect {
             session.disableFilter("nestFilter");
             session.disableFilter("commentFilter");
             session.disableFilter("postcardFilter");
-            session.disableFilter("inquiryFilter");
+            session.enableFilter("inquiryFilter");
             return;
         }
 

--- a/src/main/java/com/dodo/dodoserver/global/config/SoftDeleteFilterAspect.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SoftDeleteFilterAspect.java
@@ -33,6 +33,7 @@ public class SoftDeleteFilterAspect {
             session.disableFilter("nestFilter");
             session.disableFilter("commentFilter");
             session.disableFilter("postcardFilter");
+            session.disableFilter("inquiryFilter");
             return;
         }
 
@@ -42,6 +43,7 @@ public class SoftDeleteFilterAspect {
             session.enableFilter("nestFilter");
             session.disableFilter("commentFilter");
             session.enableFilter("postcardFilter");
+            session.enableFilter("inquiryFilter");
             return;
         }
 
@@ -49,5 +51,6 @@ public class SoftDeleteFilterAspect {
         session.enableFilter("nestFilter");
         session.enableFilter("commentFilter");
         session.enableFilter("postcardFilter");
+        session.enableFilter("inquiryFilter");
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/inquiry/service/AdminInquiryServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/inquiry/service/AdminInquiryServiceTest.java
@@ -1,0 +1,89 @@
+package com.dodo.dodoserver.domain.admin.inquiry.service;
+
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.InquiryAnswerRequestDto;
+import com.dodo.dodoserver.domain.inquiry.dao.InquiryRepository;
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryType;
+import com.dodo.dodoserver.domain.inquiry.service.InquiryNotificationService;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminInquiryServiceTest {
+
+    @InjectMocks
+    private AdminInquiryService adminInquiryService;
+
+    @Mock
+    private InquiryRepository inquiryRepository;
+
+    @Mock
+    private InquiryNotificationService inquiryNotificationService;
+
+    @Test
+    @DisplayName("관리자용 문의 목록 조회 성공")
+    void getInquiries_success() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 10);
+        User user = User.builder().id(1L).nickname("유저").build();
+        Inquiry inquiry = Inquiry.builder()
+                .id(1L)
+                .user(user)
+                .type(InquiryType.BUG)
+                .title("제목")
+                .status(InquiryStatus.PENDING)
+                .build();
+        Page<AdminInquiryResponseDto> page = new PageImpl<>(List.of(AdminInquiryResponseDto.from(inquiry)));
+
+        given(inquiryRepository.findInquiriesForAdmin(InquiryStatus.PENDING, pageable)).willReturn(page);
+
+        // when
+        Page<AdminInquiryResponseDto> result = adminInquiryService.getInquiries(InquiryStatus.PENDING, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("제목");
+    }
+
+    @Test
+    @DisplayName("문의 답변 등록 성공 및 알림 이벤트 발행 확인")
+    void answerInquiry_success() {
+        // given
+        Long inquiryId = 1L;
+        User user = User.builder().id(1L).email("user@test.com").build();
+        Inquiry inquiry = Inquiry.builder()
+                .id(inquiryId)
+                .user(user)
+                .status(InquiryStatus.PENDING)
+                .build();
+        InquiryAnswerRequestDto requestDto = new InquiryAnswerRequestDto("답변 내용");
+
+        given(inquiryRepository.findById(inquiryId)).willReturn(Optional.of(inquiry));
+
+        // when
+        adminInquiryService.answerInquiry(inquiryId, requestDto);
+
+        // then
+        assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.COMPLETED);
+        assertThat(inquiry.getAnswer()).isEqualTo("답변 내용");
+        verify(inquiryNotificationService).sendInquiryAnswerNotification(inquiry);
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/inquiry/service/InquiryServiceTest.java
@@ -1,0 +1,142 @@
+package com.dodo.dodoserver.domain.inquiry.service;
+
+import com.dodo.dodoserver.domain.inquiry.dao.InquiryRepository;
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryRequestDto;
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryResponseDto;
+import com.dodo.dodoserver.domain.inquiry.entity.Inquiry;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryStatus;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryType;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InquiryServiceTest {
+
+    @InjectMocks
+    private InquiryService inquiryService;
+
+    @Mock
+    private InquiryRepository inquiryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("문의 등록 성공")
+    void createInquiry_success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        InquiryRequestDto requestDto = new InquiryRequestDto(InquiryType.BUG, "제목", "내용");
+        Inquiry inquiry = Inquiry.builder()
+                .id(1L)
+                .user(user)
+                .type(InquiryType.BUG)
+                .title("제목")
+                .content("내용")
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(inquiryRepository.save(any(Inquiry.class))).willReturn(inquiry);
+
+        // when
+        InquiryResponseDto result = inquiryService.createInquiry(userId, requestDto);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("제목");
+        assertThat(result.getStatus()).isEqualTo(InquiryStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("내 문의 목록 조회 성공")
+    void getMyInquiries_success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        PageRequest pageable = PageRequest.of(0, 10);
+        Inquiry inquiry = Inquiry.builder()
+                .id(1L)
+                .user(user)
+                .type(InquiryType.ACCOUNT)
+                .title("문의")
+                .build();
+        Page<Inquiry> page = new PageImpl<>(List.of(inquiry));
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(inquiryRepository.findAllByUser(user, pageable)).willReturn(page);
+
+        // when
+        Page<InquiryResponseDto> result = inquiryService.getMyInquiries(userId, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("문의");
+    }
+
+    @Test
+    @DisplayName("문의 수정 실패 - 처리 완료된 문의")
+    void updateInquiry_fail_completed() {
+        // given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        Long inquiryId = 1L;
+        Inquiry inquiry = Inquiry.builder()
+                .id(inquiryId)
+                .user(user)
+                .status(InquiryStatus.COMPLETED)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(inquiryRepository.findById(inquiryId)).willReturn(Optional.of(inquiry));
+        InquiryRequestDto requestDto = new InquiryRequestDto(InquiryType.BUG, "수정제목", "수정내용");
+
+        // when & then
+        assertThatThrownBy(() -> inquiryService.updateInquiry(userId, inquiryId, requestDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.CANNOT_MODIFY_COMPLETED_INQUIRY.getMessage());
+    }
+
+    @Test
+    @DisplayName("문의 삭제 성공")
+    void deleteInquiry_success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        Long inquiryId = 1L;
+        Inquiry inquiry = Inquiry.builder()
+                .id(inquiryId)
+                .user(user)
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(inquiryRepository.findById(inquiryId)).willReturn(Optional.of(inquiry));
+
+        // when
+        inquiryService.deleteInquiry(userId, inquiryId);
+
+        // then
+        verify(inquiryRepository).delete(inquiry);
+    }
+}


### PR DESCRIPTION
## 📌 개요 (Overview)
  사용자가 서비스 이용 중 발생하는 문제나 문의사항을 관리자에게 직접 전달하고, 관리자가 답변을 제공할 수 있는 1:1 문의 시스템을 구축하였습니다. 답변 등록 시 유저에게 실시간 FCM 알림이 전송되어 원활한 피드백 루프를 지원합니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - [x] 도메인 엔티티 및 Enum 설계: Inquiry 엔티티와 관련 Enum(InquiryType, InquiryStatus) 구현
   - [x] Soft Delete 적용: @Filter를 사용하여 유저/관리자 API 호출 시 삭제된 문의가 필터링되도록 설정 (관리자 API는 필요 시 해제 가능)
   - [x] 유저용 API 구현:
       - 1:1 문의 등록 (POST /api/v1/inquiries)
       - 내 문의 리스트 조회 (GET /api/v1/inquiries/me)
       - 문의 수정/삭제 (처리 완료 상태 시 IQ003 예외 처리로 무결성 보장)
   - [x] 관리자용 API 구현:
       - 문의 리스트 조회 (상태별 필터링 지원, Querydsl 연동)
       - 문의 상세 조회
       - 문의 답변 등록 및 상태 변경 로직
   - [x] FCM 알림 연동: ApplicationEventPublisher 기반의 이벤트 발행 방식으로 관리자 답변 시 비동기 알림 발송 (INQUIRY_ANSWERED 타입)
   - [x] 테스트 및 검증: InquiryService 및 AdminInquiryService에 대한 단위 테스트 코드 작성 및 통과 완료





## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #69 

## 📝 추가 참고 사항 (Additional Notes)
   - 유저용 API는 UserPrincipal에서 userId를 추출하여 처리하도록 보안 컨벤션을 준수하였습니다.
   - 관리자용 API는 글로벌 SecurityConfig의 /api/v1/admin/** 설정에 의해 ADMIN 권한이 강제됩니다.
   - 클라이언트 개발자를 위한 상세 API JSON 명세서를 별도로 정리하여 공유하였습니다. (노션)

