### PR TITLE
Feat/68/notification payload update

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestService.java
@@ -288,7 +288,7 @@ public class AdminNestService {
                     tokens,
                     TITLE_COMMENT_DELETED,
                     reason,
-                    Map.of(KEY_TYPE, TYPE_COMMENT_DELETED, KEY_COMMENT_ID, commentId.toString())
+                    Map.of(KEY_TYPE, TYPE_COMMENT_DELETED, KEY_NEST_ID, comment.getNest().getId().toString())
             ));
         }
         

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestNotificationService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestNotificationService.java
@@ -66,7 +66,6 @@ public class NestNotificationService {
         Map<String, String> data = new HashMap<>();
         data.put(KEY_TYPE, type);
         data.put(KEY_NEST_ID, nest.getId().toString());
-        data.put(KEY_COMMENT_ID, savedComment.getId().toString());
 
         // 이벤트 발행
         eventPublisher.publishEvent(new NotificationEvent(fcmTokens, title, body, data));
@@ -116,7 +115,6 @@ public class NestNotificationService {
         Map<String, String> data = new HashMap<>();
         data.put(KEY_TYPE, TYPE_COMMENT_LIKE);
         data.put(KEY_NEST_ID, nest.getId().toString());
-        data.put(KEY_COMMENT_ID, comment.getId().toString());
 
         eventPublisher.publishEvent(new NotificationEvent(fcmTokens, TITLE_COMMENT_LIKE,
                 String.format(BODY_COMMENT_LIKE, reactor.getNickname()), data));

--- a/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
+++ b/src/main/java/com/dodo/dodoserver/global/common/constants/NotificationConstants.java
@@ -6,17 +6,16 @@ public final class NotificationConstants {
     // Data Keys
     public static final String KEY_TYPE = "type";
     public static final String KEY_NEST_ID = "nestId";
-    public static final String KEY_COMMENT_ID = "commentId";
     public static final String KEY_POSTCARD_ID = "postcardId";
     public static final String KEY_INQUIRY_ID = "inquiryId";
 
     // Type Values
-    public static final String TYPE_COMMENT = "COMMENT";
-    public static final String TYPE_REPLY = "REPLY";
-    public static final String TYPE_NEST_LIKE = "NEST_LIKE";
-    public static final String TYPE_COMMENT_LIKE = "COMMENT_LIKE";
-    public static final String TYPE_POSTCARD_EXCHANGED = "POSTCARD_EXCHANGED";
-    public static final String TYPE_POSTCARD_LIKE = "POSTCARD_LIKE";
+    public static final String TYPE_COMMENT = "NEST";
+    public static final String TYPE_REPLY = "NEST";
+    public static final String TYPE_NEST_LIKE = "NEST";
+    public static final String TYPE_COMMENT_LIKE = "NEST";
+    public static final String TYPE_POSTCARD_EXCHANGED = "POSTCARD";
+    public static final String TYPE_POSTCARD_LIKE = "POSTCARD";
     public static final String TYPE_NEST_DELETED = "NEST_DELETED";
     public static final String TYPE_POSTCARD_DELETED = "POSTCARD_DELETED";
     public static final String TYPE_COMMENT_DELETED = "COMMENT_DELETED";

--- a/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
+++ b/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
@@ -32,13 +32,14 @@ public class FcmService {
 			return;
 		}
 
+		// event.data()가 불변 객체일 수 있으므로 수정 가능한 HashMap으로 복사
+		java.util.Map<String, String> dynamicData = new java.util.HashMap<>(event.data());
+		dynamicData.put("title", event.title());
+		dynamicData.put("body", event.body());
+
 		MulticastMessage message = MulticastMessage.builder()
 			.addAllTokens(event.tokens())
-			.setNotification(Notification.builder()
-				.setTitle(event.title())
-				.setBody(event.body())
-				.build())
-			.putAllData(event.data())
+			.putAllData(dynamicData) // title, body가 포함된 통합 데이터 맵 전송
 			.setAndroidConfig(AndroidConfig.builder()
 				.setPriority(AndroidConfig.Priority.HIGH)
 				.build())
@@ -46,7 +47,7 @@ public class FcmService {
 
 		try {
 			BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
-			log.info("FCM Sent Successfully. Success count: {}, Failure count: {}", 
+			log.info("FCM Sent Successfully (Pure Data Message). Success count: {}, Failure count: {}", 
 				response.getSuccessCount(), response.getFailureCount());
 			
 			if (response.getFailureCount() > 0) {

--- a/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
+++ b/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
@@ -4,7 +4,6 @@ import com.google.firebase.messaging.AndroidConfig;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +13,9 @@ import org.springframework.stereotype.Service;
 
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.SendResponse;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -54,14 +56,22 @@ public class FcmService {
 
 		try {
 			BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
-			log.info("FCM Sent Successfully (Pure Data Message). Success count: {}, Failure count: {}", 
+			log.info("[NOTIFICATION] FCM Sent Successfully (Pure Data Message). Success count: {}, Failure count: {}",
 				response.getSuccessCount(), response.getFailureCount());
 			
 			if (response.getFailureCount() > 0) {
-				log.warn("FCM Partial Failures detected. Check logs for details.");
+				log.warn("[NOTIFICATION] FCM Partial Failures detected. Details:");
+				List<SendResponse> responses = response.getResponses();
+				for (int i = 0; i < responses.size(); i++) {
+					SendResponse sr = responses.get(i);
+					if (!sr.isSuccessful()) {
+						log.warn("[NOTIFICATION] Failure at index {}: Token={}, Error={}",
+							i, event.tokens().get(i), sr.getException().getMessage());
+					}
+				}
 			}
 		} catch (FirebaseMessagingException e) {
-			log.error("FCM Multicast Send Failed: {}", e.getMessage());
+			log.error("[NOTIFICATION] FCM Multicast Send Failed: {}", e.getMessage());
 			throw new RuntimeException("FCM 전송 중 오류 발생", e);
 		}
 	}

--- a/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
+++ b/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
@@ -32,10 +32,17 @@ public class FcmService {
 			return;
 		}
 
-		// event.data()가 불변 객체일 수 있으므로 수정 가능한 HashMap으로 복사
-		java.util.Map<String, String> dynamicData = new java.util.HashMap<>(event.data());
-		dynamicData.put("title", event.title());
-		dynamicData.put("body", event.body());
+		// event.data()가 불변 객체일 수 있으므로 수정 가능한 HashMap으로 복사 (null 체크 포함)
+		java.util.Map<String, String> dynamicData = event.data() != null 
+			? new java.util.HashMap<>(event.data()) 
+			: new java.util.HashMap<>();
+
+		if (event.title() != null) {
+			dynamicData.put("title", event.title());
+		}
+		if (event.body() != null) {
+			dynamicData.put("body", event.body());
+		}
 
 		MulticastMessage message = MulticastMessage.builder()
 			.addAllTokens(event.tokens())

--- a/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
+++ b/src/main/java/com/dodo/dodoserver/infrastructure/fcm/FcmService.java
@@ -56,18 +56,17 @@ public class FcmService {
 
 		try {
 			BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
-			log.info("[NOTIFICATION] FCM Sent Successfully (Pure Data Message). Success count: {}, Failure count: {}",
+			log.info("FCM Sent Successfully (Pure Data Message). Success count: {}, Failure count: {}", 
 				response.getSuccessCount(), response.getFailureCount());
-			
-			if (response.getFailureCount() > 0) {
-				log.warn("[NOTIFICATION] FCM Partial Failures detected. Details:");
-				List<SendResponse> responses = response.getResponses();
-				for (int i = 0; i < responses.size(); i++) {
-					SendResponse sr = responses.get(i);
-					if (!sr.isSuccessful()) {
-						log.warn("[NOTIFICATION] Failure at index {}: Token={}, Error={}",
-							i, event.tokens().get(i), sr.getException().getMessage());
-					}
+
+			List<SendResponse> responses = response.getResponses();
+			for (int i = 0; i < responses.size(); i++) {
+				SendResponse sr = responses.get(i);
+				if (sr.isSuccessful()) {
+					log.info("[NOTIFICATION] Success at index {}: Token={}", i, event.tokens().get(i));
+				} else {
+					log.warn("[NOTIFICATION] Failure at index {}: Token={}, Error={}", 
+						i, event.tokens().get(i), sr.getException().getMessage());
 				}
 			}
 		} catch (FirebaseMessagingException e) {

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -29,8 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.dodo.dodoserver.global.common.constants.NotificationConstants.DEFAULT_COMMENT_DELETE_REASON;
-import static com.dodo.dodoserver.global.common.constants.NotificationConstants.DEFAULT_NEST_DELETE_REASON;
+import static com.dodo.dodoserver.global.common.constants.NotificationConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -161,7 +160,8 @@ class AdminNestServiceTest {
     void deleteCommentForAdmin_success() {
         // given
         User author = User.builder().id(1L).build();
-        NestComment comment = NestComment.builder().id(10L).user(author).build();
+        Nest nest = Nest.builder().id(100L).build();
+        NestComment comment = NestComment.builder().id(10L).user(author).nest(nest).build();
         UserDevice device = UserDevice.builder().fcmToken("token").build();
         AdminCommentDeleteRequestDto requestDto = mock(AdminCommentDeleteRequestDto.class);
         given(requestDto.getReason()).willReturn("부적절한 댓글");
@@ -174,7 +174,9 @@ class AdminNestServiceTest {
 
         // then
         verify(fcmService, times(1)).sendNotification(argThat(event -> 
-                event.body().equals("부적절한 댓글")));
+                event.body().equals("부적절한 댓글") &&
+                event.data().get(KEY_NEST_ID).equals("100") &&
+                !event.data().containsKey("commentId")));
         verify(commentLikeRepository, times(1)).deleteByComment(comment);
         verify(nestCommentRepository, times(1)).delete(comment);
         verify(reportRepository, times(1)).updateStatusByTarget(ReportType.COMMENT, 10L, ReportStatus.PROCESSED);
@@ -185,7 +187,8 @@ class AdminNestServiceTest {
     void deleteComment_useDefaultReason_whenReasonIsMissing() {
         // given
         User author = User.builder().id(1L).build();
-        NestComment comment = NestComment.builder().id(10L).user(author).build();
+        Nest nest = Nest.builder().id(100L).build();
+        NestComment comment = NestComment.builder().id(10L).user(author).nest(nest).build();
         UserDevice device = UserDevice.builder().fcmToken("token").build();
         AdminCommentDeleteRequestDto requestDto = new AdminCommentDeleteRequestDto();
 
@@ -197,7 +200,8 @@ class AdminNestServiceTest {
 
         // then
         verify(fcmService).sendNotification(argThat(event -> 
-            event.body().equals(DEFAULT_COMMENT_DELETE_REASON)
+            event.body().equals(DEFAULT_COMMENT_DELETE_REASON) &&
+            event.data().get(KEY_NEST_ID).equals("100")
         ));
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestNotificationServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestNotificationServiceTest.java
@@ -161,7 +161,6 @@ class NestNotificationServiceTest {
         NotificationEvent event = captor.getValue();
         assertThat(event.title()).isEqualTo(NotificationConstants.TITLE_COMMENT_LIKE);
         assertThat(event.data().get(NotificationConstants.KEY_TYPE)).isEqualTo(NotificationConstants.TYPE_COMMENT_LIKE);
-        assertThat(event.data().get(NotificationConstants.KEY_COMMENT_ID)).isEqualTo(comment.getId().toString());
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
알림 구조를 Pure Data Message 방식으로 변경하고, 클라이언트 라우팅 효율화를 위해 알림 타입 및 페이로드 키를 최적화했습니다.

## 🛠️ 작업 내용 (Changes)
   - FCM 전송 방식 변경 (FcmService)
       - MulticastMessage 구성 시 notification 블록을 삭제하고 title과 body를 data 페이로드에 포함하여 전송 (Pure Data Message 전환)
   - 알림 상수 통합 및 최적화 (NotificationConstants)
       - NEST 관련 타입(TYPE_COMMENT, TYPE_REPLY 등) 및 POSTCARD 관련 타입을 각각 "NEST", "POSTCARD"로 단일화
       - 미사용되는 KEY_COMMENT_ID 상수를 삭제하고 관련 로직 제거
   - 라우팅 데이터 단일화
       - 댓글, 답글, 댓글 좋아요 알림 시 클라이언트에서 둥지로 바로 이동할 수 있도록 nestId만 전달하도록 수정 (NestNotificationService, AdminNestService)
   - 테스트 코드 정비
       - 변경된 알림 구조 및 상수에 맞춰 NestNotificationServiceTest, AdminNestServiceTest의 검증 로직 수정 및 NPE 해결


``` markdwon
 현재 백엔드는 Pure Data Message 방식을 사용하므로, 모든 알림 데이터는 data 페이로드 내에 포함되어 전달됩니다. 안드로이드 클라이언트에서는 FirebaseMessagingService.onMessageReceived()에서 remoteMessage.data를 통해
  title, body 및 이동 경로 데이터를 추출해야 합니다.

  ---

  📡 공통 메시지 규격 (Common Payload)

  ┌──────────┬────────┬─────────────────────────────────────────────────────────────┐
  │ Key      │ Type   │ Description                                                 │
  ├──────────┼────────┼─────────────────────────────────────────────────────────────┤
  │ title    │ String │ 알림 제목 (시스템 트레이에 표시할 텍스트)                   │
  │ body     │ String │ 알림 본문 (시스템 트레이에 표시할 상세 내용)                │
  │ type     │ String │ 알림 타입 (앱 내 라우팅 및 아이콘 구분용)                   │
  │ {ID_KEY} │ String │ 상세 페이지 이동을 위한 고유 ID (예: nestId, postcardId 등) │
  └──────────┴────────┴─────────────────────────────────────────────────────────────┘
  ---

  1. 둥지(NEST) 관련 알림
  이 타입은 댓글, 답글, 좋아요 등 둥지 내 인터랙션이 발생했을 때 전송됩니다.

  ┌──────────────────┬─────────────────┬───────────────┬───────────────────────────┐
  │ 시나리오         │ type            │ 추가 Data Key │ 비고                      │
  ├──────────────────┼─────────────────┼───────────────┼───────────────────────────┤
  │ 새 댓글 등록     │ NEST            │ nestId        │ 둥지 제작자에게 전송      │
  │ 댓글의 답글 등록 │ NEST            │ nestId        │ 부모 댓글 작성자에게 전송 │
  │ 둥지 좋아요      │ NEST            │ nestId        │ 둥지 제작자에게 전송      │
  │ 댓글 좋아요      │ NEST            │ nestId        │ 댓글 작성자에게 전송      │
  │ 관리자 댓글 삭제 │ COMMENT_DELETED │ nestId        │ 댓글 작성자에게 제재 알림 │
  │ 관리자 둥지 삭제 │ NEST_DELETED    │ nestId        │ 둥지 작성자에게 제재 알림 │
  └──────────────────┴─────────────────┴───────────────┴───────────────────────────┘
  ---

  2. 엽서(POSTCARD) 관련 알림
  엽서 교환 및 리액션 관련 알림입니다.

  ┌──────────────────┬──────────────────┬────────────────────┬───────────────────────────┐
  │ 시나리오         │ type             │ 추가 Data Key      │ 비고                      │
  ├──────────────────┼──────────────────┼────────────────────┼───────────────────────────┤
  │ 엽서 교환 완료   │ POSTCARD         │ nestId, postcardId │ 엽서 원작자에게 전송      │
  │ 엽서 리액션      │ POSTCARD         │ postcardId         │ 엽서 원작자에게 전송      │
  │ 관리자 엽서 삭제 │ POSTCARD_DELETED │ postcardId         │ 엽서 작성자에게 제재 알림 │
  └──────────────────┴──────────────────┴────────────────────┴───────────────────────────┘
  ---

  3. 문의(INQUIRY) 및 공지(NOTICE)
  1:1 문의 답변 및 시스템 전체 공지 알림입니다.

  ┌────────────────┬──────────────────┬───────────────┬────────────────────────────────┐
  │ 시나리오       │ type             │ 추가 Data Key │ 비고                           │
  ├────────────────┼──────────────────┼───────────────┼────────────────────────────────┤
  │ 문의 답변 등록 │ INQUIRY_ANSWERED │ inquiryId     │ 문의 작성자에게 전송           │
  │ 전체 공지 발행 │ NOTICE           │ noticeId      │ 모든 유저에게 배치(Batch) 전송 │
  └────────────────┴──────────────────┴───────────────┴────────────────────────────────┘
  ---

  🔍 백엔드 코드상 실제 사용되는 Key/Value 목록

  안드로이드 onMessageReceived에서 사용할 상수 값들입니다.

    1 // Data Keys
    2 val KEY_TITLE = "title"
    3 val KEY_BODY = "body"
    4 val KEY_TYPE = "type"
    5 val KEY_NEST_ID = "nestId"
    6 val KEY_POSTCARD_ID = "postcardId"
    7 val KEY_INQUIRY_ID = "inquiryId"
    8 val KEY_NOTICE_ID = "noticeId"
    9
   10 // Type Values
   11 val TYPE_NEST = "NEST"
   12 val TYPE_POSTCARD = "POSTCARD"
   13 val TYPE_INQUIRY_ANSWERED = "INQUIRY_ANSWERED"
   14 val TYPE_NOTICE = "NOTICE"
   15 val TYPE_NEST_DELETED = "NEST_DELETED"
   16 val TYPE_POSTCARD_DELETED = "POSTCARD_DELETED"
   17 val TYPE_COMMENT_DELETED = "COMMENT_DELETED"

  💡 안드로이드 구현 가이드 (Example)

    1 override fun onMessageReceived(remoteMessage: RemoteMessage) {
    2     val data = remoteMessage.data
    3     val title = data["title"]
    4     val body = data["body"]
    5     val type = data["type"]
    6
    7     when (type) {
    8         "NEST" -> {
    9             val nestId = data["nestId"]
   10             // 둥지 상세 페이지 이동 로직
   11         }
   12         "POSTCARD" -> {
   13             val postcardId = data["postcardId"]
   14             // 엽서 상세 페이지 이동 로직
   15         }
   16         // ... 기타 타입 처리
   17     }
   18
   19     // 알림 생성 로직 호출
   20     sendNotification(title, body, type, data)
   21 }
```

## 결과 (/ Results)
   - 모든 알림은 이제 data: { "title": "...", "body": "...", "type": "...", "nestId": "..." } 형태의 Pure Data Payload로 발송됩니다.


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #68

## 📝 추가 참고 사항 (Additional Notes)
   - 안드로이드 클라이언트에서는 이제 remoteMessage.data에서 title과 body를 직접 추출하여 시스템 알림을 생성해야 합니다.
   - KEY_COMMENT_ID가 제거되었으므로, 클라이언트에서도 해당 키에 의존하는 로직이 있다면 수정이 필요합니다.
