### PR TITLE
fix/#71: 관리자 둥지 목록 조회 시 삭제된 댓글 제외하도록 수정

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
@@ -55,7 +55,7 @@ public class AdminNestRepositoryCustomImpl implements AdminNestRepositoryCustom 
                 .select(nest.id)
                 .from(nest)
                 .leftJoin(nestReaction).on(nestReaction.nest.eq(nest))
-                .leftJoin(nestComment).on(nestComment.nest.eq(nest))
+                .leftJoin(nestComment).on(nestComment.nest.eq(nest).and(nestComment.deletedAt.isNull()))
                 .leftJoin(report).on(report.targetId.eq(nest.id).and(report.reportType.eq(ReportType.NEST)))
                 .where(dateCondition, deletedCondition)
                 .groupBy(nest.id)
@@ -101,7 +101,7 @@ public class AdminNestRepositoryCustomImpl implements AdminNestRepositoryCustom 
         Map<Long, Long> commentCountMap = queryFactory
                 .select(nestComment.nest.id, nestComment.count())
                 .from(nestComment)
-                .where(nestComment.nest.id.in(nestIds))
+                .where(nestComment.nest.id.in(nestIds), nestComment.deletedAt.isNull())
                 .groupBy(nestComment.nest.id)
                 .fetch().stream()
                 .collect(Collectors.toMap(t -> t.get(nestComment.nest.id), t -> t.get(nestComment.count())));


### PR DESCRIPTION
## 📌 개요 (Overview)
관리자 도메인의 둥지(Nest) 목록 조회 API(`/api/v1/admin/nests`)에서 삭제된 댓글(soft-deleted)이 댓글 수(`commentCount`)에 포함되는 버그를 수정했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
- [x] `AdminNestRepositoryCustomImpl`의 둥지 목록 조회 쿼리 수정: 댓글 수 기준 정렬 시 `deleted_at IS NULL` 조건을 추가하여 유효한 댓글만 집계하도록 개선
- [x] `AdminNestRepositoryCustomImpl`의 통계 조회 쿼리 수정: `commentCountMap` 집계 시 `deleted_at IS NULL` 필터를 추가하여 삭제된 댓글 제외



## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #71 


