### PR TITLE
Feat/75/admin lift sanction

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/controller/AdminController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/controller/AdminController.java
@@ -35,4 +35,13 @@ public class AdminController {
         adminService.sanctionUser(userId, requestDto);
         return ApiResponseDto.success(null);
     }
+
+    /**
+     * 유저 제재 해제
+     */
+    @DeleteMapping("/users/{userId}/sanction")
+    public ApiResponseDto<Void> deleteSanctionUser(@PathVariable Long userId) {
+        adminService.liftSanction(userId);
+        return ApiResponseDto.success(null);
+    }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/controller/AdminController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/controller/AdminController.java
@@ -40,7 +40,7 @@ public class AdminController {
      * 유저 제재 해제
      */
     @DeleteMapping("/users/{userId}/sanction")
-    public ApiResponseDto<Void> deleteSanctionUser(@PathVariable Long userId) {
+    public ApiResponseDto<Void> deleteSanction(@PathVariable Long userId) {
         adminService.liftSanction(userId);
         return ApiResponseDto.success(null);
     }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionHistory.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionHistory.java
@@ -27,7 +27,7 @@ public class SanctionHistory {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "sanction_type", nullable = false)
+    @Column(name = "sanction_type", nullable = false, length = 20)
     private SanctionType sanctionType;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionType.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionType.java
@@ -10,7 +10,8 @@ import java.time.LocalDateTime;
 public enum SanctionType {
     SEVEN_DAYS(7, "7일 정지"),
     THIRTY_DAYS(30, "30일 정지"),
-    PERMANENT(null, "영구 정지");
+    PERMANENT(null, "영구 정지"),
+    LIFTED(0, "제재 해제");
 
     private final Integer days;
     private final String description;
@@ -19,6 +20,9 @@ public enum SanctionType {
         if (this == PERMANENT) {
             // 영구 정지: 9999년 12월 31일
             return LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+        }
+        if (this == LIFTED) {
+            return LocalDateTime.now();
         }
         return LocalDateTime.now().plusDays(this.days);
     }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionType.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionType.java
@@ -18,8 +18,8 @@ public enum SanctionType {
 
     public LocalDateTime calculateEndedAt() {
         if (this == PERMANENT) {
-            // 영구 정지: 9999년 12월 31일
-            return LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+            // 영구 정지: 타임존 변환 시 MySQL DATETIME 범위를 넘지 않도록 안전하게 설정
+            return LocalDateTime.of(9999, 1, 1, 0, 0, 0);
         }
         if (this == LIFTED) {
             return LocalDateTime.now();

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionType.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/entity/SanctionType.java
@@ -21,9 +21,6 @@ public enum SanctionType {
             // 영구 정지: 타임존 변환 시 MySQL DATETIME 범위를 넘지 않도록 안전하게 설정
             return LocalDateTime.of(9999, 1, 1, 0, 0, 0);
         }
-        if (this == LIFTED) {
-            return LocalDateTime.now();
-        }
         return LocalDateTime.now().plusDays(this.days);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
@@ -72,7 +72,7 @@ public class AdminService {
                 .user(user)
                 .sanctionType(SanctionType.LIFTED)
                 .reason("관리자에 의한 제재 즉시 해제")
-                .endedAt(LocalDateTime.now())
+                .endedAt(SanctionType.LIFTED.calculateEndedAt())
                 .build();
 
         sanctionHistoryRepository.save(history);

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.admin.user.dao.UserAdminRepository;
 import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.domain.admin.user.dto.UserSanctionRequestDto;
 import com.dodo.dodoserver.domain.admin.user.entity.SanctionHistory;
+import com.dodo.dodoserver.domain.admin.user.entity.SanctionType;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
@@ -52,6 +53,28 @@ public class AdminService {
                 .endedAt(endedAt)
                 .build();
         
+        sanctionHistoryRepository.save(history);
+    }
+
+    /**
+     * 유저 제재 즉시 해제
+     */
+    @Transactional
+    public void liftSanction(Long userId) {
+        User user = userAdminRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 1. User 엔티티의 제재 정보 초기화
+        user.liftSanction();
+
+        // 2. 제재 해제 이력 저장
+        SanctionHistory history = SanctionHistory.builder()
+                .user(user)
+                .sanctionType(SanctionType.LIFTED)
+                .reason("관리자에 의한 제재 즉시 해제")
+                .endedAt(LocalDateTime.now())
+                .build();
+
         sanctionHistoryRepository.save(history);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/entity/User.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/entity/User.java
@@ -65,4 +65,11 @@ public class User {
     public void applySanction(LocalDateTime endedAt) {
         this.sanctionedUntil = endedAt;
     }
+
+    /**
+     * 유저의 제재를 해제합니다.
+     */
+    public void liftSanction() {
+        this.sanctionedUntil = null;
+    }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminControllerTest.java
@@ -158,7 +158,7 @@ class AdminControllerTest {
     @Test
     @DisplayName("유저 제재 해제 성공 - 관리자 권한")
     @WithMockUserPrincipal(role = "ROLE_ADMIN")
-    void deleteSanctionUser_success() throws Exception {
+    void deleteSanction_success() throws Exception {
         // when & then
         mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete("/api/v1/admin/users/1/sanction")
                         .with(csrf()))

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/controller/AdminControllerTest.java
@@ -154,4 +154,15 @@ class AdminControllerTest {
                 .andExpect(jsonPath("$.status").value("ERROR"))
                 .andExpect(jsonPath("$.code").value(ErrorCode.INPUT_VALIDATION_ERROR.getCode()));
     }
+
+    @Test
+    @DisplayName("유저 제재 해제 성공 - 관리자 권한")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void deleteSanctionUser_success() throws Exception {
+        // when & then
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete("/api/v1/admin/users/1/sanction")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/service/AdminServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/service/AdminServiceTest.java
@@ -78,4 +78,25 @@ class AdminServiceTest {
         assertThat(user.getSanctionedUntil().getYear()).isEqualTo(9999);
         verify(sanctionHistoryRepository).save(any(SanctionHistory.class));
     }
+
+    @Test
+    @DisplayName("유저 제재 즉시 해제 성공")
+    void liftSanction_success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .build();
+        user.applySanction(java.time.LocalDateTime.now().plusDays(7));
+
+        given(userAdminRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        adminService.liftSanction(userId);
+
+        // then
+        assertThat(user.getSanctionedUntil()).isNull();
+        verify(sanctionHistoryRepository).save(any(SanctionHistory.class));
+    }
 }


### PR DESCRIPTION
## 📌 개요 (Overview)
  관리자가 유저의 제재를 즉시 해제할 수 있는 API를 추가하여 운영 편의성을 개선했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - [x] User 엔티티 내 제재 해제 메서드(liftSanction) 추가
   - [x] SanctionType Enum에 LIFTED 타입 추가 및 종료 시점 계산 로직 반영
   - [x] AdminService 내 제재 해제 비즈니스 로직 및 이력(SanctionHistory) 저장 기능 구현
   - [x] AdminController에 제재 해제 엔드포인트(DELETE /api/v1/admin/users/{userId}/sanction) 추가
   - [x] 서비스 및 컨트롤러 단위 테스트 코드 작성 및 검증 완료



## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #75 

## 📝 추가 참고 사항 (Additional Notes)
   - 제재 해제 시에도 SanctionHistory에 기록을 남겨 운영 이력을 추적할 수 있도록 설계했습니다.