### PR TITLE
Feat/73/add author id to reported postcards

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
@@ -267,7 +267,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
                 ));
 
         Map<Long, Tuple> postcardInfoMap = queryFactory
-                .select(postcard.id, user.nickname, postcard.content, postcard.imageUrl)
+                .select(postcard.id, user.id, user.nickname, postcard.content, postcard.imageUrl)
                 .from(postcard)
                 .join(postcard.originalAuthor, user)
                 .where(postcard.id.in(targetIds))
@@ -283,6 +283,7 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
 
             return AdminPostcardReportResponseDto.builder()
                     .postcardId(id)
+                    .authorId(info != null ? info.get(user.id) : null)
                     .authorNickname(info != null ? info.get(user.nickname) : "알 수 없음")
                     .content(info != null ? info.get(postcard.content) : "")
                     .imageUrl(info != null ? info.get(postcard.imageUrl) : "")

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dao/AdminReportRepositoryCustomImpl.java
@@ -281,12 +281,24 @@ public class AdminReportRepositoryCustomImpl implements AdminReportRepositoryCus
             Long reportCount = t.get(report.targetId.count());
             ReportStatus status = t.get(report.status.min());
 
+            Long authorId = null;
+            String authorNickname = "알 수 없음";
+            String postcardContent = "";
+            String imageUrl = "";
+
+            if (info != null) {
+                authorId = info.get(user.id);
+                authorNickname = info.get(user.nickname);
+                postcardContent = info.get(postcard.content);
+                imageUrl = info.get(postcard.imageUrl);
+            }
+
             return AdminPostcardReportResponseDto.builder()
                     .postcardId(id)
-                    .authorId(info != null ? info.get(user.id) : null)
-                    .authorNickname(info != null ? info.get(user.nickname) : "알 수 없음")
-                    .content(info != null ? info.get(postcard.content) : "")
-                    .imageUrl(info != null ? info.get(postcard.imageUrl) : "")
+                    .authorId(authorId)
+                    .authorNickname(authorNickname)
+                    .content(postcardContent)
+                    .imageUrl(imageUrl)
                     .firstReportedAt(t.get(report.createdAt.min()))
                     .lastReportedAt(t.get(report.createdAt.max()))
                     .reportCount(reportCount != null ? reportCount : 0L)

--- a/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminPostcardReportResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/report/dto/AdminPostcardReportResponseDto.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Builder
 public class AdminPostcardReportResponseDto {
     private Long postcardId;
+    private Long authorId;
     private String authorNickname;
     private String content;
     private String imageUrl;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ logging:
   level:
     org.springframework.web: INFO
     org.hibernate.SQL: DEBUG
-    org.hibernate.orm.results: TRACE
+    org.hibernate.orm.results: INFO
     com.dodo.dodoserver: DEBUG
 
 

--- a/src/test/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/postcard/controller/AdminPostcardControllerTest.java
@@ -85,6 +85,7 @@ class AdminPostcardControllerTest {
         // given
         AdminPostcardReportResponseDto responseDto = AdminPostcardReportResponseDto.builder()
                 .postcardId(1L)
+                .authorId(10L)
                 .authorNickname("유저1")
                 .build();
         given(adminPostcardService.getReportedPostcards(any(), any(), any()))
@@ -98,6 +99,7 @@ class AdminPostcardControllerTest {
                         .param("sort", "RECENT_REPORT"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].authorId").value(10))
                 .andExpect(jsonPath("$.data.content[0].authorNickname").value("유저1"));
     }
 

--- a/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/postcard/service/AdminPostcardServiceTest.java
@@ -56,6 +56,7 @@ class AdminPostcardServiceTest {
         // given
         AdminPostcardReportResponseDto responseDto = AdminPostcardReportResponseDto.builder()
                 .postcardId(1L)
+                .authorId(10L)
                 .authorNickname("유저1")
                 .build();
         Page<AdminPostcardReportResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto));
@@ -66,6 +67,7 @@ class AdminPostcardServiceTest {
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getAuthorId()).isEqualTo(10L);
         assertThat(result.getContent().get(0).getAuthorNickname()).isEqualTo("유저1");
     }
 


### PR DESCRIPTION
## 📌 개요 (Overview)
신고된 엽서 목록 조회 API의 응답 규격에 작성자 ID(`authorId`) 필드를 추가하여, 관리자가 해당 엽서의 작성자를 명확히 식별할 수 있도록 개선했습니다.

## 🛠️ 작업 내용 (Changes)
   - AdminPostcardReportResponseDto 내 authorId 필드 추가
   - AdminReportRepositoryCustomImpl에서 Querydsl Tuple 조회 시 user.id를 추가로 fetch하도록 수정
   - AdminPostcardControllerTest에 authorId 필드 검증 로직 추가
   - AdminPostcardServiceTest에 authorId 매핑 검증 로직 추가

## 📸 스크린샷 / 결과 (Screenshots / Results)
  API 응답 예시:
``` json
  {
      "status": "SUCCESS",
      "code": "200",
      "message": "성공",
      "data": {
          "content": [
              {
                  "postcardId": 15,
                  "authorId": 10,
                  "authorNickname": "안녕",
                  "content": "막창",
                  "imageUrl": "https://...",
                  ...
              }
          ],
          ...
      }
  }
```


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #73 

