### PR TITLE
Feat/77/created exchanged filter

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -43,7 +43,7 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
     @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.originalAuthor = :user AND p.isShared = true")
     Page<Postcard> findCreatedSharedByUser(@Param("user") User user, Pageable pageable);
 
-    @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.originalAuthor = :user AND p.isExchanged = true")
+    @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.originalAuthor = :user AND p.isExchanged = true AND p.isShared = false")
     Page<Postcard> findCreatedExchangedByUser(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.currentOwner = :user AND p.originalAuthor != :user")

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/dao/PostcardRepository.java
@@ -43,6 +43,9 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long> {
     @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.originalAuthor = :user AND p.isShared = true")
     Page<Postcard> findCreatedSharedByUser(@Param("user") User user, Pageable pageable);
 
+    @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.originalAuthor = :user AND p.isExchanged = true")
+    Page<Postcard> findCreatedExchangedByUser(@Param("user") User user, Pageable pageable);
+
     @Query("SELECT p FROM Postcard p JOIN FETCH p.originalAuthor WHERE p.currentOwner = :user AND p.originalAuthor != :user")
     Page<Postcard> findAcquiredByUser(@Param("user") User user, Pageable pageable);
 

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -152,6 +152,8 @@ public class PostcardService {
             return postcardRepository.findCreatedNotSharedByUser(user, pageable);
         } else if ("CREATED_SHARED".equalsIgnoreCase(filter)) {
             return postcardRepository.findCreatedSharedByUser(user, pageable);
+        } else if ("CREATED_EXCHANGED".equalsIgnoreCase(filter)) {
+            return postcardRepository.findCreatedExchangedByUser(user, pageable);
         } else if ("ACQUIRED".equalsIgnoreCase(filter)) {
             return postcardRepository.findAcquiredByUser(user, pageable);
         } else {

--- a/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/mypage/service/MyPageServiceTest.java
@@ -114,6 +114,24 @@ class MyPageServiceTest {
     }
 
     @Test
+    @DisplayName("엽서 인벤토리 조회 - CREATED_EXCHANGED 필터")
+    void getMyPostcards_createdExchanged() {
+        // given
+        User user = User.builder().id(1L).nickname("test").build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Postcard postcard = Postcard.builder().id(1L).originalAuthor(user).build();
+        given(postcardService.getPostcardEntitiesByFilter(anyLong(), any(), any())).willReturn(new PageImpl<>(List.of(postcard)));
+        given(postcardReactionRepository.findAllByPostcardIn(any())).willReturn(Collections.emptyList());
+
+        // when
+        myPageService.getMyPostcards(1L, "CREATED_EXCHANGED", pageable);
+
+        // then
+        verify(postcardService).getPostcardEntitiesByFilter(1L, "CREATED_EXCHANGED", pageable);
+        verify(postcardReactionRepository).findAllByPostcardIn(any());
+    }
+
+    @Test
     @DisplayName("엽서 인벤토리 조회 - ACQUIRED 필터")
     void getMyPostcards_acquired() {
         // given

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -253,6 +253,7 @@ class PostcardServiceTest {
     void getPostcardInventory_createdExchanged_success() {
         // given
         myPostcard.setExchanged(true);
+        myPostcard.setShared(false);
         myPostcard.setCurrentOwner(null);
         List<Postcard> exchangedList = List.of(myPostcard);
         Page<Postcard> inventoryPage = new PageImpl<>(exchangedList);

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -249,6 +249,26 @@ class PostcardServiceTest {
     }
 
     @Test
+    @DisplayName("엽서 인벤토리 조회 성공 - 내가 생성하고 교환된 엽서만")
+    void getPostcardInventory_createdExchanged_success() {
+        // given
+        myPostcard.setExchanged(true);
+        myPostcard.setCurrentOwner(null);
+        List<Postcard> exchangedList = List.of(myPostcard);
+        Page<Postcard> inventoryPage = new PageImpl<>(exchangedList);
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(postcardRepository.findCreatedExchangedByUser(eq(user), any(Pageable.class))).willReturn(inventoryPage);
+
+        // when
+        Page<PostcardResponseDto> result = postcardService.getPostcardInventory(user.getId(), "CREATED_EXCHANGED", Pageable.unpaged());
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(myPostcard.getId());
+        assertThat(result.getContent().get(0).isExchanged()).isTrue();
+    }
+
+    @Test
     @DisplayName("엽서 인벤토리 조회 성공 - 내가 가져온 엽서만")
     void getPostcardInventory_acquired_success() {
         // given


### PR DESCRIPTION
## 📌 개요 (Overview)
마이페이지 엽서 목록 조회 시, 사용자가 직접 생성했으나 타인과 교환되어 소유권이 이전된 엽서들만 필터링하여 볼 수 있는 `CREATED_EXCHANGED` 필터 기능을 추가했습니다.

## 🛠️ 작업 내용 (Changes)
   - PostcardRepository에 원작자가 본인이며 교환 상태가 true인 엽서를 조회하는 findCreatedExchangedByUser JPQL 쿼리 메서드 추가
   - PostcardService의 getPostcardEntitiesByFilter 메서드에 CREATED_EXCHANGED 필터 처리 분기 로직 구현
   - MyPageServiceTest에 마이페이지 서비스의 신규 필터 호출 및 파라미터 전달 검증 테스트 추가
   - PostcardServiceTest에 서비스 계층의 실제 데이터 필터링 로직 작동 여부를 확인하는 단위 테스트 추가

## 📸 스크린샷 / 결과 (Screenshots / Results)
UI 변경사항이나 API 테스트 결과(Postman, Swagger 등)를 캡처하여 첨부해 주세요. (권장)


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #77 

## 📝 추가 참고 사항 (Additional Notes)
   - CREATED_EXCHANGED 필터는 엽서 생애 주기 중 '교환(The Atomic Swap)'이 완료된 엽서들만 반환합니다.
   - 조사 과정에서 마이페이지 통계 카운트(countPostcardsByUser) 로직이 남에게 받은 엽서만 집계하는 현상을 발견했습니다. 이는 별도의 이슈로 분리하여 처리하거나 추후 보완이 필요할 수 있습니다.
