### PR TITLE
Feat/80/reissue sanction check

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 
@@ -57,8 +59,17 @@ public class AdminService {
         
         sanctionHistoryRepository.save(history);
 
-        // 3. 기존 리프레쉬 토큰 무효화 (Redis에서 삭제)
-        refreshTokenRepository.deleteById(userId);
+        // 3. 기존 리프레쉬 토큰 무효화 (Redis에서 삭제 - DB 트랜잭션 커밋 후 실행하여 일관성 보장)
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    refreshTokenRepository.deleteById(userId);
+                }
+            });
+        } else {
+            refreshTokenRepository.deleteById(userId);
+        }
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/user/service/AdminService.java
@@ -6,6 +6,7 @@ import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.domain.admin.user.dto.UserSanctionRequestDto;
 import com.dodo.dodoserver.domain.admin.user.entity.SanctionHistory;
 import com.dodo.dodoserver.domain.admin.user.entity.SanctionType;
+import com.dodo.dodoserver.domain.auth.dao.RefreshTokenRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
@@ -24,6 +25,7 @@ public class AdminService {
 
     private final UserAdminRepository userAdminRepository;
     private final SanctionHistoryRepository sanctionHistoryRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     /**
      * 전체 유저 관리자용 정보 조회 (페이징)
@@ -54,6 +56,9 @@ public class AdminService {
                 .build();
         
         sanctionHistoryRepository.save(history);
+
+        // 3. 기존 리프레쉬 토큰 무효화 (Redis에서 삭제)
+        refreshTokenRepository.deleteById(userId);
     }
 
     /**

--- a/src/test/java/com/dodo/dodoserver/domain/admin/user/service/AdminServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/user/service/AdminServiceTest.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.admin.user.dao.UserAdminRepository;
 import com.dodo.dodoserver.domain.admin.user.dto.UserSanctionRequestDto;
 import com.dodo.dodoserver.domain.admin.user.entity.SanctionHistory;
 import com.dodo.dodoserver.domain.admin.user.entity.SanctionType;
+import com.dodo.dodoserver.domain.auth.dao.RefreshTokenRepository;
 import com.dodo.dodoserver.domain.admin.user.service.AdminService;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,9 @@ class AdminServiceTest {
     @Mock
     private SanctionHistoryRepository sanctionHistoryRepository;
 
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
     @Test
     @DisplayName("유저 제재 처리 성공 - 7일 정지")
     void sanctionUser_success_sevenDays() {
@@ -54,6 +58,7 @@ class AdminServiceTest {
         // then
         assertThat(user.getSanctionedUntil()).isNotNull();
         verify(sanctionHistoryRepository).save(any(SanctionHistory.class));
+        verify(refreshTokenRepository).deleteById(userId);
     }
 
     @Test
@@ -77,6 +82,7 @@ class AdminServiceTest {
         // then
         assertThat(user.getSanctionedUntil().getYear()).isEqualTo(9999);
         verify(sanctionHistoryRepository).save(any(SanctionHistory.class));
+        verify(refreshTokenRepository).deleteById(userId);
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (Overview)
  유저 제재 시 리프레쉬 토큰을 즉시 무효화하여 보안성을 강화하고, 토큰 재발급 로직을 단순화했습니다.

## 🛠️ 작업 내용 (Changes)
구체적으로 어떤 부분을 변경했는지 상세히 작성해 주세요.
   - AdminService에서 유저 제재 시 해당 유저의 리프레쉬 토큰을 Redis에서 즉시 삭제하도록 구현했습니다.
   - 제재 처리 시 리프레쉬 토큰이 실제로 삭제(deleteById)되는지 검증하는 테스트 코드를 추가했습니다.

## 📸 스크린샷 / 결과 (Screenshots / Results)
   - 제재된 유저가 reissue 요청 시 흐름: Redis 내 토큰 부재로 인해 REFRESH_TOKEN_NOT_FOUND(A002) 에러가 발생하여 차단됨.


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #80 

## 📝 추가 참고 사항 (Additional Notes)
   - 제재 시점에 리프레쉬 토큰을 삭제하여 세션을 무효화하므로, AuthService 내에서 중복적인 제재 여부 확인 로직을 제외하여 시스템 복잡도를 낮췄습니다.
   - 인증 메커니즘 참고: 제재 시 리프레쉬 토큰이 삭제되더라도 이미 발급된 Access Token은 자체 만료 시간까지 유효할 수 있습니다. 그러나 Access Token 만료 후 진행되는 reissue(재발급) 과정이 즉시 차단되므로, 유저의 지속적인 서비스 이용 및 재로그인은 불가능해집니다. (가장 최근 발급된 Access Token의 수명만큼만 이용 가능)

