### PR TITLE
Feat/82/ad domain

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/ad/controller/AdvertiserAdController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/controller/AdvertiserAdController.java
@@ -1,0 +1,93 @@
+package com.dodo.dodoserver.domain.ad.controller;
+
+import com.dodo.dodoserver.domain.ad.dto.AdProposalRequestDto;
+import com.dodo.dodoserver.domain.ad.dto.AdProposalResponseDto;
+import com.dodo.dodoserver.domain.ad.dto.AdStatisticsResponseDto;
+import com.dodo.dodoserver.domain.ad.dto.AdvertiserMyAccountResponseDto;
+import com.dodo.dodoserver.domain.ad.service.AdvertiserAdService;
+import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Advertiser Ad", description = "광고주 전용 광고 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/advertiser/ads")
+public class AdvertiserAdController {
+
+    private final AdvertiserAdService advertiserAdService;
+
+    /**
+     * 내 광고주 계정 정보 조회 (잔여 개수, 만료일 등)
+     */
+    @Operation(summary = "내 광고주 계정 정보 조회", description = "광고주의 발행 가능 광고 개수, 현재 게시 중인 광고 수, 권한 만료일 등을 조회합니다.")
+    @GetMapping("/account")
+    public ApiResponseDto<AdvertiserMyAccountResponseDto> getMyAccountInfo(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponseDto.success(advertiserAdService.getMyAccountInfo(userPrincipal.getId()));
+    }
+
+    /**
+     * 광고 신청
+     */
+    @Operation(summary = "광고 신청", description = "새로운 광고 게시물을 신청(PENDING 상태)합니다. 광고주 권한 및 잔여 개수를 검증합니다.")
+    @PostMapping("/proposals")
+    public ApiResponseDto<Void> createProposal(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody AdProposalRequestDto requestDto) {
+        advertiserAdService.createProposal(userPrincipal.getId(), requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    /**
+     * 광고 신청 수정 (재심사 요청)
+     */
+    @Operation(summary = "광고 신청 수정", description = "반려되었거나 대기 중인 광고 신청의 내용을 수정하고 재심사를 요청합니다.")
+    @PutMapping("/proposals/{proposalId}")
+    public ApiResponseDto<Void> updateProposal(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long proposalId,
+            @Valid @RequestBody AdProposalRequestDto requestDto) {
+        advertiserAdService.updateProposal(userPrincipal.getId(), proposalId, requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    /**
+     * 내 광고 신청 내역 조회
+     */
+    @Operation(summary = "내 광고 신청 내역 조회", description = "광고주 본인이 신청한 모든 광고 신청 내역(대기, 승인, 반려)을 조회합니다.")
+    @GetMapping("/proposals/me")
+    public ApiResponseDto<List<AdProposalResponseDto>> getMyProposals(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponseDto.success(advertiserAdService.getMyProposals(userPrincipal.getId()));
+    }
+
+    /**
+     * 발행된 내 광고 둥지 목록 조회
+     */
+    @Operation(summary = "발행된 내 광고 둥지 목록 조회", description = "광고주 본인이 발행하여 현재 게시 중인 광고 둥지 목록을 조회합니다.")
+    @GetMapping("/nests/me")
+    public ApiResponseDto<List<NestSimpleResponseDto>> getMyAdNests(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponseDto.success(advertiserAdService.getMyAdNests(userPrincipal.getId()));
+    }
+
+    /**
+     * 광고 성과 통계 조회
+     */
+    @Operation(summary = "광고 성과 통계 조회", description = "본인이 발행한 특정 광고 둥지의 누적 노출수(impressions)와 클릭수(clicks)를 조회합니다.")
+    @GetMapping("/nests/{nestId}/statistics")
+    public ApiResponseDto<AdStatisticsResponseDto> getAdStatistics(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long nestId) {
+        return ApiResponseDto.success(advertiserAdService.getAdStatistics(userPrincipal.getId(), nestId));
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dao/AdProposalRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dao/AdProposalRepository.java
@@ -1,0 +1,14 @@
+package com.dodo.dodoserver.domain.ad.dao;
+
+import com.dodo.dodoserver.domain.ad.entity.AdProposal;
+import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AdProposalRepository extends JpaRepository<AdProposal, Long> {
+    List<AdProposal> findAllByStatus(AdProposalStatus status);
+    List<AdProposal> findAllByAdvertiser(User advertiser);
+    long countByAdvertiserAndStatus(User advertiser, AdProposalStatus status);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
@@ -15,7 +15,8 @@ public interface NestAdInfoRepository extends JpaRepository<NestAdInfo, Long> {
     Optional<NestAdInfo> findByNest(Nest nest);
     Optional<NestAdInfo> findByNestId(Long nestId);
 
-    List<NestAdInfo> findAllByExpiredAtBefore(LocalDateTime now);
+    @Query("SELECT n FROM NestAdInfo n JOIN n.nest nest WHERE n.expiredAt < :now AND nest.deletedAt IS NULL")
+    List<NestAdInfo> findAllByExpiredAtBefore(@Param("now") LocalDateTime now);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE NestAdInfo n SET n.impressions = n.impressions + 1 WHERE n.nest.id IN :nestIds")

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
@@ -15,7 +15,7 @@ public interface NestAdInfoRepository extends JpaRepository<NestAdInfo, Long> {
     Optional<NestAdInfo> findByNest(Nest nest);
     Optional<NestAdInfo> findByNestId(Long nestId);
 
-    @Query("SELECT n FROM NestAdInfo n JOIN n.nest nest WHERE n.expiredAt < :now AND nest.deletedAt IS NULL")
+    @Query("SELECT n FROM NestAdInfo n JOIN FETCH n.nest WHERE n.expiredAt < :now AND n.nest.deletedAt IS NULL")
     List<NestAdInfo> findAllByExpiredAtBefore(@Param("now") LocalDateTime now);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
@@ -29,4 +29,8 @@ public interface NestAdInfoRepository extends JpaRepository<NestAdInfo, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE NestAdInfo n SET n.clicks = n.clicks + :increment WHERE n.nest.id = :nestId")
     void incrementClicksBatch(@Param("nestId") Long nestId, @Param("increment") Long increment);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE NestAdInfo n SET n.impressions = n.impressions + :increment WHERE n.nest.id = :nestId")
+    void incrementImpressionsBatch(@Param("nestId") Long nestId, @Param("increment") Long increment);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
@@ -1,0 +1,27 @@
+package com.dodo.dodoserver.domain.ad.dao;
+
+import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface NestAdInfoRepository extends JpaRepository<NestAdInfo, Long> {
+    Optional<NestAdInfo> findByNest(Nest nest);
+    Optional<NestAdInfo> findByNestId(Long nestId);
+
+    List<NestAdInfo> findAllByExpiredAtBefore(LocalDateTime now);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE NestAdInfo n SET n.impressions = n.impressions + 1 WHERE n.nest.id IN :nestIds")
+    void incrementImpressions(@Param("nestIds") List<Long> nestIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE NestAdInfo n SET n.clicks = n.clicks + 1 WHERE n.nest.id = :nestId")
+    void incrementClicks(@Param("nestId") Long nestId);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dao/NestAdInfoRepository.java
@@ -25,4 +25,8 @@ public interface NestAdInfoRepository extends JpaRepository<NestAdInfo, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE NestAdInfo n SET n.clicks = n.clicks + 1 WHERE n.nest.id = :nestId")
     void incrementClicks(@Param("nestId") Long nestId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE NestAdInfo n SET n.clicks = n.clicks + :increment WHERE n.nest.id = :nestId")
+    void incrementClicksBatch(@Param("nestId") Long nestId, @Param("increment") Long increment);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdProposalRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdProposalRequestDto.java
@@ -1,0 +1,30 @@
+package com.dodo.dodoserver.domain.ad.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class AdProposalRequestDto {
+    @NotNull(message = "위도는 필수입니다.")
+    private Double latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private Double longitude;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    private Integer unlockRadius = 100;
+
+    private List<String> imageUrls;
+
+    private List<Long> categoryIds;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdProposalResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdProposalResponseDto.java
@@ -1,0 +1,41 @@
+package com.dodo.dodoserver.domain.ad.dto;
+
+import com.dodo.dodoserver.domain.ad.entity.AdProposal;
+import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AdProposalResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private Double latitude;
+    private Double longitude;
+    private Integer unlockRadius;
+    private List<String> imageUrls;
+    private List<Long> categoryIds;
+    private AdProposalStatus status;
+    private String rejectReason;
+    private LocalDateTime createdAt;
+
+    public static AdProposalResponseDto from(AdProposal proposal) {
+        return AdProposalResponseDto.builder()
+                .id(proposal.getId())
+                .title(proposal.getTitle())
+                .content(proposal.getContent())
+                .latitude(proposal.getLatitude())
+                .longitude(proposal.getLongitude())
+                .unlockRadius(proposal.getUnlockRadius())
+                .imageUrls(proposal.getImageUrls())
+                .categoryIds(proposal.getCategoryIds())
+                .status(proposal.getStatus())
+                .rejectReason(proposal.getRejectReason())
+                .createdAt(proposal.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdProposalResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdProposalResponseDto.java
@@ -19,11 +19,12 @@ public class AdProposalResponseDto {
     private Integer unlockRadius;
     private List<String> imageUrls;
     private List<Long> categoryIds;
+    private List<String> categoryNames;
     private AdProposalStatus status;
     private String rejectReason;
     private LocalDateTime createdAt;
 
-    public static AdProposalResponseDto from(AdProposal proposal) {
+    public static AdProposalResponseDto from(AdProposal proposal, List<String> categoryNames) {
         return AdProposalResponseDto.builder()
                 .id(proposal.getId())
                 .title(proposal.getTitle())
@@ -33,9 +34,14 @@ public class AdProposalResponseDto {
                 .unlockRadius(proposal.getUnlockRadius())
                 .imageUrls(proposal.getImageUrls())
                 .categoryIds(proposal.getCategoryIds())
+                .categoryNames(categoryNames)
                 .status(proposal.getStatus())
                 .rejectReason(proposal.getRejectReason())
                 .createdAt(proposal.getCreatedAt())
                 .build();
+    }
+
+    public static AdProposalResponseDto from(AdProposal proposal) {
+        return from(proposal, null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdStatisticsResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdStatisticsResponseDto.java
@@ -1,0 +1,26 @@
+package com.dodo.dodoserver.domain.ad.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdStatisticsResponseDto {
+    private Long nestId;
+    private String title;
+    private Long impressions;
+    private Long clicks;
+    private LocalDateTime expiredAt;
+
+    public static AdStatisticsResponseDto of(Long nestId, String title, Long impressions, Long clicks, LocalDateTime expiredAt) {
+        return AdStatisticsResponseDto.builder()
+                .nestId(nestId)
+                .title(title)
+                .impressions(impressions)
+                .clicks(clicks)
+                .expiredAt(expiredAt)
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdvertiserMyAccountResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dto/AdvertiserMyAccountResponseDto.java
@@ -1,0 +1,33 @@
+package com.dodo.dodoserver.domain.ad.dto;
+
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdvertiserMyAccountResponseDto {
+    private Integer allowedAdCount;
+    private Long currentAdCount;
+    private Long pendingAdCount;
+    private Long remainingAdCount;
+    private LocalDateTime expiredAt;
+    private Boolean isExpired;
+
+    public static AdvertiserMyAccountResponseDto of(AdvertiserAuthority authority, long currentAdCount, long pendingAdCount) {
+        long totalUsed = currentAdCount + pendingAdCount;
+        long remaining = Math.max(0, authority.getAllowedAdCount() - totalUsed);
+        boolean isExpired = authority.getExpiredAt().isBefore(LocalDateTime.now());
+
+        return AdvertiserMyAccountResponseDto.builder()
+                .allowedAdCount(authority.getAllowedAdCount())
+                .currentAdCount(currentAdCount)
+                .pendingAdCount(pendingAdCount)
+                .remainingAdCount(remaining)
+                .expiredAt(authority.getExpiredAt())
+                .isExpired(isExpired)
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/entity/AdProposal.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/entity/AdProposal.java
@@ -1,0 +1,83 @@
+package com.dodo.dodoserver.domain.ad.entity;
+
+import com.dodo.dodoserver.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.List;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "ad_proposals")
+@EntityListeners(AuditingEntityListener.class)
+public class AdProposal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "advertiser_id", nullable = false)
+    private User advertiser;
+
+    /**
+     * SRID 4326: GPS 좌표계 (WGS84)
+     * POINT(longitude, latitude) 순서 저장 주의
+     */
+    @Column(nullable = false, columnDefinition = "POINT SRID 4326")
+    private Point point;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder.Default
+    @Column(name = "unlock_radius")
+    private Integer unlockRadius = 100;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "image_urls", columnDefinition = "json")
+    private List<String> imageUrls;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "category_ids", columnDefinition = "json")
+    private List<Long> categoryIds;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AdProposalStatus status;
+
+    @Column(name = "reject_reason")
+    private String rejectReason;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // 위도 추출 편의 메서드
+    public Double getLatitude() {
+        return point != null ? point.getY() : null;
+    }
+
+    // 경도 추출 편의 메서드
+    public Double getLongitude() {
+        return point != null ? point.getX() : null;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/entity/AdProposalStatus.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/entity/AdProposalStatus.java
@@ -1,0 +1,5 @@
+package com.dodo.dodoserver.domain.ad.entity;
+
+public enum AdProposalStatus {
+    PENDING, APPROVED, REJECTED
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/entity/NestAdInfo.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/entity/NestAdInfo.java
@@ -1,0 +1,52 @@
+package com.dodo.dodoserver.domain.ad.entity;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "nest_ad_info")
+@EntityListeners(AuditingEntityListener.class)
+public class NestAdInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "nest_id", nullable = false, unique = true)
+    private Nest nest;
+
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Builder.Default
+    @Column(name = "priority_score", nullable = false)
+    private Integer priorityScore = 0;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Long impressions = 0L;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Long clicks = 0L;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/scheduler/AdScheduler.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/scheduler/AdScheduler.java
@@ -52,22 +52,16 @@ public class AdScheduler {
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void processExpiredAdvertiserAuthorities() {
-        // 이 부분은 효율을 위해 Querydsl이나 벌크 연산으로 대체 가능하지만, 
-        // 권한 강등 시 추가 로직(알림 등)이 생길 수 있으므로 리스트 조회 후 처리
-        List<AdvertiserAuthority> allAuthorities = advertiserAuthorityRepository.findAll();
         LocalDateTime now = LocalDateTime.now();
+        List<AdvertiserAuthority> expiredAuthorities = advertiserAuthorityRepository.findAllByExpiredAtBefore(now);
 
-        long downgradedCount = allAuthorities.stream()
-                .filter(auth -> auth.getExpiredAt().isBefore(now))
-                .peek(auth -> {
-                    User user = auth.getUser();
-                    user.setRole(Role.USER);
-                    advertiserAuthorityRepository.delete(auth);
-                })
-                .count();
-
-        if (downgradedCount > 0) {
-            log.info("만료 광고주 권한 강등 처리 완료: {}명", downgradedCount);
+        if (!expiredAuthorities.isEmpty()) {
+            expiredAuthorities.forEach(auth -> {
+                User user = auth.getUser();
+                user.setRole(Role.USER);
+                advertiserAuthorityRepository.delete(auth);
+            });
+            log.info("만료 광고주 권한 강등 처리 완료: {}명", expiredAuthorities.size());
         }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/ad/scheduler/AdScheduler.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/scheduler/AdScheduler.java
@@ -1,0 +1,72 @@
+package com.dodo.dodoserver.domain.ad.scheduler;
+
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import com.dodo.dodoserver.domain.user.entity.Role;
+import com.dodo.dodoserver.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AdScheduler {
+
+    private final NestAdInfoRepository nestAdInfoRepository;
+    private final NestRepository nestRepository;
+    private final AdvertiserAuthorityRepository advertiserAuthorityRepository;
+
+    /**
+     * 광고 기한 만료 처리 (매 시간 정각)
+     * NestAdInfo의 expired_at이 지난 광고 둥지를 Soft Delete 처리
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void processExpiredAds() {
+        LocalDateTime now = LocalDateTime.now();
+        List<NestAdInfo> expiredAds = nestAdInfoRepository.findAllByExpiredAtBefore(now);
+
+        if (!expiredAds.isEmpty()) {
+            expiredAds.forEach(adInfo -> {
+                adInfo.getNest().setDeletedAt(now);
+                nestAdInfoRepository.delete(adInfo);
+            });
+            log.info("만료 광고 처리 완료: {}건", expiredAds.size());
+        }
+    }
+
+    /**
+     * 광고주 권한 만료 처리 (매일 자정)
+     * AdvertiserAuthority의 expired_at이 지난 유저의 Role을 USER로 강등
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void processExpiredAdvertiserAuthorities() {
+        // 이 부분은 효율을 위해 Querydsl이나 벌크 연산으로 대체 가능하지만, 
+        // 권한 강등 시 추가 로직(알림 등)이 생길 수 있으므로 리스트 조회 후 처리
+        List<AdvertiserAuthority> allAuthorities = advertiserAuthorityRepository.findAll();
+        LocalDateTime now = LocalDateTime.now();
+
+        long downgradedCount = allAuthorities.stream()
+                .filter(auth -> auth.getExpiredAt().isBefore(now))
+                .peek(auth -> {
+                    User user = auth.getUser();
+                    user.setRole(Role.USER);
+                    advertiserAuthorityRepository.delete(auth);
+                })
+                .count();
+
+        if (downgradedCount > 0) {
+            log.info("만료 광고주 권한 강등 처리 완료: {}명", downgradedCount);
+        }
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/scheduler/AdScheduler.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/scheduler/AdScheduler.java
@@ -33,12 +33,13 @@ public class AdScheduler {
     @Transactional
     public void processExpiredAds() {
         LocalDateTime now = LocalDateTime.now();
-        List<NestAdInfo> expiredAds = nestAdInfoRepository.findAllByExpiredAtBefore(now);
+            List<NestAdInfo> expiredAds = nestAdInfoRepository.findAllByExpiredAtBefore(now);
 
         if (!expiredAds.isEmpty()) {
             expiredAds.forEach(adInfo -> {
-                adInfo.getNest().setDeletedAt(now);
-                nestAdInfoRepository.delete(adInfo);
+                if (adInfo.getNest().getDeletedAt() == null) {
+                    adInfo.getNest().setDeletedAt(now);
+                }
             });
             log.info("만료 광고 처리 완료: {}건", expiredAds.size());
         }

--- a/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
@@ -9,6 +9,8 @@ import com.dodo.dodoserver.domain.ad.dto.AdvertiserMyAccountResponseDto;
 import com.dodo.dodoserver.domain.ad.entity.AdProposal;
 import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
 import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
+import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
@@ -29,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +45,7 @@ public class AdvertiserAdService {
     private final AdProposalRepository adProposalRepository;
     private final NestAdInfoRepository nestAdInfoRepository;
     private final NestRepository nestRepository;
+    private final CategoryRepository categoryRepository;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -141,8 +147,26 @@ public class AdvertiserAdService {
         User advertiser = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        return adProposalRepository.findAllByAdvertiser(advertiser).stream()
-                .map(AdProposalResponseDto::from)
+        List<AdProposal> proposals = adProposalRepository.findAllByAdvertiser(advertiser);
+
+        // Extract all unique category IDs from all proposals
+        List<Long> allCategoryIds = proposals.stream()
+                .flatMap(p -> p.getCategoryIds().stream())
+                .distinct()
+                .toList();
+
+        // Fetch category names and create a map (ID -> Name)
+        Map<Long, String> categoryMap = categoryRepository.findAllById(allCategoryIds).stream()
+                .collect(Collectors.toMap(Category::getId, Category::getName));
+
+        return proposals.stream()
+                .map(proposal -> {
+                    List<String> categoryNames = proposal.getCategoryIds().stream()
+                            .map(categoryMap::get)
+                            .filter(Objects::nonNull)
+                            .toList();
+                    return AdProposalResponseDto.from(proposal, categoryNames);
+                })
                 .toList();
     }
 

--- a/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
@@ -1,0 +1,185 @@
+package com.dodo.dodoserver.domain.ad.service;
+
+import com.dodo.dodoserver.domain.ad.dao.AdProposalRepository;
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.ad.dto.AdProposalRequestDto;
+import com.dodo.dodoserver.domain.ad.dto.AdProposalResponseDto;
+import com.dodo.dodoserver.domain.ad.dto.AdStatisticsResponseDto;
+import com.dodo.dodoserver.domain.ad.dto.AdvertiserMyAccountResponseDto;
+import com.dodo.dodoserver.domain.ad.entity.AdProposal;
+import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.dto.NestSimpleResponseDto;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdvertiserAdService {
+
+    private final UserRepository userRepository;
+    private final AdvertiserAuthorityRepository advertiserAuthorityRepository;
+    private final AdProposalRepository adProposalRepository;
+    private final NestAdInfoRepository nestAdInfoRepository;
+    private final NestRepository nestRepository;
+
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    /**
+     * 내 광고주 계정 정보 조회 (잔여 개수, 만료일 등)
+     */
+    @Transactional(readOnly = true)
+    public AdvertiserMyAccountResponseDto getMyAccountInfo(Long userId) {
+        User advertiser = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        AdvertiserAuthority authority = advertiserAuthorityRepository.findByUser(advertiser)
+                .orElseThrow(() -> new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED));
+
+        long currentAdCount = nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(advertiser);
+        long pendingCount = adProposalRepository.countByAdvertiserAndStatus(advertiser, AdProposalStatus.PENDING);
+
+        return AdvertiserMyAccountResponseDto.of(authority, currentAdCount, pendingCount);
+    }
+
+    /**
+     * 광고 신청 (PENDING)
+     */
+    @Transactional
+    public void createProposal(Long userId, AdProposalRequestDto requestDto) {
+        User advertiser = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        AdvertiserAuthority authority = advertiserAuthorityRepository.findByUser(advertiser)
+                .orElseThrow(() -> new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED));
+
+        // 권한 만료 체크
+        if (authority.getExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED); // TODO: 전용 에러코드 필요시 추가
+        }
+
+        // 발행 가능 개수 체크 (현재 승인된 광고 수 + 신청 중인 광고 수)
+        long currentAdCount = nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(advertiser);
+        long pendingCount = adProposalRepository.countByAdvertiserAndStatus(advertiser, AdProposalStatus.PENDING);
+
+        if (currentAdCount + pendingCount >= authority.getAllowedAdCount()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // TODO: 광고 개수 초과 에러코드
+        }
+
+        Point point = geometryFactory.createPoint(new Coordinate(requestDto.getLongitude(), requestDto.getLatitude()));
+
+        AdProposal proposal = AdProposal.builder()
+                .advertiser(advertiser)
+                .point(point)
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .unlockRadius(requestDto.getUnlockRadius())
+                .imageUrls(requestDto.getImageUrls())
+                .categoryIds(requestDto.getCategoryIds())
+                .status(AdProposalStatus.PENDING)
+                .build();
+
+        adProposalRepository.save(proposal);
+        log.info("광고 신청 완료: Advertiser={}, Title={}", userId, requestDto.getTitle());
+    }
+
+    /**
+     * 광고 신청 수정 (재심사 요청)
+     */
+    @Transactional
+    public void updateProposal(Long userId, Long proposalId, AdProposalRequestDto requestDto) {
+        AdProposal proposal = adProposalRepository.findById(proposalId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+
+        if (!proposal.getAdvertiser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        // PENDING 또는 REJECTED 상태만 수정 가능
+        if (proposal.getStatus() == AdProposalStatus.APPROVED) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Point point = geometryFactory.createPoint(new Coordinate(requestDto.getLongitude(), requestDto.getLatitude()));
+        proposal.setPoint(point);
+        proposal.setTitle(requestDto.getTitle());
+        proposal.setContent(requestDto.getContent());
+        proposal.setUnlockRadius(requestDto.getUnlockRadius());
+        proposal.setImageUrls(requestDto.getImageUrls());
+        proposal.setCategoryIds(requestDto.getCategoryIds());
+        
+        // 다시 심사 대기 상태로 변경
+        proposal.setStatus(AdProposalStatus.PENDING);
+        proposal.setRejectReason(null);
+
+        log.info("광고 신청 수정 및 재심사 요청 완료: ProposalId={}", proposalId);
+    }
+
+    /**
+     * 내 광고 신청 내역 조회
+     */
+    @Transactional(readOnly = true)
+    public List<AdProposalResponseDto> getMyProposals(Long userId) {
+        User advertiser = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return adProposalRepository.findAllByAdvertiser(advertiser).stream()
+                .map(AdProposalResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 발행된 내 광고 둥지 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NestSimpleResponseDto> getMyAdNests(Long userId) {
+        User advertiser = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return nestRepository.findAllByCreatorAndIsAdTrueAndDeletedAtIsNull(advertiser).stream()
+                .map(NestSimpleResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 광고 성과 통계 조회
+     */
+    @Transactional(readOnly = true)
+    public AdStatisticsResponseDto getAdStatistics(Long userId, Long nestId) {
+        Nest nest = nestRepository.findById(nestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
+
+        if (!nest.getCreator().getId().equals(userId) || !nest.isAd()) {
+            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        NestAdInfo adInfo = nestAdInfoRepository.findByNest(nest)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+
+        return AdStatisticsResponseDto.of(
+                nest.getId(),
+                nest.getTitle(),
+                adInfo.getImpressions(),
+                adInfo.getClicks(),
+                adInfo.getExpiredAt()
+        );
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
@@ -76,6 +76,7 @@ public class AdvertiserAdService {
 
         AdvertiserAuthority authority = getValidAuthority(advertiser);
         checkAdCountLimit(advertiser, authority);
+        validateCategoryIds(requestDto.getCategoryIds());
 
         Point point = geometryFactory.createPoint(new Coordinate(requestDto.getLongitude(), requestDto.getLatitude()));
 
@@ -119,6 +120,8 @@ public class AdvertiserAdService {
             checkAdCountLimit(advertiser, authority);
         }
 
+        validateCategoryIds(requestDto.getCategoryIds());
+
         Point point = geometryFactory.createPoint(new Coordinate(requestDto.getLongitude(), requestDto.getLatitude()));
         proposal.setPoint(point);
         proposal.setTitle(requestDto.getTitle());
@@ -132,6 +135,22 @@ public class AdvertiserAdService {
         proposal.setRejectReason(null);
 
         log.info("광고 신청 수정 및 재심사 요청 완료: ProposalId={}", proposalId);
+    }
+
+    private void validateCategoryIds(List<Long> categoryIds) {
+        if (categoryIds != null && !categoryIds.isEmpty()) {
+            List<Category> categories = categoryRepository.findAllById(categoryIds);
+
+            if (categories.size() != categoryIds.size()) {
+                throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+            }
+
+            for (Category category : categories) {
+                if (category.getDeletedAt() != null) {
+                    throw new BusinessException(ErrorCode.ALREADY_DELETED_CATEGORY);
+                }
+            }
+        }
     }
 
     private AdvertiserAuthority getValidAuthority(User advertiser) {

--- a/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
@@ -167,7 +167,9 @@ public class AdvertiserAdService {
 
         // Extract all unique category IDs from all proposals
         List<Long> allCategoryIds = proposals.stream()
-                .flatMap(p -> p.getCategoryIds().stream())
+                .map(AdProposal::getCategoryIds)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
                 .distinct()
                 .toList();
 
@@ -177,10 +179,11 @@ public class AdvertiserAdService {
 
         return proposals.stream()
                 .map(proposal -> {
-                    List<String> categoryNames = proposal.getCategoryIds().stream()
+                    List<Long> categoryIds = proposal.getCategoryIds();
+                    List<String> categoryNames = categoryIds != null ? categoryIds.stream()
                             .map(categoryMap::get)
                             .filter(Objects::nonNull)
-                            .toList();
+                            .toList() : List.of();
                     return AdProposalResponseDto.from(proposal, categoryNames);
                 })
                 .toList();

--- a/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
@@ -74,21 +74,8 @@ public class AdvertiserAdService {
         User advertiser = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        AdvertiserAuthority authority = advertiserAuthorityRepository.findByUser(advertiser)
-                .orElseThrow(() -> new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED));
-
-        // 권한 만료 체크
-        if (authority.getExpiredAt().isBefore(LocalDateTime.now())) {
-            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED); // TODO: 전용 에러코드 필요시 추가
-        }
-
-        // 발행 가능 개수 체크 (현재 승인된 광고 수 + 신청 중인 광고 수)
-        long currentAdCount = nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(advertiser);
-        long pendingCount = adProposalRepository.countByAdvertiserAndStatus(advertiser, AdProposalStatus.PENDING);
-
-        if (currentAdCount + pendingCount >= authority.getAllowedAdCount()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // TODO: 광고 개수 초과 에러코드
-        }
+        AdvertiserAuthority authority = getValidAuthority(advertiser);
+        checkAdCountLimit(advertiser, authority);
 
         Point point = geometryFactory.createPoint(new Coordinate(requestDto.getLongitude(), requestDto.getLatitude()));
 
@@ -124,6 +111,14 @@ public class AdvertiserAdService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
+        User advertiser = proposal.getAdvertiser();
+        AdvertiserAuthority authority = getValidAuthority(advertiser);
+
+        // REJECTED 상태에서 PENDING으로 변경되는 경우에만 개수 체크 (기존 PENDING은 이미 카운트에 포함됨)
+        if (proposal.getStatus() == AdProposalStatus.REJECTED) {
+            checkAdCountLimit(advertiser, authority);
+        }
+
         Point point = geometryFactory.createPoint(new Coordinate(requestDto.getLongitude(), requestDto.getLatitude()));
         proposal.setPoint(point);
         proposal.setTitle(requestDto.getTitle());
@@ -137,6 +132,27 @@ public class AdvertiserAdService {
         proposal.setRejectReason(null);
 
         log.info("광고 신청 수정 및 재심사 요청 완료: ProposalId={}", proposalId);
+    }
+
+    private AdvertiserAuthority getValidAuthority(User advertiser) {
+        AdvertiserAuthority authority = advertiserAuthorityRepository.findByUser(advertiser)
+                .orElseThrow(() -> new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED));
+
+        // 권한 만료 체크
+        if (authority.getExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.ADVERTISER_AUTHORITY_EXPIRED);
+        }
+        return authority;
+    }
+
+    private void checkAdCountLimit(User advertiser, AdvertiserAuthority authority) {
+        // 발행 가능 개수 체크 (현재 승인된 광고 수 + 신청 중인 광고 수)
+        long currentAdCount = nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(advertiser);
+        long pendingCount = adProposalRepository.countByAdvertiserAndStatus(advertiser, AdProposalStatus.PENDING);
+
+        if (currentAdCount + pendingCount >= authority.getAllowedAdCount()) {
+            throw new BusinessException(ErrorCode.AD_COUNT_LIMIT_EXCEEDED);
+        }
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdService.java
@@ -147,23 +147,25 @@ public class AdvertiserAdService {
     }
 
     /**
-     * 발행된 내 광고 둥지 목록 조회
+     * 발행된 내 광고 둥지 목록 조회 (만료/삭제된 광고 포함)
      */
     @Transactional(readOnly = true)
     public List<NestSimpleResponseDto> getMyAdNests(Long userId) {
         User advertiser = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        return nestRepository.findAllByCreatorAndIsAdTrueAndDeletedAtIsNull(advertiser).stream()
+        // SoftDeleteFilterAspect에 의해 nestFilter가 비활성화된 상태이므로 모든 광고가 조회됨
+        return nestRepository.findAllByCreatorAndIsAdTrue(advertiser).stream()
                 .map(NestSimpleResponseDto::from)
                 .toList();
     }
 
     /**
-     * 광고 성과 통계 조회
+     * 광고 성과 통계 조회 (만료/삭제된 광고 포함)
      */
     @Transactional(readOnly = true)
     public AdStatisticsResponseDto getAdStatistics(Long userId, Long nestId) {
+        // SoftDeleteFilterAspect에 의해 nestFilter가 비활성화된 상태이므로 삭제된 둥지도 조회됨
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
@@ -171,7 +173,7 @@ public class AdvertiserAdService {
             throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
         }
 
-        NestAdInfo adInfo = nestAdInfoRepository.findByNest(nest)
+        NestAdInfo adInfo = nestAdInfoRepository.findByNestId(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
 
         return AdStatisticsResponseDto.of(

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdController.java
@@ -88,10 +88,12 @@ public class AdminAdController {
     /**
      * 게시된 광고 목록 조회
      */
-    @Operation(summary = "게시된 광고 목록 조회", description = "현재 활성화되어 게시 중인 광고 둥지 목록과 통계를 조회합니다.")
+    @Operation(summary = "게시된 광고 목록 조회", description = "게시 중이거나 삭제된 광고 둥지 목록과 통계를 조회합니다.")
     @GetMapping("/nests")
-    public ApiResponseDto<Page<AdNestAdminResponseDto>> getAdNests(Pageable pageable) {
-        return ApiResponseDto.success(adminAdService.getAdNests(pageable));
+    public ApiResponseDto<Page<AdNestAdminResponseDto>> getAdNests(
+            @RequestParam(required = false, defaultValue = "ALL") AdStatusFilter status,
+            Pageable pageable) {
+        return ApiResponseDto.success(adminAdService.getAdNests(status, pageable));
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdController.java
@@ -4,6 +4,8 @@ import com.dodo.dodoserver.domain.admin.ad.dto.*;
 import com.dodo.dodoserver.domain.admin.ad.service.AdminAdService;
 import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Admin Ad", description = "관리자용 광고 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/ads")
@@ -22,6 +25,7 @@ public class AdminAdController {
     /**
      * 광고주 권한 부여를 위한 유저 검색
      */
+    @Operation(summary = "광고주 권한 부여를 위한 유저 검색", description = "이메일 키워드를 통해 광고주 권한을 부여할 유저를 검색합니다.")
     @GetMapping("/users/search")
     public ApiResponseDto<List<UserAdminResponseDto>> searchUsers(@RequestParam String email) {
         return ApiResponseDto.success(adminAdService.searchUsersByEmail(email));
@@ -30,6 +34,7 @@ public class AdminAdController {
     /**
      * 광고주 권한 부여 및 수정
      */
+    @Operation(summary = "광고주 권한 부여 및 수정", description = "유저에게 광고주(ADVERTISER) 역할을 부여하고 발행 가능 개수와 기한을 설정합니다.")
     @PostMapping("/advertisers/{userId}")
     public ApiResponseDto<Void> grantAdvertiserRole(
             @PathVariable Long userId,
@@ -41,6 +46,7 @@ public class AdminAdController {
     /**
      * 광고주 목록 조회
      */
+    @Operation(summary = "광고주 목록 조회", description = "시스템에 등록된 광고주 목록을 페이징하여 조회합니다.")
     @GetMapping("/advertisers")
     public ApiResponseDto<Page<AdvertiserResponseDto>> getAllAdvertisers(Pageable pageable) {
         return ApiResponseDto.success(adminAdService.getAllAdvertisers(pageable));
@@ -49,6 +55,7 @@ public class AdminAdController {
     /**
      * 광고 신청 목록 조회 (PENDING)
      */
+    @Operation(summary = "광고 신청 목록 조회 (PENDING)", description = "승인 대기 중인 광고 신청 목록을 조회합니다.")
     @GetMapping("/proposals")
     public ApiResponseDto<List<AdProposalAdminResponseDto>> getPendingProposals() {
         return ApiResponseDto.success(adminAdService.getPendingProposals());
@@ -57,6 +64,7 @@ public class AdminAdController {
     /**
      * 광고 신청 승인
      */
+    @Operation(summary = "광고 신청 승인", description = "광고 신청을 승인하여 실제 광고 둥지를 생성하고 발행합니다.")
     @PostMapping("/proposals/{proposalId}/approve")
     public ApiResponseDto<Void> approveProposal(
             @PathVariable Long proposalId,
@@ -68,6 +76,7 @@ public class AdminAdController {
     /**
      * 광고 신청 반려
      */
+    @Operation(summary = "광고 신청 반려", description = "광고 신청을 반려하고 반려 사유를 기록합니다.")
     @PostMapping("/proposals/{proposalId}/reject")
     public ApiResponseDto<Void> rejectProposal(
             @PathVariable Long proposalId,
@@ -79,6 +88,7 @@ public class AdminAdController {
     /**
      * 게시된 광고 목록 조회
      */
+    @Operation(summary = "게시된 광고 목록 조회", description = "현재 활성화되어 게시 중인 광고 둥지 목록과 통계를 조회합니다.")
     @GetMapping("/nests")
     public ApiResponseDto<Page<AdNestAdminResponseDto>> getAdNests(Pageable pageable) {
         return ApiResponseDto.success(adminAdService.getAdNests(pageable));
@@ -87,6 +97,7 @@ public class AdminAdController {
     /**
      * 광고 강제 삭제 (Soft Delete)
      */
+    @Operation(summary = "광고 강제 삭제", description = "관리자 권한으로 게시 중인 광고를 즉시 삭제(Soft Delete)합니다.")
     @DeleteMapping("/nests/{nestId}")
     public ApiResponseDto<Void> deleteAdNest(@PathVariable Long nestId) {
         adminAdService.deleteAdNest(nestId);

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdController.java
@@ -1,0 +1,95 @@
+package com.dodo.dodoserver.domain.admin.ad.controller;
+
+import com.dodo.dodoserver.domain.admin.ad.dto.*;
+import com.dodo.dodoserver.domain.admin.ad.service.AdminAdService;
+import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
+import com.dodo.dodoserver.global.common.ApiResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/ads")
+public class AdminAdController {
+
+    private final AdminAdService adminAdService;
+
+    /**
+     * 광고주 권한 부여를 위한 유저 검색
+     */
+    @GetMapping("/users/search")
+    public ApiResponseDto<List<UserAdminResponseDto>> searchUsers(@RequestParam String email) {
+        return ApiResponseDto.success(adminAdService.searchUsersByEmail(email));
+    }
+
+    /**
+     * 광고주 권한 부여 및 수정
+     */
+    @PostMapping("/advertisers/{userId}")
+    public ApiResponseDto<Void> grantAdvertiserRole(
+            @PathVariable Long userId,
+            @Valid @RequestBody AdvertiserAuthorityRequestDto requestDto) {
+        adminAdService.grantAdvertiserRole(userId, requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    /**
+     * 광고주 목록 조회
+     */
+    @GetMapping("/advertisers")
+    public ApiResponseDto<Page<AdvertiserResponseDto>> getAllAdvertisers(Pageable pageable) {
+        return ApiResponseDto.success(adminAdService.getAllAdvertisers(pageable));
+    }
+
+    /**
+     * 광고 신청 목록 조회 (PENDING)
+     */
+    @GetMapping("/proposals")
+    public ApiResponseDto<List<AdProposalAdminResponseDto>> getPendingProposals() {
+        return ApiResponseDto.success(adminAdService.getPendingProposals());
+    }
+
+    /**
+     * 광고 신청 승인
+     */
+    @PostMapping("/proposals/{proposalId}/approve")
+    public ApiResponseDto<Void> approveProposal(
+            @PathVariable Long proposalId,
+            @Valid @RequestBody AdApproveRequestDto requestDto) {
+        adminAdService.approveProposal(proposalId, requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    /**
+     * 광고 신청 반려
+     */
+    @PostMapping("/proposals/{proposalId}/reject")
+    public ApiResponseDto<Void> rejectProposal(
+            @PathVariable Long proposalId,
+            @Valid @RequestBody AdRejectRequestDto requestDto) {
+        adminAdService.rejectProposal(proposalId, requestDto);
+        return ApiResponseDto.success(null);
+    }
+
+    /**
+     * 게시된 광고 목록 조회
+     */
+    @GetMapping("/nests")
+    public ApiResponseDto<Page<AdNestAdminResponseDto>> getAdNests(Pageable pageable) {
+        return ApiResponseDto.success(adminAdService.getAdNests(pageable));
+    }
+
+    /**
+     * 광고 강제 삭제 (Soft Delete)
+     */
+    @DeleteMapping("/nests/{nestId}")
+    public ApiResponseDto<Void> deleteAdNest(@PathVariable Long nestId) {
+        adminAdService.deleteAdNest(nestId);
+        return ApiResponseDto.success(null);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dao/AdAdminRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dao/AdAdminRepository.java
@@ -1,0 +1,7 @@
+package com.dodo.dodoserver.domain.admin.ad.dao;
+
+import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdAdminRepository extends JpaRepository<NestAdInfo, Long>, AdAdminRepositoryCustom {
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dao/AdAdminRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dao/AdAdminRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.dodo.dodoserver.domain.admin.ad.dao;
+
+import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import com.dodo.dodoserver.domain.admin.ad.dto.AdStatusFilter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AdAdminRepositoryCustom {
+    Page<NestAdInfo> findAllWithFilter(AdStatusFilter filter, Pageable pageable);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dao/AdAdminRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dao/AdAdminRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.dodo.dodoserver.domain.admin.ad.dao;
+
+import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import com.dodo.dodoserver.domain.ad.entity.QNestAdInfo;
+import com.dodo.dodoserver.domain.admin.ad.dto.AdStatusFilter;
+import com.dodo.dodoserver.domain.nest.entity.QNest;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AdAdminRepositoryImpl implements AdAdminRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<NestAdInfo> findAllWithFilter(AdStatusFilter filter, Pageable pageable) {
+        QNestAdInfo nestAdInfo = QNestAdInfo.nestAdInfo;
+        QNest nest = QNest.nest;
+
+        List<NestAdInfo> content = queryFactory
+                .selectFrom(nestAdInfo)
+                .join(nestAdInfo.nest, nest).fetchJoin()
+                .where(statusEq(filter))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(nest.createdAt.desc())
+                .fetch();
+
+        JPAQuery<Long> totalQuery = queryFactory
+                .select(Wildcard.count)
+                .from(nestAdInfo)
+                .join(nestAdInfo.nest, nest)
+                .where(statusEq(filter));
+
+        return PageableExecutionUtils.getPage(content, pageable, totalQuery::fetchOne);
+    }
+
+    private BooleanExpression statusEq(AdStatusFilter filter) {
+        if (filter == null || filter == AdStatusFilter.ALL) {
+            return null;
+        }
+        if (filter == AdStatusFilter.ACTIVE) {
+            return QNest.nest.deletedAt.isNull();
+        }
+        if (filter == AdStatusFilter.DELETED) {
+            return QNest.nest.deletedAt.isNotNull();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdApproveRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdApproveRequestDto.java
@@ -1,0 +1,16 @@
+package com.dodo.dodoserver.domain.admin.ad.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class AdApproveRequestDto {
+    @NotNull(message = "광고 만료일은 필수입니다.")
+    private LocalDateTime expiredAt;
+
+    private Integer priorityScore = 0;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdNestAdminResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdNestAdminResponseDto.java
@@ -1,0 +1,33 @@
+package com.dodo.dodoserver.domain.admin.ad.dto;
+
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdNestAdminResponseDto {
+    private Long id;
+    private String title;
+    private String advertiserNickname;
+    private LocalDateTime expiredAt;
+    private Integer priorityScore;
+    private Long impressions;
+    private Long clicks;
+    private LocalDateTime createdAt;
+
+    public static AdNestAdminResponseDto of(Nest nest, LocalDateTime expiredAt, Integer priorityScore, Long impressions, Long clicks) {
+        return AdNestAdminResponseDto.builder()
+                .id(nest.getId())
+                .title(nest.getTitle())
+                .advertiserNickname(nest.getCreator().getNickname())
+                .expiredAt(expiredAt)
+                .priorityScore(priorityScore)
+                .impressions(impressions)
+                .clicks(clicks)
+                .createdAt(nest.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdNestAdminResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdNestAdminResponseDto.java
@@ -17,6 +17,7 @@ public class AdNestAdminResponseDto {
     private Long impressions;
     private Long clicks;
     private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
 
     public static AdNestAdminResponseDto of(Nest nest, LocalDateTime expiredAt, Integer priorityScore, Long impressions, Long clicks) {
         return AdNestAdminResponseDto.builder()
@@ -28,6 +29,7 @@ public class AdNestAdminResponseDto {
                 .impressions(impressions)
                 .clicks(clicks)
                 .createdAt(nest.getCreatedAt())
+                .deletedAt(nest.getDeletedAt())
                 .build();
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdProposalAdminResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdProposalAdminResponseDto.java
@@ -1,0 +1,45 @@
+package com.dodo.dodoserver.domain.admin.ad.dto;
+
+import com.dodo.dodoserver.domain.ad.entity.AdProposal;
+import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AdProposalAdminResponseDto {
+    private Long id;
+    private Long advertiserId;
+    private String advertiserNickname;
+    private String title;
+    private String content;
+    private Double latitude;
+    private Double longitude;
+    private Integer unlockRadius;
+    private List<String> imageUrls;
+    private List<Long> categoryIds;
+    private AdProposalStatus status;
+    private String rejectReason;
+    private LocalDateTime createdAt;
+
+    public static AdProposalAdminResponseDto from(AdProposal proposal) {
+        return AdProposalAdminResponseDto.builder()
+                .id(proposal.getId())
+                .advertiserId(proposal.getAdvertiser().getId())
+                .advertiserNickname(proposal.getAdvertiser().getNickname())
+                .title(proposal.getTitle())
+                .content(proposal.getContent())
+                .latitude(proposal.getLatitude())
+                .longitude(proposal.getLongitude())
+                .unlockRadius(proposal.getUnlockRadius())
+                .imageUrls(proposal.getImageUrls())
+                .categoryIds(proposal.getCategoryIds())
+                .status(proposal.getStatus())
+                .rejectReason(proposal.getRejectReason())
+                .createdAt(proposal.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdProposalAdminResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdProposalAdminResponseDto.java
@@ -21,11 +21,12 @@ public class AdProposalAdminResponseDto {
     private Integer unlockRadius;
     private List<String> imageUrls;
     private List<Long> categoryIds;
+    private List<String> categoryNames;
     private AdProposalStatus status;
     private String rejectReason;
     private LocalDateTime createdAt;
 
-    public static AdProposalAdminResponseDto from(AdProposal proposal) {
+    public static AdProposalAdminResponseDto from(AdProposal proposal, List<String> categoryNames) {
         return AdProposalAdminResponseDto.builder()
                 .id(proposal.getId())
                 .advertiserId(proposal.getAdvertiser().getId())
@@ -37,9 +38,14 @@ public class AdProposalAdminResponseDto {
                 .unlockRadius(proposal.getUnlockRadius())
                 .imageUrls(proposal.getImageUrls())
                 .categoryIds(proposal.getCategoryIds())
+                .categoryNames(categoryNames)
                 .status(proposal.getStatus())
                 .rejectReason(proposal.getRejectReason())
                 .createdAt(proposal.getCreatedAt())
                 .build();
+    }
+
+    public static AdProposalAdminResponseDto from(AdProposal proposal) {
+        return from(proposal, null);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdRejectRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdRejectRequestDto.java
@@ -1,0 +1,12 @@
+package com.dodo.dodoserver.domain.admin.ad.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdRejectRequestDto {
+    @NotBlank(message = "반려 사유는 필수입니다.")
+    private String rejectReason;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdStatusFilter.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdStatusFilter.java
@@ -1,0 +1,5 @@
+package com.dodo.dodoserver.domain.admin.ad.dto;
+
+public enum AdStatusFilter {
+    ALL, ACTIVE, DELETED
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdvertiserAuthorityRequestDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdvertiserAuthorityRequestDto.java
@@ -1,0 +1,19 @@
+package com.dodo.dodoserver.domain.admin.ad.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class AdvertiserAuthorityRequestDto {
+    @NotNull(message = "허용 광고 개수는 필수입니다.")
+    @Min(value = 1, message = "최소 1개 이상의 광고를 허용해야 합니다.")
+    private Integer allowedAdCount;
+
+    @NotNull(message = "만료일은 필수입니다.")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdvertiserResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdvertiserResponseDto.java
@@ -1,0 +1,29 @@
+package com.dodo.dodoserver.domain.admin.ad.dto;
+
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdvertiserResponseDto {
+    private Long userId;
+    private String email;
+    private String nickname;
+    private Integer allowedAdCount;
+    private LocalDateTime expiredAt;
+    private LocalDateTime createdAt;
+
+    public static AdvertiserResponseDto from(AdvertiserAuthority authority) {
+        return AdvertiserResponseDto.builder()
+                .userId(authority.getUser().getId())
+                .email(authority.getUser().getEmail())
+                .nickname(authority.getUser().getNickname())
+                .allowedAdCount(authority.getAllowedAdCount())
+                .expiredAt(authority.getExpiredAt())
+                .createdAt(authority.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -1,0 +1,229 @@
+package com.dodo.dodoserver.domain.admin.ad.service;
+
+import com.dodo.dodoserver.domain.ad.dao.AdProposalRepository;
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.ad.entity.AdProposal;
+import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
+import com.dodo.dodoserver.domain.admin.ad.dto.*;
+import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
+import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
+import com.dodo.dodoserver.domain.category.entity.Category;
+import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.entity.NestCategory;
+import com.dodo.dodoserver.domain.nest.entity.NestImage;
+import com.dodo.dodoserver.domain.nest.entity.NestLocation;
+import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import com.dodo.dodoserver.domain.user.entity.Role;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminAdService {
+
+    private final UserRepository userRepository;
+    private final AdvertiserAuthorityRepository advertiserAuthorityRepository;
+    private final AdProposalRepository adProposalRepository;
+    private final NestRepository nestRepository;
+    private final NestAdInfoRepository nestAdInfoRepository;
+    private final CategoryRepository categoryRepository;
+    private final NestCategoryRepository nestCategoryRepository;
+
+    /**
+     * 이메일로 유저 검색
+     */
+    @Transactional(readOnly = true)
+    public List<UserAdminResponseDto> searchUsersByEmail(String email) {
+        return userRepository.findAllByEmailContaining(email).stream()
+                .map(user -> UserAdminResponseDto.builder()
+                        .id(user.getId())
+                        .nickname(user.getNickname())
+                        .email(user.getEmail())
+                        .role(user.getRole())
+                        .createdAt(user.getCreatedAt())
+                        .sanctionedUntil(user.getSanctionedUntil())
+                        .isSanctioned(user.getSanctionedUntil() != null && user.getSanctionedUntil().isAfter(LocalDateTime.now()))
+                        .build())
+                .toList();
+    }
+
+    /**
+     * 광고주 권한 부여/수정
+     */
+    @Transactional
+    public void grantAdvertiserRole(Long userId, AdvertiserAuthorityRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        user.setRole(Role.ADVERTISER);
+
+        AdvertiserAuthority authority = advertiserAuthorityRepository.findByUser(user)
+                .orElse(AdvertiserAuthority.builder().user(user).build());
+
+        authority.setAllowedAdCount(requestDto.getAllowedAdCount());
+        authority.setExpiredAt(requestDto.getExpiredAt());
+
+        advertiserAuthorityRepository.save(authority);
+        log.info("광고주 권한 부여 완료: User={}, AllowedAdCount={}, ExpiredAt={}", userId, requestDto.getAllowedAdCount(), requestDto.getExpiredAt());
+    }
+
+    /**
+     * 광고주 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<AdvertiserResponseDto> getAllAdvertisers(Pageable pageable) {
+        return advertiserAuthorityRepository.findAll(pageable)
+                .map(AdvertiserResponseDto::from);
+    }
+
+    /**
+     * 광고 신청 목록 조회 (PENDING)
+     */
+    @Transactional(readOnly = true)
+    public List<AdProposalAdminResponseDto> getPendingProposals() {
+        return adProposalRepository.findAllByStatus(AdProposalStatus.PENDING).stream()
+                .map(AdProposalAdminResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 광고 신청 승인
+     */
+    @Transactional
+    public void approveProposal(Long proposalId, AdApproveRequestDto requestDto) {
+        AdProposal proposal = adProposalRepository.findById(proposalId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+
+        if (proposal.getStatus() != AdProposalStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 1. Nest 생성
+        Nest nest = Nest.builder()
+                .creator(proposal.getAdvertiser())
+                .title(proposal.getTitle())
+                .content(proposal.getContent())
+                .unlockRadius(proposal.getUnlockRadius())
+                .isAd(true)
+                .build();
+
+        // 2. NestLocation 생성
+        NestLocation location = NestLocation.builder()
+                .nest(nest)
+                .point(proposal.getPoint())
+                .build();
+        nest.setLocation(location);
+
+        // 3. NestImage 생성
+        if (proposal.getImageUrls() != null) {
+            List<String> urls = proposal.getImageUrls();
+            IntStream.range(0, urls.size()).forEach(i -> {
+                NestImage image = NestImage.builder()
+                        .nest(nest)
+                        .imageUrl(urls.get(i))
+                        .sortOrder(i + 1)
+                        .build();
+                nest.addImage(image);
+            });
+        }
+
+        Nest savedNest = nestRepository.save(nest);
+
+        // 4. NestCategory 생성
+        if (proposal.getCategoryIds() != null) {
+            proposal.getCategoryIds().forEach(categoryId -> {
+                Category category = categoryRepository.findById(categoryId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+                NestCategory nestCategory = NestCategory.builder()
+                        .nest(savedNest)
+                        .category(category)
+                        .build();
+                nestCategoryRepository.save(nestCategory);
+            });
+        }
+
+        // 5. NestAdInfo 생성
+        NestAdInfo adInfo = NestAdInfo.builder()
+                .nest(savedNest)
+                .expiredAt(requestDto.getExpiredAt())
+                .priorityScore(requestDto.getPriorityScore())
+                .build();
+        nestAdInfoRepository.save(adInfo);
+
+        // 6. 신청 삭제
+        adProposalRepository.delete(proposal);
+
+        log.info("광고 신청 승인 완료: ProposalId={}, NestId={}", proposalId, savedNest.getId());
+    }
+
+    /**
+     * 광고 신청 반려
+     */
+    @Transactional
+    public void rejectProposal(Long proposalId, AdRejectRequestDto requestDto) {
+        AdProposal proposal = adProposalRepository.findById(proposalId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+
+        if (proposal.getStatus() != AdProposalStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        proposal.setStatus(AdProposalStatus.REJECTED);
+        proposal.setRejectReason(requestDto.getRejectReason());
+
+        log.info("광고 신청 반려 완료: ProposalId={}, Reason={}", proposalId, requestDto.getRejectReason());
+    }
+
+    /**
+     * 게시된 광고 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<AdNestAdminResponseDto> getAdNests(Pageable pageable) {
+        return nestAdInfoRepository.findAll(pageable)
+                .map(adInfo -> AdNestAdminResponseDto.of(
+                        adInfo.getNest(),
+                        adInfo.getExpiredAt(),
+                        adInfo.getPriorityScore(),
+                        adInfo.getImpressions(),
+                        adInfo.getClicks()
+                ));
+    }
+
+    /**
+     * 광고 강제 삭제 (Soft Delete)
+     */
+    @Transactional
+    public void deleteAdNest(Long nestId) {
+        Nest nest = nestRepository.findById(nestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
+
+        if (!nest.isAd()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // NestAdInfo 삭제 (연관 정보)
+        nestAdInfoRepository.findByNest(nest).ifPresent(nestAdInfoRepository::delete);
+
+        // Nest 본체 Soft Delete
+        nest.setDeletedAt(LocalDateTime.now());
+        log.info("광고 강제 삭제 완료: NestId={}", nestId);
+    }
+}

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -10,6 +10,7 @@ import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.nest.entity.NestCategory;
@@ -48,6 +49,7 @@ public class AdminAdService {
     private final NestAdInfoRepository nestAdInfoRepository;
     private final CategoryRepository categoryRepository;
     private final NestCategoryRepository nestCategoryRepository;
+    private final NestCommentRepository nestCommentRepository;
 
     /**
      * 이메일로 유저 검색
@@ -61,6 +63,8 @@ public class AdminAdService {
                         .email(user.getEmail())
                         .role(user.getRole())
                         .createdAt(user.getCreatedAt())
+                        .nestCount(nestRepository.countByCreator(user))
+                        .commentCount(nestCommentRepository.countByUser(user))
                         .sanctionedUntil(user.getSanctionedUntil())
                         .isSanctioned(user.getSanctionedUntil() != null && user.getSanctionedUntil().isAfter(LocalDateTime.now()))
                         .build())

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -105,7 +105,9 @@ public class AdminAdService {
 
         // Extract all unique category IDs
         List<Long> allCategoryIds = proposals.stream()
-                .flatMap(p -> p.getCategoryIds().stream())
+                .map(AdProposal::getCategoryIds)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
                 .distinct()
                 .toList();
 
@@ -115,10 +117,11 @@ public class AdminAdService {
 
         return proposals.stream()
                 .map(proposal -> {
-                    List<String> categoryNames = proposal.getCategoryIds().stream()
+                    List<Long> categoryIds = proposal.getCategoryIds();
+                    List<String> categoryNames = categoryIds != null ? categoryIds.stream()
                             .map(categoryMap::get)
                             .filter(Objects::nonNull)
-                            .toList();
+                            .toList() : List.of();
                     return AdProposalAdminResponseDto.from(proposal, categoryNames);
                 })
                 .toList();

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -219,10 +219,7 @@ public class AdminAdService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        // NestAdInfo 삭제 (연관 정보)
-        nestAdInfoRepository.findByNest(nest).ifPresent(nestAdInfoRepository::delete);
-
-        // Nest 본체 Soft Delete
+        // Nest 본체 Soft Delete (NestAdInfo는 통계 보존을 위해 유지)
         nest.setDeletedAt(LocalDateTime.now());
         log.info("광고 강제 삭제 완료: NestId={}", nestId);
     }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.admin.ad.service;
 
 import com.dodo.dodoserver.domain.ad.dao.AdProposalRepository;
 import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.admin.ad.dao.AdAdminRepository;
 import com.dodo.dodoserver.domain.ad.entity.AdProposal;
 import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
 import com.dodo.dodoserver.domain.ad.entity.NestAdInfo;
@@ -47,6 +48,7 @@ public class AdminAdService {
     private final AdProposalRepository adProposalRepository;
     private final NestRepository nestRepository;
     private final NestAdInfoRepository nestAdInfoRepository;
+    private final AdAdminRepository adAdminRepository;
     private final CategoryRepository categoryRepository;
     private final NestCategoryRepository nestCategoryRepository;
     private final NestCommentRepository nestCommentRepository;
@@ -243,8 +245,8 @@ public class AdminAdService {
      * 게시된 광고 목록 조회
      */
     @Transactional(readOnly = true)
-    public Page<AdNestAdminResponseDto> getAdNests(Pageable pageable) {
-        return nestAdInfoRepository.findAll(pageable)
+    public Page<AdNestAdminResponseDto> getAdNests(AdStatusFilter status, Pageable pageable) {
+        return adAdminRepository.findAllWithFilter(status, pageable)
                 .map(adInfo -> AdNestAdminResponseDto.of(
                         adInfo.getNest(),
                         adInfo.getExpiredAt(),

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -31,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Service
@@ -98,8 +101,26 @@ public class AdminAdService {
      */
     @Transactional(readOnly = true)
     public List<AdProposalAdminResponseDto> getPendingProposals() {
-        return adProposalRepository.findAllByStatus(AdProposalStatus.PENDING).stream()
-                .map(AdProposalAdminResponseDto::from)
+        List<AdProposal> proposals = adProposalRepository.findAllByStatus(AdProposalStatus.PENDING);
+
+        // Extract all unique category IDs
+        List<Long> allCategoryIds = proposals.stream()
+                .flatMap(p -> p.getCategoryIds().stream())
+                .distinct()
+                .toList();
+
+        // Fetch category names and create a map
+        Map<Long, String> categoryMap = categoryRepository.findAllById(allCategoryIds).stream()
+                .collect(Collectors.toMap(Category::getId, Category::getName));
+
+        return proposals.stream()
+                .map(proposal -> {
+                    List<String> categoryNames = proposal.getCategoryIds().stream()
+                            .map(categoryMap::get)
+                            .filter(Objects::nonNull)
+                            .toList();
+                    return AdProposalAdminResponseDto.from(proposal, categoryNames);
+                })
                 .toList();
     }
 

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -136,6 +136,25 @@ public class AdminAdService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
+        User advertiser = proposal.getAdvertiser();
+        if (advertiser.getRole() != Role.ADVERTISER) {
+            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        AdvertiserAuthority authority = advertiserAuthorityRepository.findByUser(advertiser)
+                .orElseThrow(() -> new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED));
+
+        // 권한 만료 체크
+        if (authority.getExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.ADVERTISER_AUTHORITY_EXPIRED);
+        }
+
+        // 발행 가능 개수 체크 (현재 승인된 광고 수)
+        long currentAdCount = nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(advertiser);
+        if (currentAdCount >= authority.getAllowedAdCount()) {
+            throw new BusinessException(ErrorCode.AD_COUNT_LIMIT_EXCEEDED);
+        }
+
         // 1. Nest 생성
         Nest nest = Nest.builder()
                 .creator(proposal.getAdvertiser())

--- a/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/controller/NestGpsController.java
@@ -3,6 +3,9 @@ package com.dodo.dodoserver.domain.nest.controller;
 import com.dodo.dodoserver.domain.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.service.NestService;
 import com.dodo.dodoserver.global.common.ApiResponseDto;
+import com.dodo.dodoserver.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -10,11 +13,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import com.dodo.dodoserver.global.security.UserPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Nest GPS", description = "위치 기반 둥지 조회 API")
 @RestController
 @RequestMapping("/api/v1/nests")
 @RequiredArgsConstructor
@@ -22,11 +25,10 @@ public class NestGpsController {
 
     private final NestService nestService;
 
-
-
     /**
      * 사용자 현재 위치 검증을 통한 둥지 해금
      */
+    @Operation(summary = "사용자 현재 위치 검증을 통한 둥지 해금", description = "사용자의 현재 위치가 둥지의 해금 반경 내에 있는지 확인하고 해금합니다.")
     @PostMapping("/{id}/unlock")
     public ApiResponseDto<String> unlockNest(
             @AuthenticationPrincipal UserPrincipal principal,
@@ -37,11 +39,10 @@ public class NestGpsController {
         return ApiResponseDto.success("둥지가 성공적으로 해금되었습니다.");
     }
 
-
-
     /**
      * 특정 ID 리스트 둥지 요약 정보 조회 (클러스터링 클릭 시 사용)
      */
+    @Operation(summary = "ID 리스트 기반 둥지 요약 정보 조회", description = "여러 개의 둥지 ID를 받아 해당 둥지들의 요약 정보를 반환합니다. 클러스터링 클릭 시 등에 사용됩니다.")
     @GetMapping("/summaries")
     public ApiResponseDto<List<NestSummaryResponseDto>> getNestsByIds(
             @AuthenticationPrincipal UserPrincipal principal,
@@ -52,9 +53,10 @@ public class NestGpsController {
     }
 
     /**
-     * 현재 위치 기반 반경 내 카테고리별 둥지 리스트 조회
+     * 현재 위치 기반 반경 내 카테고리별 둥지 리스트 조회 (광고 제외)
      * 정렬 기준 예시: sort=createdAt,desc / sort=viewCount,desc
      */
+    @Operation(summary = "반경 내 일반 둥지 리스트 조회", description = "현재 위치 기준 반경 내에 있는 일반 둥지(광고 제외) 목록을 페이징하여 조회합니다.")
     @GetMapping
     public ApiResponseDto<Page<NestSummaryResponseDto>> getNearbyNests(
             @AuthenticationPrincipal UserPrincipal principal,
@@ -68,8 +70,9 @@ public class NestGpsController {
     }
 
     /**
-     * 현재 위치 기반 반경 내 모든 둥지 핀 정보 조회
+     * 현재 위치 기반 반경 내 모든 일반 둥지 핀 정보 조회 (광고 제외)
      */
+    @Operation(summary = "반경 내 일반 둥지 핀 조회", description = "현재 위치 기준 반경 내에 있는 일반 둥지(광고 제외)들의 ID와 좌표 정보를 조회합니다.")
     @GetMapping("/pins")
     public ApiResponseDto<List<NestPinResponseDto>> getNearbyPins(
             @RequestParam Double latitude,
@@ -78,5 +81,19 @@ public class NestGpsController {
             @RequestParam(required = false) List<Long> categoryIds) {
 
         return ApiResponseDto.success(nestService.getNearbyPins(latitude, longitude, radiusMeter, categoryIds));
+    }
+
+    /**
+     * 현재 위치 기반 반경 내 광고 둥지 핀 정보 조회 (우선순위 적용)
+     */
+    @Operation(summary = "반경 내 광고 둥지 핀 조회", description = "현재 위치 기준 반경 내에 있는 광고 둥지들의 핀 정보를 우선순위에 따라 조회합니다. 조회 시 노출수(impressions)가 증가합니다.")
+    @GetMapping("/ad-pins")
+    public ApiResponseDto<List<NestPinResponseDto>> getNearbyAdPins(
+            @RequestParam Double latitude,
+            @RequestParam Double longitude,
+            @RequestParam(required = false) Double radiusMeter,
+            @RequestParam(required = false) List<Long> categoryIds) {
+
+        return ApiResponseDto.success(nestService.getNearbyAdPins(latitude, longitude, radiusMeter, categoryIds));
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestCommentRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestCommentRepository.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.nest.dao;
 
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +17,8 @@ public interface NestCommentRepository extends JpaRepository<NestComment, Long> 
     // 특정 둥지의 모든 댓글 조회 (삭제된 댓글 포함 여부는 필터로 제어됨)
     @Query("SELECT nc FROM NestComment nc JOIN FETCH nc.user WHERE nc.nest.id = :nestId")
     List<NestComment> findAllByNestId(@Param("nestId") Long nestId);
+
+    long countByUser(User user);
 
     void deleteAllByNest(Nest nest);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
@@ -19,6 +19,8 @@ public interface NestRepository extends JpaRepository<Nest, Long>, NestRepositor
 
     long countByCreatorAndIsAdTrueAndDeletedAtIsNull(User creator);
 
+    long countByCreator(User creator);
+
     List<Nest> findAllByCreatorAndIsAdTrueAndDeletedAtIsNull(User creator);
 
     List<Nest> findAllByCreatorAndIsAdTrue(User creator);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
@@ -20,4 +20,6 @@ public interface NestRepository extends JpaRepository<Nest, Long>, NestRepositor
     long countByCreatorAndIsAdTrueAndDeletedAtIsNull(User creator);
 
     List<Nest> findAllByCreatorAndIsAdTrueAndDeletedAtIsNull(User creator);
+
+    List<Nest> findAllByCreatorAndIsAdTrue(User creator);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
@@ -3,14 +3,21 @@ package com.dodo.dodoserver.domain.nest.dao;
 import com.dodo.dodoserver.domain.admin.nest.dao.AdminNestRepositoryCustom;
 import com.dodo.dodoserver.domain.nest.dao.querydsl.NestRepositoryCustom;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NestRepository extends JpaRepository<Nest, Long>, NestRepositoryCustom, AdminNestRepositoryCustom {
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Nest n SET n.viewCount = n.viewCount + :increment WHERE n.id = :nestId")
     void incrementViewCount(@Param("nestId") Long nestId, @Param("increment") Long increment);
+
+    long countByCreatorAndIsAdTrueAndDeletedAtIsNull(User creator);
+
+    List<Nest> findAllByCreatorAndIsAdTrueAndDeletedAtIsNull(User creator);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryCustom.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryCustom.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public interface NestRepositoryCustom {
     List<NestPinResponseDto> findNearbyPins(Point point, Double radiusMeter, List<Long> categoryIds);
+    List<NestPinResponseDto> findNearbyAdPins(Point point, Double radiusMeter, List<Long> categoryIds, int limit);
     Page<NestQueryDto> findNearbyNests(Point point, Double radiusMeter, List<Long> categoryIds, Pageable pageable);
     List<NestQueryDto> findNestsByIdsCustom(List<Long> nestIds, Sort sort);
     Double calculateDistance(Long nestId, Point point);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/querydsl/NestRepositoryImpl.java
@@ -31,6 +31,7 @@ import static com.dodo.dodoserver.domain.nest.entity.QNestLocation.nestLocation;
 import static com.dodo.dodoserver.domain.nest.entity.QNestCategory.nestCategory;
 import static com.dodo.dodoserver.domain.nest.entity.QNestReaction.nestReaction;
 import static com.dodo.dodoserver.domain.category.entity.QCategory.category;
+import static com.dodo.dodoserver.domain.ad.entity.QNestAdInfo.nestAdInfo;
 
 @RequiredArgsConstructor
 public class NestRepositoryImpl implements NestRepositoryCustom {
@@ -53,8 +54,34 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 .where(
                         distance.loe(radiusMeter),
                         categoryIn(categoryIds),
-                        nest.deletedAt.isNull()
+                        nest.deletedAt.isNull(),
+                        nest.isAd.isFalse()
                 )
+                .fetch();
+    }
+
+    @Override
+    public List<NestPinResponseDto> findNearbyAdPins(Point point, Double radiusMeter, List<Long> categoryIds, int limit) {
+        NumberTemplate<Double> distance = Expressions.numberTemplate(Double.class,
+                "ST_Distance_Sphere({0}, {1})", nestLocation.point, point);
+
+        return queryFactory
+                .select(Projections.constructor(NestPinResponseDto.class,
+                        nest.id,
+                        Expressions.numberTemplate(Double.class, "ST_Latitude({0})", nestLocation.point),
+                        Expressions.numberTemplate(Double.class, "ST_Longitude({0})", nestLocation.point)
+                ))
+                .from(nest)
+                .join(nest.location, nestLocation)
+                .join(nestAdInfo).on(nestAdInfo.nest.id.eq(nest.id))
+                .where(
+                        distance.loe(radiusMeter),
+                        categoryIn(categoryIds),
+                        nest.deletedAt.isNull(),
+                        nest.isAd.isTrue()
+                )
+                .orderBy(nestAdInfo.priorityScore.desc(), nest.createdAt.desc())
+                .limit(limit)
                 .fetch();
     }
 
@@ -126,7 +153,8 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 .where(
                         distance.loe(radiusMeter),
                         categoryIn(categoryIds),
-                        nest.deletedAt.isNull()
+                        nest.deletedAt.isNull(),
+                        nest.isAd.isFalse()
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
@@ -166,7 +194,8 @@ public class NestRepositoryImpl implements NestRepositoryCustom {
                 .where(
                         distance.loe(radiusMeter),
                         categoryIn(categoryIds),
-                        nest.deletedAt.isNull()
+                        nest.deletedAt.isNull(),
+                        nest.isAd.isFalse()
                 )
                 .fetchOne();
 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -368,20 +368,20 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        // Redis 기반 조회수 증가 (중복 방지 포함)
-        redisViewCountService.incrementViewCount(nestId, userId);
-
-        // 광고인 경우 클릭수 증가 (Redis 기반)
-        if (nest.isAd()) {
-            redisViewCountService.incrementAdClickCount(nestId);
-        }
-
         boolean isUnlocked = nest.isAd() 
                 || unlockHistoryRepository.existsByUserAndNest(user, nest) 
                 || nest.getCreator().equals(user); // 자기 자신일 경우 해금
 
         if (!isUnlocked) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
+        }
+
+        // Redis 기반 조회수 증가 (중복 방지 포함)
+        redisViewCountService.incrementViewCount(nestId, userId);
+
+        // 광고인 경우 클릭수 증가 (Redis 기반)
+        if (nest.isAd()) {
+            redisViewCountService.incrementAdClickCount(nestId);
         }
 
         UserProfile creatorProfile = userProfileRepository.findByUser(nest.getCreator()).orElse(null);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -141,7 +141,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (!nest.getCreator().equals(user)) {
+        if (!nest.getCreator().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_NEST_CREATOR);
         }
 
@@ -224,7 +224,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (!nest.getCreator().equals(user)) {
+        if (!nest.getCreator().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_NEST_CREATOR);
         }
 
@@ -258,7 +258,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (!nest.getCreator().equals(user) && !unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+        if (!nest.isAd() && !nest.getCreator().getId().equals(userId) && !unlockHistoryRepository.existsByUserAndNest(user, nest)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 
@@ -352,7 +352,7 @@ public class NestService {
 
         return nestDtos.stream().map(dto -> {
             Nest nest = dto.getNest();
-            boolean isUnlocked = nest.getCreator().equals(user) || unlockedNestIds.contains(nest.getId());
+            boolean isUnlocked = nest.isAd() || nest.getCreator().getId().equals(userId) || unlockedNestIds.contains(nest.getId());
             return NestSummaryResponseDto.from(nest, isUnlocked, dto.getLikeCount(), dto.getDistance(), dto.getCategoryNames(), nestPostcardMap.get(nest.getId()));
         }).collect(Collectors.toList());
     }
@@ -370,7 +370,7 @@ public class NestService {
 
         boolean isUnlocked = nest.isAd() 
                 || unlockHistoryRepository.existsByUserAndNest(user, nest) 
-                || nest.getCreator().equals(user); // 자기 자신일 경우 해금
+                || nest.getCreator().getId().equals(userId); // 자기 자신일 경우 해금
 
         if (!isUnlocked) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
@@ -430,6 +430,14 @@ public class NestService {
         User currentUser = currentUserId != null ? userRepository.findById(currentUserId).orElse(null) : null;
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
+
+        // 권한 체크 (해금 여부)
+        boolean isUnlocked = nest.isAd() 
+                || (currentUser != null && (nest.getCreator().getId().equals(currentUser.getId()) || unlockHistoryRepository.existsByUserAndNest(currentUser, nest)));
+
+        if (!isUnlocked) {
+            throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
+        }
 
         // 삭제된 댓글도 포함하여 조회 (AOP 필터가 이 경로에서는 비활성화됨)
         List<NestComment> allComments = nestCommentRepository.findAllByNestId(nestId);
@@ -524,6 +532,16 @@ public class NestService {
         NestComment comment = nestCommentRepository.findById(commentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
 
+        Nest nest = comment.getNest();
+        // 권한 체크 (해금 여부)
+        boolean isUnlocked = nest.isAd() 
+                || nest.getCreator().getId().equals(userId) 
+                || unlockHistoryRepository.existsByUserAndNest(user, nest);
+
+        if (!isUnlocked) {
+            throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
+        }
+
         Optional<CommentLike> existingLike = commentLikeRepository.findByUserAndComment(user, comment);
 
         if (existingLike.isPresent()) {
@@ -603,7 +621,7 @@ public class NestService {
 
         return nests.map(dto -> {
             Nest nestEntity = dto.getNest();
-            boolean isUnlocked = nestEntity.getCreator().equals(user) || unlockedNestIds.contains(nestEntity.getId());
+            boolean isUnlocked = nestEntity.isAd() || nestEntity.getCreator().getId().equals(userId) || unlockedNestIds.contains(nestEntity.getId());
             return NestSummaryResponseDto.from(nestEntity, isUnlocked, dto.getLikeCount(), dto.getDistance(), dto.getCategoryNames(), nestPostcardMap.get(nestEntity.getId()));
         });
     }
@@ -619,7 +637,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (nest.getCreator().equals(user) || unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+        if (nest.isAd() || nest.getCreator().getId().equals(userId) || unlockHistoryRepository.existsByUserAndNest(user, nest)) {
             throw new BusinessException(ErrorCode.ALREADY_UNLOCKED);
         }
 
@@ -652,7 +670,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (!unlockHistoryRepository.existsByUserAndNest(user, nest) && !nest.getCreator().equals(user)) {
+        if (!nest.isAd() && !unlockHistoryRepository.existsByUserAndNest(user, nest) && !nest.getCreator().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -258,7 +258,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (!nest.isAd() && !nest.getCreator().getId().equals(userId) && !unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+        if (!isNestUnlockedForUser(nest, user)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 
@@ -368,9 +368,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        boolean isUnlocked = nest.isAd() 
-                || unlockHistoryRepository.existsByUserAndNest(user, nest) 
-                || nest.getCreator().getId().equals(userId); // 자기 자신일 경우 해금
+        boolean isUnlocked = isNestUnlockedForUser(nest, user);
 
         if (!isUnlocked) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
@@ -432,10 +430,7 @@ public class NestService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
         // 권한 체크 (해금 여부)
-        boolean isUnlocked = nest.isAd() 
-                || (currentUser != null && (nest.getCreator().getId().equals(currentUser.getId()) || unlockHistoryRepository.existsByUserAndNest(currentUser, nest)));
-
-        if (!isUnlocked) {
+        if (!isNestUnlockedForUser(nest, currentUser)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 
@@ -534,11 +529,7 @@ public class NestService {
 
         Nest nest = comment.getNest();
         // 권한 체크 (해금 여부)
-        boolean isUnlocked = nest.isAd() 
-                || nest.getCreator().getId().equals(userId) 
-                || unlockHistoryRepository.existsByUserAndNest(user, nest);
-
-        if (!isUnlocked) {
+        if (!isNestUnlockedForUser(nest, user)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 
@@ -637,7 +628,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (nest.isAd() || nest.getCreator().getId().equals(userId) || unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+        if (isNestUnlockedForUser(nest, user)) {
             throw new BusinessException(ErrorCode.ALREADY_UNLOCKED);
         }
 
@@ -670,7 +661,7 @@ public class NestService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        if (!nest.isAd() && !unlockHistoryRepository.existsByUserAndNest(user, nest) && !nest.getCreator().getId().equals(userId)) {
+        if (!isNestUnlockedForUser(nest, user)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 
@@ -705,5 +696,16 @@ public class NestService {
         if (type == ReactionType.LIKE) {
             nestNotificationService.sendNestLikeNotification(user, nest);
         }
+    }
+
+    /**
+     * 사용자가 둥지를 해금했거나 접근 가능한 상태인지 확인합니다.
+     * (광고 둥지, 작성자 본인, 해금 이력 보유 여부 검사)
+     */
+    public boolean isNestUnlockedForUser(Nest nest, User user) {
+        if (nest.isAd()) return true;
+        if (user == null) return false;
+        if (nest.getCreator().getId().equals(user.getId())) return true;
+        return unlockHistoryRepository.existsByUserAndNest(user, nest);
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -380,6 +380,10 @@ public class NestService {
                 || unlockHistoryRepository.existsByUserAndNest(user, nest) 
                 || nest.getCreator().equals(user); // 자기 자신일 경우 해금
 
+        if (!isUnlocked) {
+            throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
+        }
+
         UserProfile creatorProfile = userProfileRepository.findByUser(nest.getCreator()).orElse(null);
         long likeCount = nestReactionRepository.countByNestAndReactionType(nest, ReactionType.LIKE);
         long dislikeCount = nestReactionRepository.countByNestAndReactionType(nest, ReactionType.DISLIKE);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -376,7 +376,8 @@ public class NestService {
             redisViewCountService.incrementAdClickCount(nestId);
         }
 
-        boolean isUnlocked = unlockHistoryRepository.existsByUserAndNest(user, nest) 
+        boolean isUnlocked = nest.isAd() 
+                || unlockHistoryRepository.existsByUserAndNest(user, nest) 
                 || nest.getCreator().equals(user); // 자기 자신일 경우 해금
 
         UserProfile creatorProfile = userProfileRepository.findByUser(nest.getCreator()).orElse(null);

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -2,6 +2,7 @@ package com.dodo.dodoserver.domain.nest.service;
 
 import static com.dodo.dodoserver.global.common.constants.NestConstants.*;
 
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.*;
@@ -49,6 +50,7 @@ public class NestService {
     private final NestNotificationService nestNotificationService;
     private final RedisViewCountService redisViewCountService;
     private final PostcardRepository postcardRepository;
+    private final NestAdInfoRepository nestAdInfoRepository;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -369,6 +371,11 @@ public class NestService {
         // Redis 기반 조회수 증가 (중복 방지 포함)
         redisViewCountService.incrementViewCount(nestId, userId);
 
+        // 광고인 경우 클릭수 증가
+        if (nest.isAd()) {
+            nestAdInfoRepository.incrementClicks(nestId);
+        }
+
         boolean isUnlocked = unlockHistoryRepository.existsByUserAndNest(user, nest) 
                 || nest.getCreator().equals(user); // 자기 자신일 경우 해금
 
@@ -532,13 +539,31 @@ public class NestService {
 
 
     /**
-     * 현재 위치 기반 반경 내 모든 둥지 핀 정보 조회
+     * 현재 위치 기반 반경 내 모든 둥지 핀 정보 조회 (광고 제외)
      */
     @Transactional(readOnly = true)
     public List<NestPinResponseDto> getNearbyPins(Double latitude, Double longitude, Double radiusMeter, List<Long> categoryIds) {
         double radius = (radiusMeter != null) ? radiusMeter : DEFAULT_FIND_RADIUS_METER;
         Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude)); // (x,y)
         return nestRepository.findNearbyPins(point, radius, categoryIds);
+    }
+
+    /**
+     * 현재 위치 기반 반경 내 광고 둥지 핀 정보 조회 및 노출수 증가
+     */
+    @Transactional
+    public List<NestPinResponseDto> getNearbyAdPins(Double latitude, Double longitude, Double radiusMeter, List<Long> categoryIds) {
+        double radius = (radiusMeter != null) ? radiusMeter : DEFAULT_FIND_RADIUS_METER;
+        Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+
+        List<NestPinResponseDto> adPins = nestRepository.findNearbyAdPins(point, radius, categoryIds, 5); // 최대 5개 제한
+
+        if (!adPins.isEmpty()) {
+            List<Long> adNestIds = adPins.stream().map(NestPinResponseDto::getId).toList();
+            nestAdInfoRepository.incrementImpressions(adNestIds);
+        }
+
+        return adPins;
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -371,9 +371,9 @@ public class NestService {
         // Redis 기반 조회수 증가 (중복 방지 포함)
         redisViewCountService.incrementViewCount(nestId, userId);
 
-        // 광고인 경우 클릭수 증가
+        // 광고인 경우 클릭수 증가 (Redis 기반)
         if (nest.isAd()) {
-            nestAdInfoRepository.incrementClicks(nestId);
+            redisViewCountService.incrementAdClickCount(nestId);
         }
 
         boolean isUnlocked = unlockHistoryRepository.existsByUserAndNest(user, nest) 

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/NestService.java
@@ -2,7 +2,6 @@ package com.dodo.dodoserver.domain.nest.service;
 
 import static com.dodo.dodoserver.global.common.constants.NestConstants.*;
 
-import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.*;
@@ -50,7 +49,6 @@ public class NestService {
     private final NestNotificationService nestNotificationService;
     private final RedisViewCountService redisViewCountService;
     private final PostcardRepository postcardRepository;
-    private final NestAdInfoRepository nestAdInfoRepository;
 
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -574,7 +572,7 @@ public class NestService {
 
         if (!adPins.isEmpty()) {
             List<Long> adNestIds = adPins.stream().map(NestPinResponseDto::getId).toList();
-            nestAdInfoRepository.incrementImpressions(adNestIds);
+            redisViewCountService.incrementAdImpressionCount(adNestIds);
         }
 
         return adPins;

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
@@ -28,6 +28,9 @@ public class RedisViewCountService {
     private static final String AD_CLICK_COUNT_KEY = "nest:ad:clickCount:%d";
     private static final String UPDATED_AD_NESTS_KEY = "nest:ad:updatedClicks";
 
+    private static final String AD_IMPRESSION_COUNT_KEY = "nest:ad:impressionCount:%d";
+    private static final String UPDATED_AD_IMPRESSIONS_KEY = "nest:ad:updatedImpressions";
+
     /**
      * 조회수 증가 로직 (중복 방지 포함)
      */
@@ -54,6 +57,19 @@ public class RedisViewCountService {
     }
 
     /**
+     * 광고 노출수 증가 로직 (지도 조회 시)
+     */
+    public void incrementAdImpressionCount(java.util.List<Long> nestIds) {
+        if (nestIds == null || nestIds.isEmpty()) return;
+
+        for (Long nestId : nestIds) {
+            String countKey = String.format(AD_IMPRESSION_COUNT_KEY, nestId);
+            redisTemplate.opsForValue().increment(countKey);
+            redisTemplate.opsForSet().add(UPDATED_AD_IMPRESSIONS_KEY, String.valueOf(nestId));
+        }
+    }
+
+    /**
      * Redis의 현재 증가분 조회
      */
     public Long getCachedViewCount(Long nestId) {
@@ -70,6 +86,7 @@ public class RedisViewCountService {
     public void syncToDb() {
         syncViewCountToDb();
         syncAdClickCountToDb();
+        syncAdImpressionCountToDb();
     }
 
     private void syncViewCountToDb() {
@@ -115,6 +132,29 @@ public class RedisViewCountService {
             }
             
             redisTemplate.opsForSet().remove(UPDATED_AD_NESTS_KEY, nestIdStr);
+        }
+    }
+
+    private void syncAdImpressionCountToDb() {
+        Set<String> updatedNestIds = redisTemplate.opsForSet().members(UPDATED_AD_IMPRESSIONS_KEY);
+        if (updatedNestIds == null || updatedNestIds.isEmpty()) {
+            return;
+        }
+
+        log.info("Redis 광고 노출수 DB 동기화 시작: {} 건", updatedNestIds.size());
+
+        for (String nestIdStr : updatedNestIds) {
+            Long nestId = Long.parseLong(nestIdStr);
+            String countKey = String.format(AD_IMPRESSION_COUNT_KEY, nestId);
+
+            String countStr = redisTemplate.opsForValue().getAndDelete(countKey);
+
+            if (countStr != null) {
+                Long increment = Long.parseLong(countStr);
+                nestAdInfoRepository.incrementImpressionsBatch(nestId, increment);
+            }
+
+            redisTemplate.opsForSet().remove(UPDATED_AD_IMPRESSIONS_KEY, nestIdStr);
         }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountService.java
@@ -1,5 +1,6 @@
 package com.dodo.dodoserver.domain.nest.service;
 
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,10 +19,14 @@ public class RedisViewCountService {
 
     private final StringRedisTemplate redisTemplate;
     private final NestRepository nestRepository;
+    private final NestAdInfoRepository nestAdInfoRepository;
 
     private static final String VIEW_USER_KEY = "nest:view:%d:user:%d";
     private static final String VIEW_COUNT_KEY = "nest:viewCount:%d";
     private static final String UPDATED_NESTS_KEY = "nest:updatedViews";
+
+    private static final String AD_CLICK_COUNT_KEY = "nest:ad:clickCount:%d";
+    private static final String UPDATED_AD_NESTS_KEY = "nest:ad:updatedClicks";
 
     /**
      * 조회수 증가 로직 (중복 방지 포함)
@@ -40,6 +45,15 @@ public class RedisViewCountService {
     }
 
     /**
+     * 광고 클릭수 증가 로직
+     */
+    public void incrementAdClickCount(Long nestId) {
+        String countKey = String.format(AD_CLICK_COUNT_KEY, nestId);
+        redisTemplate.opsForValue().increment(countKey);
+        redisTemplate.opsForSet().add(UPDATED_AD_NESTS_KEY, String.valueOf(nestId));
+    }
+
+    /**
      * Redis의 현재 증가분 조회
      */
     public Long getCachedViewCount(Long nestId) {
@@ -49,11 +63,16 @@ public class RedisViewCountService {
     }
 
     /**
-     * 10분마다 Redis의 조회수 증가분을 DB에 반영
+     * 10분마다 Redis의 조회수 및 광고 클릭수 증가분을 DB에 반영
      */
     @Scheduled(cron = "0 0/10 * * * *")
     @Transactional
-    public void syncViewCountToDb() {
+    public void syncToDb() {
+        syncViewCountToDb();
+        syncAdClickCountToDb();
+    }
+
+    private void syncViewCountToDb() {
         Set<String> updatedNestIds = redisTemplate.opsForSet().members(UPDATED_NESTS_KEY);
         if (updatedNestIds == null || updatedNestIds.isEmpty()) {
             return;
@@ -74,7 +93,28 @@ public class RedisViewCountService {
             
             redisTemplate.opsForSet().remove(UPDATED_NESTS_KEY, nestIdStr);
         }
-        
-        log.info("Redis 조회수 DB 동기화 완료");
+    }
+
+    private void syncAdClickCountToDb() {
+        Set<String> updatedNestIds = redisTemplate.opsForSet().members(UPDATED_AD_NESTS_KEY);
+        if (updatedNestIds == null || updatedNestIds.isEmpty()) {
+            return;
+        }
+
+        log.info("Redis 광고 클릭수 DB 동기화 시작: {} 건", updatedNestIds.size());
+
+        for (String nestIdStr : updatedNestIds) {
+            Long nestId = Long.parseLong(nestIdStr);
+            String countKey = String.format(AD_CLICK_COUNT_KEY, nestId);
+            
+            String countStr = redisTemplate.opsForValue().getAndDelete(countKey);
+            
+            if (countStr != null) {
+                Long increment = Long.parseLong(countStr);
+                nestAdInfoRepository.incrementClicksBatch(nestId, increment);
+            }
+            
+            redisTemplate.opsForSet().remove(UPDATED_AD_NESTS_KEY, nestIdStr);
+        }
     }
 }

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -75,8 +75,8 @@ public class PostcardService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        // 둥지 작성자가 아니고, 해금 이력도 없는 경우에만 에러 발생
-        if (!nest.getCreator().equals(user) && !unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+        // 둥지 작성자가 아니고, 해금 이력도 없으며, 광고도 아닌 경우에만 에러 발생
+        if (!nest.isAd() && !nest.getCreator().getId().equals(userId) && !unlockHistoryRepository.existsByUserAndNest(user, nest)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 

--- a/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/postcard/service/PostcardService.java
@@ -1,8 +1,8 @@
 package com.dodo.dodoserver.domain.postcard.service;
 
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
-import com.dodo.dodoserver.domain.nest.dao.UnlockHistoryRepository;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.service.NestService;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardReactionRepository;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.dto.*;
@@ -30,7 +30,7 @@ public class PostcardService {
     private final PostcardRepository postcardRepository;
     private final PostcardRedisService postcardRedisService;
     private final NestRepository nestRepository;
-    private final UnlockHistoryRepository unlockHistoryRepository;
+    private final NestService nestService;
     private final PostcardNotificationService postcardNotificationService;
     private final PostcardReactionRepository postcardReactionRepository;
     private final UserRepository userRepository;
@@ -75,8 +75,8 @@ public class PostcardService {
         Nest nest = nestRepository.findById(nestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEST_NOT_FOUND));
 
-        // 둥지 작성자가 아니고, 해금 이력도 없으며, 광고도 아닌 경우에만 에러 발생
-        if (!nest.isAd() && !nest.getCreator().getId().equals(userId) && !unlockHistoryRepository.existsByUserAndNest(user, nest)) {
+        // 둥지 해금 여부 확인 (작성자 본인, 광고, 해금 이력 포함)
+        if (!nestService.isNestUnlockedForUser(nest, user)) {
             throw new BusinessException(ErrorCode.NEST_NOT_UNLOCKED);
         }
 

--- a/src/main/java/com/dodo/dodoserver/domain/user/dao/AdvertiserAuthorityRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/dao/AdvertiserAuthorityRepository.java
@@ -1,0 +1,12 @@
+package com.dodo.dodoserver.domain.user.dao;
+
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdvertiserAuthorityRepository extends JpaRepository<AdvertiserAuthority, Long> {
+    Optional<AdvertiserAuthority> findByUser(User user);
+    Optional<AdvertiserAuthority> findByUserId(Long userId);
+}

--- a/src/main/java/com/dodo/dodoserver/domain/user/dao/AdvertiserAuthorityRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/dao/AdvertiserAuthorityRepository.java
@@ -3,10 +3,17 @@ package com.dodo.dodoserver.domain.user.dao;
 import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface AdvertiserAuthorityRepository extends JpaRepository<AdvertiserAuthority, Long> {
     Optional<AdvertiserAuthority> findByUser(User user);
     Optional<AdvertiserAuthority> findByUserId(Long userId);
+
+    @Query("SELECT a FROM AdvertiserAuthority a JOIN FETCH a.user WHERE a.expiredAt < :now")
+    List<AdvertiserAuthority> findAllByExpiredAtBefore(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/dao/UserRepository.java
@@ -3,10 +3,12 @@ package com.dodo.dodoserver.domain.user.dao;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
     boolean existsByNickname(String nickname);
+    List<User> findAllByEmailContaining(String email);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/user/entity/AdvertiserAuthority.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/entity/AdvertiserAuthority.java
@@ -1,0 +1,42 @@
+package com.dodo.dodoserver.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "advertiser_authorities")
+@EntityListeners(AuditingEntityListener.class)
+public class AdvertiserAuthority {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "allowed_ad_count", nullable = false)
+    private Integer allowedAdCount;
+
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dodo/dodoserver/domain/user/entity/Role.java
+++ b/src/main/java/com/dodo/dodoserver/domain/user/entity/Role.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
     USER("ROLE_USER"),
+    ADVERTISER("ROLE_ADVERTISER"),
     ADMIN("ROLE_ADMIN");
 
     private final String key;

--- a/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
+++ b/src/main/java/com/dodo/dodoserver/error/ErrorCode.java
@@ -71,7 +71,11 @@ public enum ErrorCode {
     // Inquiry (IQ)
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "IQ001", "문의사항을 찾을 수 없습니다."),
     NOT_INQUIRY_OWNER(HttpStatus.FORBIDDEN, "IQ002", "해당 문의사항에 대한 권한이 없습니다."),
-    CANNOT_MODIFY_COMPLETED_INQUIRY(HttpStatus.BAD_REQUEST, "IQ003", "처리 완료된 문의는 수정하거나 삭제할 수 없습니다.");
+    CANNOT_MODIFY_COMPLETED_INQUIRY(HttpStatus.BAD_REQUEST, "IQ003", "처리 완료된 문의는 수정하거나 삭제할 수 없습니다."),
+
+    // Ad (AD)
+    ADVERTISER_AUTHORITY_EXPIRED(HttpStatus.FORBIDDEN, "AD001", "광고주 권한이 만료되었습니다."),
+    AD_COUNT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "AD002", "발행 가능한 광고 개수를 초과했습니다.");
 
 
 

--- a/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(WHITE_LIST).permitAll()
 				.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+				.requestMatchers("/api/v1/advertiser/**").hasRole("ADVERTISER")
 				.anyRequest().authenticated()
 			)
 

--- a/src/main/java/com/dodo/dodoserver/global/config/SoftDeleteFilterAspect.java
+++ b/src/main/java/com/dodo/dodoserver/global/config/SoftDeleteFilterAspect.java
@@ -47,7 +47,16 @@ public class SoftDeleteFilterAspect {
             return;
         }
 
-        // 3. 그 외 모든 일반 API는 모든 필터 활성화 (소프트 삭제 데이터 숨김)
+        // 3. 광고주 전용 API 중 과거 이력 조회가 필요한 경우 필터 비활성화
+        if (requestURI.startsWith("/api/v1/advertiser/ads/nests")) {
+            session.disableFilter("nestFilter");
+            session.enableFilter("commentFilter");
+            session.enableFilter("postcardFilter");
+            session.enableFilter("inquiryFilter");
+            return;
+        }
+
+        // 4. 그 외 모든 일반 API는 모든 필터 활성화 (소프트 삭제 데이터 숨김)
         session.enableFilter("nestFilter");
         session.enableFilter("commentFilter");
         session.enableFilter("postcardFilter");

--- a/src/test/java/com/dodo/dodoserver/domain/ad/controller/AdvertiserAdControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/ad/controller/AdvertiserAdControllerTest.java
@@ -1,0 +1,129 @@
+package com.dodo.dodoserver.domain.ad.controller;
+
+import com.dodo.dodoserver.domain.ad.dto.AdProposalRequestDto;
+import com.dodo.dodoserver.domain.ad.dto.AdProposalResponseDto;
+import com.dodo.dodoserver.domain.ad.dto.AdvertiserMyAccountResponseDto;
+import com.dodo.dodoserver.domain.ad.service.AdvertiserAdService;
+import com.dodo.dodoserver.global.config.AppProperties;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdvertiserAdController.class)
+@Import(SecurityConfig.class)
+class AdvertiserAdControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdvertiserAdService advertiserAdService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("광고주 계정 정보 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADVERTISER")
+    void getMyAccountInfo_success() throws Exception {
+        AdvertiserMyAccountResponseDto responseDto = AdvertiserMyAccountResponseDto.builder()
+                .allowedAdCount(5)
+                .remainingAdCount(3L)
+                .expiredAt(LocalDateTime.now().plusMonths(1))
+                .build();
+
+        given(advertiserAdService.getMyAccountInfo(any())).willReturn(responseDto);
+
+        mockMvc.perform(get("/api/v1/advertiser/ads/account"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.allowedAdCount").value(5));
+    }
+
+    @Test
+    @DisplayName("광고 신청 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADVERTISER")
+    void createProposal_success() throws Exception {
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setTitle("새 광고");
+        requestDto.setContent("내용");
+        requestDto.setLatitude(37.5);
+        requestDto.setLongitude(127.0);
+
+        mockMvc.perform(post("/api/v1/advertiser/ads/proposals")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("내 광고 신청 내역 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADVERTISER")
+    void getMyProposals_success() throws Exception {
+        AdProposalResponseDto responseDto = AdProposalResponseDto.builder()
+                .id(1L)
+                .title("신청 광고")
+                .build();
+
+        given(advertiserAdService.getMyProposals(any())).willReturn(List.of(responseDto));
+
+        mockMvc.perform(get("/api/v1/advertiser/ads/proposals/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].title").value("신청 광고"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
@@ -10,6 +10,7 @@ import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
 import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -88,6 +90,63 @@ class AdvertiserAdServiceTest {
         given(adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING)).willReturn(1L);
 
         assertThatThrownBy(() -> advertiserAdService.createProposal(user.getId(), requestDto))
-                .isInstanceOf(BusinessException.class);
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AD_COUNT_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("광고 신청 수정 실패 - 반려된 신청서 재제출 시 허용 개수 초과")
+    void updateProposal_fail_limitExceeded_whenResubmittingRejected() {
+        Long proposalId = 100L;
+        AdProposal proposal = AdProposal.builder()
+                .id(proposalId)
+                .advertiser(user)
+                .status(AdProposalStatus.REJECTED)
+                .build();
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setTitle("수정 제목");
+        requestDto.setLatitude(37.5);
+        requestDto.setLongitude(127.0);
+
+        given(adProposalRepository.findById(proposalId)).willReturn(Optional.of(proposal));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(3L); // 이미 한도 도달
+        given(adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING)).willReturn(0L);
+
+        assertThatThrownBy(() -> advertiserAdService.updateProposal(user.getId(), proposalId, requestDto))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AD_COUNT_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("광고 신청 수정 실패 - 권한 만료")
+    void updateProposal_fail_authorityExpired() {
+        Long proposalId = 100L;
+        AdProposal proposal = AdProposal.builder()
+                .id(proposalId)
+                .advertiser(user)
+                .status(AdProposalStatus.REJECTED)
+                .build();
+        
+        // 만료된 권한 생성
+        AdvertiserAuthority expiredAuthority = AdvertiserAuthority.builder()
+                .user(user)
+                .allowedAdCount(3)
+                .expiredAt(LocalDateTime.now().minusDays(1))
+                .build();
+        
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setLatitude(37.5);
+        requestDto.setLongitude(127.0);
+
+        given(adProposalRepository.findById(proposalId)).willReturn(Optional.of(proposal));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(expiredAuthority));
+
+        assertThatThrownBy(() -> advertiserAdService.updateProposal(user.getId(), proposalId, requestDto))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ADVERTISER_AUTHORITY_EXPIRED);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
@@ -103,6 +103,7 @@ class AdvertiserAdServiceTest {
     @Test
     @DisplayName("광고 신청 수정 실패 - 반려된 신청서 재제출 시 허용 개수 초과")
     void updateProposal_fail_limitExceeded_whenResubmittingRejected() {
+        // given
         Long proposalId = 100L;
         AdProposal proposal = AdProposal.builder()
                 .id(proposalId)
@@ -119,6 +120,7 @@ class AdvertiserAdServiceTest {
         given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(3L); // 이미 한도 도달
         given(adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING)).willReturn(0L);
 
+        // when & then
         assertThatThrownBy(() -> advertiserAdService.updateProposal(user.getId(), proposalId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
@@ -128,6 +130,7 @@ class AdvertiserAdServiceTest {
     @Test
     @DisplayName("광고 신청 수정 실패 - 권한 만료")
     void updateProposal_fail_authorityExpired() {
+        // given
         Long proposalId = 100L;
         AdProposal proposal = AdProposal.builder()
                 .id(proposalId)
@@ -149,6 +152,7 @@ class AdvertiserAdServiceTest {
         given(adProposalRepository.findById(proposalId)).willReturn(Optional.of(proposal));
         given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(expiredAuthority));
 
+        // when & then
         assertThatThrownBy(() -> advertiserAdService.updateProposal(user.getId(), proposalId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
@@ -158,6 +162,7 @@ class AdvertiserAdServiceTest {
     @Test
     @DisplayName("내 광고 신청 내역 조회 성공 - 카테고리 ID가 null인 경우 포함")
     void getMyProposals_success_withNullCategoryIds() {
+        // given
         AdProposal p1 = AdProposal.builder().id(1L).advertiser(user).categoryIds(List.of(1L)).build();
         AdProposal p2 = AdProposal.builder().id(2L).advertiser(user).categoryIds(null).build(); // null 카테고리
         
@@ -165,8 +170,10 @@ class AdvertiserAdServiceTest {
         given(adProposalRepository.findAllByAdvertiser(user)).willReturn(List.of(p1, p2));
         given(categoryRepository.findAllById(any())).willReturn(List.of());
 
+        // when
         List<AdProposalResponseDto> result = advertiserAdService.getMyProposals(user.getId());
 
+        // then
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getCategoryNames()).isEmpty();
         assertThat(result.get(1).getCategoryNames()).isEmpty();

--- a/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
@@ -1,0 +1,93 @@
+package com.dodo.dodoserver.domain.ad.service;
+
+import com.dodo.dodoserver.domain.ad.dao.AdProposalRepository;
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.ad.dto.AdProposalRequestDto;
+import com.dodo.dodoserver.domain.ad.entity.AdProposal;
+import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdvertiserAdServiceTest {
+
+    @InjectMocks
+    private AdvertiserAdService advertiserAdService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private AdvertiserAuthorityRepository advertiserAuthorityRepository;
+    @Mock
+    private AdProposalRepository adProposalRepository;
+    @Mock
+    private NestRepository nestRepository;
+    @Mock
+    private NestAdInfoRepository nestAdInfoRepository;
+
+    private User user;
+    private AdvertiserAuthority authority;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().id(1L).nickname("광고주").build();
+        authority = AdvertiserAuthority.builder()
+                .user(user)
+                .allowedAdCount(3)
+                .expiredAt(LocalDateTime.now().plusDays(10))
+                .build();
+    }
+
+    @Test
+    @DisplayName("광고 신청 성공")
+    void createProposal_success() {
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setTitle("신청 제목");
+        requestDto.setContent("신청 내용");
+        requestDto.setLatitude(37.5);
+        requestDto.setLongitude(127.0);
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(1L);
+        given(adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING)).willReturn(0L);
+
+        advertiserAdService.createProposal(user.getId(), requestDto);
+
+        verify(adProposalRepository).save(any(AdProposal.class));
+    }
+
+    @Test
+    @DisplayName("광고 신청 실패 - 허용 개수 초과")
+    void createProposal_fail_limitExceeded() {
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setTitle("신청 제목");
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(2L);
+        given(adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING)).willReturn(1L);
+
+        assertThatThrownBy(() -> advertiserAdService.createProposal(user.getId(), requestDto))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
@@ -7,6 +7,7 @@ import com.dodo.dodoserver.domain.ad.dto.AdProposalResponseDto;
 import com.dodo.dodoserver.domain.ad.entity.AdProposal;
 import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
+import com.dodo.dodoserver.domain.category.entity.Category;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
@@ -84,6 +85,48 @@ class AdvertiserAdServiceTest {
     }
 
     @Test
+    @DisplayName("광고 신청 실패 - 존재하지 않는 카테고리")
+    void createProposal_fail_invalidCategory() {
+        // given
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setCategoryIds(List.of(999L));
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(1L);
+        given(adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING)).willReturn(0L);
+        // 999L에 해당하는 카테고리가 없음
+        given(categoryRepository.findAllById(List.of(999L))).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> advertiserAdService.createProposal(user.getId(), requestDto))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CATEGORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("광고 신청 실패 - 삭제된 카테고리")
+    void createProposal_fail_deletedCategory() {
+        // given
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setCategoryIds(List.of(1L));
+        Category deletedCategory = Category.builder().id(1L).name("삭제된카테고리").deletedAt(LocalDateTime.now()).build();
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(1L);
+        given(adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING)).willReturn(0L);
+        given(categoryRepository.findAllById(List.of(1L))).willReturn(List.of(deletedCategory));
+
+        // when & then
+        assertThatThrownBy(() -> advertiserAdService.createProposal(user.getId(), requestDto))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ALREADY_DELETED_CATEGORY);
+    }
+
+    @Test
     @DisplayName("광고 신청 실패 - 허용 개수 초과")
     void createProposal_fail_limitExceeded() {
         AdProposalRequestDto requestDto = new AdProposalRequestDto();
@@ -157,6 +200,33 @@ class AdvertiserAdServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ADVERTISER_AUTHORITY_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("광고 신청 수정 실패 - 존재하지 않는 카테고리")
+    void updateProposal_fail_invalidCategory() {
+        // given
+        Long proposalId = 100L;
+        AdProposal proposal = AdProposal.builder()
+                .id(proposalId)
+                .advertiser(user)
+                .status(AdProposalStatus.REJECTED)
+                .build();
+        
+        AdProposalRequestDto requestDto = new AdProposalRequestDto();
+        requestDto.setCategoryIds(List.of(999L));
+        requestDto.setLatitude(37.5);
+        requestDto.setLongitude(127.0);
+
+        given(adProposalRepository.findById(proposalId)).willReturn(Optional.of(proposal));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(categoryRepository.findAllById(List.of(999L))).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> advertiserAdService.updateProposal(user.getId(), proposalId, requestDto))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CATEGORY_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/ad/service/AdvertiserAdServiceTest.java
@@ -3,8 +3,10 @@ package com.dodo.dodoserver.domain.ad.service;
 import com.dodo.dodoserver.domain.ad.dao.AdProposalRepository;
 import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
 import com.dodo.dodoserver.domain.ad.dto.AdProposalRequestDto;
+import com.dodo.dodoserver.domain.ad.dto.AdProposalResponseDto;
 import com.dodo.dodoserver.domain.ad.entity.AdProposal;
 import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
@@ -21,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +48,8 @@ class AdvertiserAdServiceTest {
     private NestRepository nestRepository;
     @Mock
     private NestAdInfoRepository nestAdInfoRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
 
     private User user;
     private AdvertiserAuthority authority;
@@ -148,5 +153,22 @@ class AdvertiserAdServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ADVERTISER_AUTHORITY_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("내 광고 신청 내역 조회 성공 - 카테고리 ID가 null인 경우 포함")
+    void getMyProposals_success_withNullCategoryIds() {
+        AdProposal p1 = AdProposal.builder().id(1L).advertiser(user).categoryIds(List.of(1L)).build();
+        AdProposal p2 = AdProposal.builder().id(2L).advertiser(user).categoryIds(null).build(); // null 카테고리
+        
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(adProposalRepository.findAllByAdvertiser(user)).willReturn(List.of(p1, p2));
+        given(categoryRepository.findAllById(any())).willReturn(List.of());
+
+        List<AdProposalResponseDto> result = advertiserAdService.getMyProposals(user.getId());
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getCategoryNames()).isEmpty();
+        assertThat(result.get(1).getCategoryNames()).isEmpty();
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdControllerTest.java
@@ -1,0 +1,125 @@
+package com.dodo.dodoserver.domain.admin.ad.controller;
+
+import com.dodo.dodoserver.domain.admin.ad.dto.AdApproveRequestDto;
+import com.dodo.dodoserver.domain.admin.ad.dto.AdProposalAdminResponseDto;
+import com.dodo.dodoserver.domain.admin.ad.dto.AdvertiserAuthorityRequestDto;
+import com.dodo.dodoserver.domain.admin.ad.service.AdminAdService;
+import com.dodo.dodoserver.global.config.AppProperties;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminAdController.class)
+@Import(SecurityConfig.class)
+class AdminAdControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdminAdService adminAdService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("광고주 권한 부여 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void grantAdvertiserRole_success() throws Exception {
+        AdvertiserAuthorityRequestDto requestDto = new AdvertiserAuthorityRequestDto();
+        requestDto.setAllowedAdCount(5);
+        requestDto.setExpiredAt(LocalDateTime.now().plusMonths(1));
+
+        mockMvc.perform(post("/api/v1/admin/ads/advertisers/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("대기 중인 광고 신청 목록 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getPendingProposals_success() throws Exception {
+        AdProposalAdminResponseDto responseDto = AdProposalAdminResponseDto.builder()
+                .id(1L)
+                .title("광고 신청")
+                .advertiserNickname("광고주")
+                .build();
+
+        given(adminAdService.getPendingProposals()).willReturn(List.of(responseDto));
+
+        mockMvc.perform(get("/api/v1/admin/ads/proposals"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].title").value("광고 신청"));
+    }
+
+    @Test
+    @DisplayName("광고 신청 승인 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void approveProposal_success() throws Exception {
+        AdApproveRequestDto requestDto = new AdApproveRequestDto();
+        requestDto.setExpiredAt(LocalDateTime.now().plusMonths(1));
+
+        mockMvc.perform(post("/api/v1/admin/ads/proposals/1/approve")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdControllerTest.java
@@ -3,6 +3,7 @@ package com.dodo.dodoserver.domain.admin.ad.controller;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdApproveRequestDto;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdProposalAdminResponseDto;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdvertiserAuthorityRequestDto;
+import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.domain.admin.ad.service.AdminAdService;
 import com.dodo.dodoserver.global.config.AppProperties;
 import com.dodo.dodoserver.global.config.SecurityConfig;
@@ -72,6 +73,30 @@ class AdminAdControllerTest {
             filterChain.doFilter(request, response);
             return null;
         }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("광고주 권한 부여를 위한 유저 검색 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void searchUsers_success() throws Exception {
+        UserAdminResponseDto responseDto = UserAdminResponseDto.builder()
+                .id(1L)
+                .nickname("도도대장")
+                .email("test@dodo.com")
+                .nestCount(5L)
+                .commentCount(10L)
+                .isSanctioned(false)
+                .build();
+
+        given(adminAdService.searchUsersByEmail("test@dodo.com")).willReturn(List.of(responseDto));
+
+        mockMvc.perform(get("/api/v1/admin/ads/users/search")
+                        .param("email", "test@dodo.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].nickname").value("도도대장"))
+                .andExpect(jsonPath("$.data[0].nestCount").value(5))
+                .andExpect(jsonPath("$.data[0].commentCount").value(10));
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/controller/AdminAdControllerTest.java
@@ -1,8 +1,6 @@
 package com.dodo.dodoserver.domain.admin.ad.controller;
 
-import com.dodo.dodoserver.domain.admin.ad.dto.AdApproveRequestDto;
-import com.dodo.dodoserver.domain.admin.ad.dto.AdProposalAdminResponseDto;
-import com.dodo.dodoserver.domain.admin.ad.dto.AdvertiserAuthorityRequestDto;
+import com.dodo.dodoserver.domain.admin.ad.dto.*;
 import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.domain.admin.ad.service.AdminAdService;
 import com.dodo.dodoserver.global.config.AppProperties;
@@ -19,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -146,5 +146,24 @@ class AdminAdControllerTest {
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("게시된 광고 목록 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getAdNests_success() throws Exception {
+        AdNestAdminResponseDto responseDto = AdNestAdminResponseDto.builder()
+                .id(1L)
+                .title("게시된 광고")
+                .advertiserNickname("광고주")
+                .build();
+
+        given(adminAdService.getAdNests(eq(AdStatusFilter.ALL), any())).willReturn(new PageImpl<>(List.of(responseDto)));
+
+        mockMvc.perform(get("/api/v1/admin/ads/nests")
+                        .param("status", "ALL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].title").value("게시된 광고"));
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
@@ -5,6 +5,7 @@ import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
 import com.dodo.dodoserver.domain.ad.entity.AdProposal;
 import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdApproveRequestDto;
+import com.dodo.dodoserver.domain.admin.ad.dto.AdProposalAdminResponseDto;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdvertiserAuthorityRequestDto;
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
@@ -29,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -169,5 +171,21 @@ class AdminAdServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AD_COUNT_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("대기 중인 광고 신청 목록 조회 성공 - 카테고리 ID가 null인 경우 포함")
+    void getPendingProposals_success_withNullCategoryIds() {
+        AdProposal p1 = AdProposal.builder().id(1L).advertiser(user).categoryIds(List.of(1L)).status(AdProposalStatus.PENDING).build();
+        AdProposal p2 = AdProposal.builder().id(2L).advertiser(user).categoryIds(null).status(AdProposalStatus.PENDING).build(); // null 카테고리
+        
+        given(adProposalRepository.findAllByStatus(AdProposalStatus.PENDING)).willReturn(List.of(p1, p2));
+        given(categoryRepository.findAllById(any())).willReturn(List.of());
+
+        List<AdProposalAdminResponseDto> result = adminAdService.getPendingProposals();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getCategoryNames()).isEmpty();
+        assertThat(result.get(1).getCategoryNames()).isEmpty();
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
@@ -15,6 +15,8 @@ import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
 import com.dodo.dodoserver.domain.user.entity.Role;
 import com.dodo.dodoserver.domain.user.entity.User;
+import com.dodo.dodoserver.error.ErrorCode;
+import com.dodo.dodoserver.error.exception.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -86,6 +89,7 @@ class AdminAdServiceTest {
     @Test
     @DisplayName("광고 신청 승인 성공")
     void approveProposal_success() {
+        user.setRole(Role.ADVERTISER);
         AdProposal proposal = AdProposal.builder()
                 .id(10L)
                 .advertiser(user)
@@ -95,11 +99,19 @@ class AdminAdServiceTest {
                 .status(AdProposalStatus.PENDING)
                 .build();
 
+        AdvertiserAuthority authority = AdvertiserAuthority.builder()
+                .user(user)
+                .allowedAdCount(3)
+                .expiredAt(LocalDateTime.now().plusDays(10))
+                .build();
+
         AdApproveRequestDto requestDto = new AdApproveRequestDto();
         requestDto.setExpiredAt(LocalDateTime.now().plusMonths(1));
         requestDto.setPriorityScore(10);
 
         given(adProposalRepository.findById(10L)).willReturn(Optional.of(proposal));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(1L);
         given(nestRepository.save(any(Nest.class))).willAnswer(inv -> inv.getArgument(0));
 
         adminAdService.approveProposal(10L, requestDto);
@@ -107,5 +119,55 @@ class AdminAdServiceTest {
         verify(nestRepository).save(any(Nest.class));
         verify(nestAdInfoRepository).save(any());
         verify(adProposalRepository).delete(proposal);
+    }
+
+    @Test
+    @DisplayName("광고 신청 승인 실패 - 광고주 권한 만료")
+    void approveProposal_fail_authorityExpired() {
+        user.setRole(Role.ADVERTISER);
+        AdProposal proposal = AdProposal.builder()
+                .id(10L)
+                .advertiser(user)
+                .status(AdProposalStatus.PENDING)
+                .build();
+
+        AdvertiserAuthority authority = AdvertiserAuthority.builder()
+                .user(user)
+                .expiredAt(LocalDateTime.now().minusDays(1)) // 만료됨
+                .build();
+
+        given(adProposalRepository.findById(10L)).willReturn(Optional.of(proposal));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+
+        assertThatThrownBy(() -> adminAdService.approveProposal(10L, new AdApproveRequestDto()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ADVERTISER_AUTHORITY_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("광고 신청 승인 실패 - 허용 개수 초과")
+    void approveProposal_fail_limitExceeded() {
+        user.setRole(Role.ADVERTISER);
+        AdProposal proposal = AdProposal.builder()
+                .id(10L)
+                .advertiser(user)
+                .status(AdProposalStatus.PENDING)
+                .build();
+
+        AdvertiserAuthority authority = AdvertiserAuthority.builder()
+                .user(user)
+                .allowedAdCount(3)
+                .expiredAt(LocalDateTime.now().plusDays(10))
+                .build();
+
+        given(adProposalRepository.findById(10L)).willReturn(Optional.of(proposal));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
+        given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(3L); // 이미 3개
+
+        assertThatThrownBy(() -> adminAdService.approveProposal(10L, new AdApproveRequestDto()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AD_COUNT_LIMIT_EXCEEDED);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
@@ -91,6 +91,7 @@ class AdminAdServiceTest {
     @Test
     @DisplayName("광고 신청 승인 성공")
     void approveProposal_success() {
+        // given
         user.setRole(Role.ADVERTISER);
         AdProposal proposal = AdProposal.builder()
                 .id(10L)
@@ -116,8 +117,10 @@ class AdminAdServiceTest {
         given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(1L);
         given(nestRepository.save(any(Nest.class))).willAnswer(inv -> inv.getArgument(0));
 
+        // when
         adminAdService.approveProposal(10L, requestDto);
 
+        // then
         verify(nestRepository).save(any(Nest.class));
         verify(nestAdInfoRepository).save(any());
         verify(adProposalRepository).delete(proposal);
@@ -126,6 +129,7 @@ class AdminAdServiceTest {
     @Test
     @DisplayName("광고 신청 승인 실패 - 광고주 권한 만료")
     void approveProposal_fail_authorityExpired() {
+        // given
         user.setRole(Role.ADVERTISER);
         AdProposal proposal = AdProposal.builder()
                 .id(10L)
@@ -141,6 +145,7 @@ class AdminAdServiceTest {
         given(adProposalRepository.findById(10L)).willReturn(Optional.of(proposal));
         given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
 
+        // when & then
         assertThatThrownBy(() -> adminAdService.approveProposal(10L, new AdApproveRequestDto()))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
@@ -150,6 +155,7 @@ class AdminAdServiceTest {
     @Test
     @DisplayName("광고 신청 승인 실패 - 허용 개수 초과")
     void approveProposal_fail_limitExceeded() {
+        // given
         user.setRole(Role.ADVERTISER);
         AdProposal proposal = AdProposal.builder()
                 .id(10L)
@@ -167,6 +173,7 @@ class AdminAdServiceTest {
         given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.of(authority));
         given(nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user)).willReturn(3L); // 이미 3개
 
+        // when & then
         assertThatThrownBy(() -> adminAdService.approveProposal(10L, new AdApproveRequestDto()))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
@@ -176,14 +183,17 @@ class AdminAdServiceTest {
     @Test
     @DisplayName("대기 중인 광고 신청 목록 조회 성공 - 카테고리 ID가 null인 경우 포함")
     void getPendingProposals_success_withNullCategoryIds() {
+        // given
         AdProposal p1 = AdProposal.builder().id(1L).advertiser(user).categoryIds(List.of(1L)).status(AdProposalStatus.PENDING).build();
         AdProposal p2 = AdProposal.builder().id(2L).advertiser(user).categoryIds(null).status(AdProposalStatus.PENDING).build(); // null 카테고리
         
         given(adProposalRepository.findAllByStatus(AdProposalStatus.PENDING)).willReturn(List.of(p1, p2));
         given(categoryRepository.findAllById(any())).willReturn(List.of());
 
+        // when
         List<AdProposalAdminResponseDto> result = adminAdService.getPendingProposals();
 
+        // then
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getCategoryNames()).isEmpty();
         assertThat(result.get(1).getCategoryNames()).isEmpty();

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
@@ -1,0 +1,111 @@
+package com.dodo.dodoserver.domain.admin.ad.service;
+
+import com.dodo.dodoserver.domain.ad.dao.AdProposalRepository;
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.ad.entity.AdProposal;
+import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
+import com.dodo.dodoserver.domain.admin.ad.dto.AdApproveRequestDto;
+import com.dodo.dodoserver.domain.admin.ad.dto.AdvertiserAuthorityRequestDto;
+import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
+import com.dodo.dodoserver.domain.user.dao.UserRepository;
+import com.dodo.dodoserver.domain.user.entity.AdvertiserAuthority;
+import com.dodo.dodoserver.domain.user.entity.Role;
+import com.dodo.dodoserver.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAdServiceTest {
+
+    @InjectMocks
+    private AdminAdService adminAdService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private AdvertiserAuthorityRepository advertiserAuthorityRepository;
+    @Mock
+    private AdProposalRepository adProposalRepository;
+    @Mock
+    private NestRepository nestRepository;
+    @Mock
+    private NestAdInfoRepository nestAdInfoRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private NestCategoryRepository nestCategoryRepository;
+
+    private User user;
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .email("advertiser@test.com")
+                .role(Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("광고주 권한 부여 성공")
+    void grantAdvertiserRole_success() {
+        AdvertiserAuthorityRequestDto requestDto = new AdvertiserAuthorityRequestDto();
+        requestDto.setAllowedAdCount(5);
+        requestDto.setExpiredAt(LocalDateTime.now().plusMonths(1));
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(advertiserAuthorityRepository.findByUser(user)).willReturn(Optional.empty());
+
+        adminAdService.grantAdvertiserRole(user.getId(), requestDto);
+
+        assertThat(user.getRole()).isEqualTo(Role.ADVERTISER);
+        verify(advertiserAuthorityRepository).save(any(AdvertiserAuthority.class));
+    }
+
+    @Test
+    @DisplayName("광고 신청 승인 성공")
+    void approveProposal_success() {
+        AdProposal proposal = AdProposal.builder()
+                .id(10L)
+                .advertiser(user)
+                .title("광고 제목")
+                .content("광고 내용")
+                .point(geometryFactory.createPoint(new Coordinate(127.0, 37.5)))
+                .status(AdProposalStatus.PENDING)
+                .build();
+
+        AdApproveRequestDto requestDto = new AdApproveRequestDto();
+        requestDto.setExpiredAt(LocalDateTime.now().plusMonths(1));
+        requestDto.setPriorityScore(10);
+
+        given(adProposalRepository.findById(10L)).willReturn(Optional.of(proposal));
+        given(nestRepository.save(any(Nest.class))).willAnswer(inv -> inv.getArgument(0));
+
+        adminAdService.approveProposal(10L, requestDto);
+
+        verify(nestRepository).save(any(Nest.class));
+        verify(nestAdInfoRepository).save(any());
+        verify(adProposalRepository).delete(proposal);
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
@@ -7,8 +7,10 @@ import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdApproveRequestDto;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdProposalAdminResponseDto;
 import com.dodo.dodoserver.domain.admin.ad.dto.AdvertiserAuthorityRequestDto;
+import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestCommentRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
 import com.dodo.dodoserver.domain.user.dao.AdvertiserAuthorityRepository;
@@ -59,6 +61,8 @@ class AdminAdServiceTest {
     private CategoryRepository categoryRepository;
     @Mock
     private NestCategoryRepository nestCategoryRepository;
+    @Mock
+    private NestCommentRepository nestCommentRepository;
 
     private User user;
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
@@ -70,6 +74,28 @@ class AdminAdServiceTest {
                 .email("advertiser@test.com")
                 .role(Role.USER)
                 .build();
+    }
+
+    @Test
+    @DisplayName("이메일로 유저 검색 성공 - 활동량 데이터 포함")
+    void searchUsersByEmail_success_withActivityCounts() {
+        // given
+        String email = "test@dodo.com";
+        user.setEmail(email);
+        
+        given(userRepository.findAllByEmailContaining(email)).willReturn(List.of(user));
+        given(nestRepository.countByCreator(user)).willReturn(5L);
+        given(nestCommentRepository.countByUser(user)).willReturn(10L);
+
+        // when
+        List<UserAdminResponseDto> result = adminAdService.searchUsersByEmail(email);
+
+        // then
+        assertThat(result).hasSize(1);
+        UserAdminResponseDto dto = result.get(0);
+        assertThat(dto.getEmail()).isEqualTo(email);
+        assertThat(dto.getNestCount()).isEqualTo(5L);
+        assertThat(dto.getCommentCount()).isEqualTo(10L);
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdServiceTest.java
@@ -2,11 +2,10 @@ package com.dodo.dodoserver.domain.admin.ad.service;
 
 import com.dodo.dodoserver.domain.ad.dao.AdProposalRepository;
 import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.admin.ad.dao.AdAdminRepository;
 import com.dodo.dodoserver.domain.ad.entity.AdProposal;
 import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
-import com.dodo.dodoserver.domain.admin.ad.dto.AdApproveRequestDto;
-import com.dodo.dodoserver.domain.admin.ad.dto.AdProposalAdminResponseDto;
-import com.dodo.dodoserver.domain.admin.ad.dto.AdvertiserAuthorityRequestDto;
+import com.dodo.dodoserver.domain.admin.ad.dto.*;
 import com.dodo.dodoserver.domain.admin.user.dto.UserAdminResponseDto;
 import com.dodo.dodoserver.domain.category.dao.CategoryRepository;
 import com.dodo.dodoserver.domain.nest.dao.NestCategoryRepository;
@@ -57,6 +56,8 @@ class AdminAdServiceTest {
     private NestRepository nestRepository;
     @Mock
     private NestAdInfoRepository nestAdInfoRepository;
+    @Mock
+    private AdAdminRepository adAdminRepository;
     @Mock
     private CategoryRepository categoryRepository;
     @Mock
@@ -223,5 +224,29 @@ class AdminAdServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getCategoryNames()).isEmpty();
         assertThat(result.get(1).getCategoryNames()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("게시된 광고 목록 조회 성공")
+    void getAdNests_success() {
+        // given
+        org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
+        Nest nest = Nest.builder().id(1L).creator(user).title("광고").build();
+        com.dodo.dodoserver.domain.ad.entity.NestAdInfo adInfo = com.dodo.dodoserver.domain.ad.entity.NestAdInfo.builder()
+                .nest(nest)
+                .expiredAt(LocalDateTime.now().plusDays(7))
+                .priorityScore(5)
+                .build();
+        
+        given(adAdminRepository.findAllWithFilter(AdStatusFilter.ALL, pageable))
+                .willReturn(new org.springframework.data.domain.PageImpl<>(List.of(adInfo)));
+
+        // when
+        org.springframework.data.domain.Page<AdNestAdminResponseDto> result = adminAdService.getAdNests(AdStatusFilter.ALL, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("광고");
+        verify(adAdminRepository).findAllWithFilter(AdStatusFilter.ALL, pageable);
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -302,7 +302,7 @@ class NestServiceTest {
     @DisplayName("둥지 댓글 리스트 조회 성공")
     void getCommentsByNestId_success() {
         Long nestId = 1L;
-        Nest nest = Nest.builder().id(nestId).build();
+        Nest nest = Nest.builder().id(nestId).creator(user).build();
         NestComment comment = NestComment.builder().id(10L).user(user).content("댓글").children(new ArrayList<>()).build();
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
@@ -323,7 +323,7 @@ class NestServiceTest {
     void getCommentsByNestId_withDeletedComment_maskingSuccess() {
         // given
         Long nestId = 1L;
-        Nest nest = Nest.builder().id(nestId).build();
+        Nest nest = Nest.builder().id(nestId).creator(user).build();
         java.time.LocalDateTime now = java.time.LocalDateTime.now();
         
         // 삭제된 댓글 생성
@@ -359,7 +359,8 @@ class NestServiceTest {
     @DisplayName("댓글 좋아요 등록 성공")
     void handleCommentLike_create() {
         Long commentId = 10L;
-        NestComment comment = NestComment.builder().id(commentId).user(user).likeCount(0L).build();
+        Nest nest = Nest.builder().id(1L).creator(user).build();
+        NestComment comment = NestComment.builder().id(commentId).nest(nest).user(user).likeCount(0L).build();
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
@@ -376,7 +377,8 @@ class NestServiceTest {
     @DisplayName("댓글 좋아요 취소 성공")
     void handleCommentLike_cancel() {
         Long commentId = 10L;
-        NestComment comment = NestComment.builder().id(commentId).user(user).likeCount(1L).build();
+        Nest nest = Nest.builder().id(1L).creator(user).build();
+        NestComment comment = NestComment.builder().id(commentId).nest(nest).user(user).likeCount(1L).build();
         CommentLike like = CommentLike.builder().user(user).comment(comment).build();
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
@@ -521,6 +523,76 @@ class NestServiceTest {
 
         assertThat(existingReaction.getReactionType()).isEqualTo(ReactionType.LIKE);
         verify(nestNotificationService).sendNestLikeNotification(eq(user), eq(nest));
+    }
+
+    @Test
+    @DisplayName("둥지 댓글 리스트 조회 성공 - 광고 둥지는 미해금 시에도 조회 성공")
+    void getCommentsByNestId_ad_success() {
+        Long nestId = 1L;
+        User creator = User.builder().id(2L).build();
+        Nest nest = Nest.builder().id(nestId).creator(creator).isAd(true).build();
+        NestComment comment = NestComment.builder().id(10L).user(creator).content("광고댓글").children(new ArrayList<>()).build();
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
+        given(nestCommentRepository.findAllByNestId(nestId)).willReturn(List.of(comment));
+        given(userProfileRepository.findAllByUserIn(any())).willReturn(new ArrayList<>());
+        given(commentLikeRepository.findAllByUserAndCommentIn(any(), any())).willReturn(new ArrayList<>());
+
+        List<CommentResponseDto> result = nestService.getCommentsByNestId(user.getId(), nestId, "DEFAULT");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getContent()).isEqualTo("광고댓글");
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 등록 성공 - 광고 둥지는 미해금 시에도 가능")
+    void handleCommentLike_ad_success() {
+        Long commentId = 10L;
+        User creator = User.builder().id(2L).build();
+        Nest nest = Nest.builder().id(1L).creator(creator).isAd(true).build();
+        NestComment comment = NestComment.builder().id(commentId).nest(nest).user(creator).likeCount(0L).build();
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        given(commentLikeRepository.findByUserAndComment(user, comment)).willReturn(Optional.empty());
+
+        nestService.handleCommentLike(user.getId(), commentId);
+
+        assertThat(comment.getLikeCount()).isEqualTo(1L);
+        verify(commentLikeRepository).save(any(CommentLike.class));
+    }
+
+    @Test
+    @DisplayName("댓글 작성 성공 - 광고 둥지는 미해금 시에도 가능")
+    void createComment_ad_success() {
+        Long nestId = 1L;
+        User creator = User.builder().id(2L).build();
+        Nest nest = Nest.builder().id(nestId).creator(creator).isAd(true).build();
+        CommentCreateRequestDto requestDto = new CommentCreateRequestDto("광고댓글", null);
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
+
+        nestService.createComment(user.getId(), nestId, requestDto);
+
+        verify(nestCommentRepository).save(any(NestComment.class));
+    }
+
+    @Test
+    @DisplayName("리액션 등록 성공 - 광고 둥지는 미해금 시에도 가능")
+    void handleReaction_ad_success() {
+        Long nestId = 1L;
+        User creator = User.builder().id(2L).build();
+        Nest nest = Nest.builder().id(nestId).creator(creator).isAd(true).build();
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
+        given(nestReactionRepository.findByUserAndNest(user, nest)).willReturn(Optional.empty());
+
+        nestService.handleReaction(user.getId(), nestId, ReactionType.LIKE);
+
+        verify(nestReactionRepository).save(any(NestReaction.class));
     }
 
     // --- 조회 (Search) 테스트 ---

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -285,7 +285,7 @@ class NestServiceTest {
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
-        given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
+        // 작성자 본인이므로 unlockHistoryRepository.existsByUserAndNest() 호출은 short-circuit 되어 호출되지 않음
         given(userProfileRepository.findByUser(user)).willReturn(Optional.empty());
         given(nestReactionRepository.findByUserAndNest(user, nest)).willReturn(Optional.of(reaction));
         given(nestCategoryRepository.findAllByNest(nest)).willReturn(new ArrayList<>());

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -236,27 +236,44 @@ class NestServiceTest {
     }
 
     @Test
-    @DisplayName("둥지 상세 조회 - 미해금 시 ")
+    @DisplayName("둥지 상세 조회 실패 - 미해금 시")
     void getNestDetail_locked() {
         Long nestId = 1L;
         User creator = User.builder().id(2L).nickname("작성자").build();
-        Nest nest = Nest.builder().id(nestId).title("비밀").content("내용").creator(creator).images(new ArrayList<>()).build();
+        Nest nest = Nest.builder().id(nestId).title("비밀").content("내용").creator(creator).images(new ArrayList<>()).isAd(false).build();
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(false);
+
+        assertThatThrownBy(() -> nestService.getNestDetail(user.getId(), nestId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.NEST_NOT_UNLOCKED.getMessage());
+
+        verify(redisViewCountService, never()).incrementViewCount(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("둥지 상세 조회 - 광고 둥지는 미해금 시에도 조회 성공")
+    void getNestDetail_ad_success() {
+        Long nestId = 1L;
+        User creator = User.builder().id(2L).nickname("광고주").build();
+        Nest nest = Nest.builder().id(nestId).title("광고").content("내용").creator(creator).images(new ArrayList<>()).isAd(true).build();
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
+        // 광고이므로 unlockHistoryRepository.existsByUserAndNest() 호출은 short-circuit 되어 호출되지 않음
         given(userProfileRepository.findByUser(creator)).willReturn(Optional.empty());
         given(nestReactionRepository.findByUserAndNest(user, nest)).willReturn(Optional.empty());
         given(nestCategoryRepository.findAllByNest(nest)).willReturn(new ArrayList<>());
-        given(redisViewCountService.getCachedViewCount(nestId)).willReturn(5L);
+        given(redisViewCountService.getCachedViewCount(nestId)).willReturn(0L);
 
         NestDetailResponseDto response = nestService.getNestDetail(user.getId(), nestId);
 
         assertThat(response.getContent()).isEqualTo("내용");
-        assertThat(response.isUnlocked()).isFalse();
-        assertThat(response.getMyReaction()).isNull();
-        assertThat(response.isMine()).isFalse();
+        assertThat(response.isUnlocked()).isTrue();
         verify(redisViewCountService).incrementViewCount(nestId, user.getId());
+        verify(redisViewCountService).incrementAdClickCount(nestId);
     }
 
     @Test

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
@@ -613,5 +614,47 @@ class NestServiceTest {
         List<NestSummaryResponseDto> result = nestService.getNestsByIds(user.getId(), ids, org.springframework.data.domain.Sort.unsorted());
 
         assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("근처 둥지 핀 조회 성공")
+    void getNearbyPins_success() {
+        Double lat = 37.5;
+        Double lng = 127.0;
+        Double radius = 500.0;
+        List<Long> categoryIds = List.of(1L);
+        Point point = geometryFactory.createPoint(new Coordinate(lng, lat));
+        
+        NestPinResponseDto pin = new NestPinResponseDto(100L, lng, lat);
+        given(nestRepository.findNearbyPins(any(Point.class), eq(radius), eq(categoryIds)))
+                .willReturn(List.of(pin));
+
+        List<NestPinResponseDto> result = nestService.getNearbyPins(lat, lng, radius, categoryIds);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("근처 광고 핀 조회 - 노출수 증가 확인")
+    void getNearbyAdPins_success() {
+        Double lat = 37.5;
+        Double lng = 127.0;
+        Double radius = 500.0;
+        List<Long> categoryIds = List.of(1L);
+        
+        NestPinResponseDto pin = new NestPinResponseDto(100L, lng, lat);
+        List<NestPinResponseDto> adPins = List.of(pin);
+        
+        given(nestRepository.findNearbyAdPins(any(Point.class), eq(radius), eq(categoryIds), eq(5)))
+                .willReturn(adPins);
+
+        List<NestPinResponseDto> result = nestService.getNearbyAdPins(lat, lng, radius, categoryIds);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(100L);
+        
+        // Redis 노출수 증가 메서드가 호출되었는지 확인
+        verify(redisViewCountService).incrementAdImpressionCount(List.of(100L));
     }
 }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/NestServiceTest.java
@@ -189,6 +189,7 @@ class NestServiceTest {
     @Test
     @DisplayName("둥지 해금 성공")
     void unlockNest_success() {
+        // given
         Long nestId = 1L;
         User creator = User.builder().id(2L).build();
         Nest nest = Nest.builder().id(nestId).creator(creator).unlockRadius(100).build();
@@ -199,14 +200,17 @@ class NestServiceTest {
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(false);
         given(nestRepository.calculateDistance(eq(nestId), any(Point.class))).willReturn(50.0);
 
+        // when
         nestService.unlockNest(user.getId(), nestId, requestDto);
 
+        // then
         verify(unlockHistoryRepository).save(any(UnlockHistory.class));
     }
 
     @Test
     @DisplayName("둥지 해금 실패 - 이미 해금됨")
     void unlockNest_fail_alreadyUnlocked() {
+        // given
         Long nestId = 1L;
         User creator = User.builder().id(2L).build();
         Nest nest = Nest.builder().id(nestId).creator(creator).build();
@@ -216,6 +220,7 @@ class NestServiceTest {
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
         given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
 
+        // when & then
         assertThatThrownBy(() -> nestService.unlockNest(user.getId(), nestId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_UNLOCKED.getMessage());
@@ -224,6 +229,7 @@ class NestServiceTest {
     @Test
     @DisplayName("둥지 해금 실패 - 작성자 본인")
     void unlockNest_fail_isCreator() {
+        // given
         Long nestId = 1L;
         Nest nest = Nest.builder().id(nestId).creator(user).build();
         NestUnlockRequestDto requestDto = new NestUnlockRequestDto(37.5, 127.0);
@@ -231,6 +237,7 @@ class NestServiceTest {
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
 
+        // when & then
         assertThatThrownBy(() -> nestService.unlockNest(user.getId(), nestId, requestDto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_UNLOCKED.getMessage());
@@ -257,6 +264,7 @@ class NestServiceTest {
     @Test
     @DisplayName("둥지 상세 조회 - 광고 둥지는 미해금 시에도 조회 성공")
     void getNestDetail_ad_success() {
+        // given
         Long nestId = 1L;
         User creator = User.builder().id(2L).nickname("광고주").build();
         Nest nest = Nest.builder().id(nestId).title("광고").content("내용").creator(creator).images(new ArrayList<>()).isAd(true).build();
@@ -269,8 +277,10 @@ class NestServiceTest {
         given(nestCategoryRepository.findAllByNest(nest)).willReturn(new ArrayList<>());
         given(redisViewCountService.getCachedViewCount(nestId)).willReturn(0L);
 
+        // when
         NestDetailResponseDto response = nestService.getNestDetail(user.getId(), nestId);
 
+        // then
         assertThat(response.getContent()).isEqualTo("내용");
         assertThat(response.isUnlocked()).isTrue();
         verify(redisViewCountService).incrementViewCount(nestId, user.getId());
@@ -619,6 +629,7 @@ class NestServiceTest {
     @Test
     @DisplayName("근처 둥지 핀 조회 성공")
     void getNearbyPins_success() {
+        // given
         Double lat = 37.5;
         Double lng = 127.0;
         Double radius = 500.0;
@@ -629,8 +640,10 @@ class NestServiceTest {
         given(nestRepository.findNearbyPins(any(Point.class), eq(radius), eq(categoryIds)))
                 .willReturn(List.of(pin));
 
+        // when
         List<NestPinResponseDto> result = nestService.getNearbyPins(lat, lng, radius, categoryIds);
 
+        // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(100L);
     }
@@ -638,6 +651,7 @@ class NestServiceTest {
     @Test
     @DisplayName("근처 광고 핀 조회 - 노출수 증가 확인")
     void getNearbyAdPins_success() {
+        // given
         Double lat = 37.5;
         Double lng = 127.0;
         Double radius = 500.0;
@@ -649,8 +663,10 @@ class NestServiceTest {
         given(nestRepository.findNearbyAdPins(any(Point.class), eq(radius), eq(categoryIds), eq(5)))
                 .willReturn(adPins);
 
+        // when
         List<NestPinResponseDto> result = nestService.getNearbyAdPins(lat, lng, radius, categoryIds);
 
+        // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(100L);
         

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountServiceTest.java
@@ -46,10 +46,13 @@ class RedisViewCountServiceTest {
     @Test
     @DisplayName("광고 노출수 증가 - Redis 저장 확인")
     void incrementAdImpressionCount_success() {
+        // given
         List<Long> nestIds = List.of(100L, 200L);
 
+        // when
         redisViewCountService.incrementAdImpressionCount(nestIds);
 
+        // then
         verify(valueOperations).increment("nest:ad:impressionCount:100");
         verify(setOperations).add("nest:ad:updatedImpressions", "100");
         verify(valueOperations).increment("nest:ad:impressionCount:200");
@@ -59,14 +62,17 @@ class RedisViewCountServiceTest {
     @Test
     @DisplayName("광고 노출수 DB 동기화 성공")
     void syncAdImpressionCountToDb_success() {
+        // given
         String updatedImpressionsKey = "nest:ad:updatedImpressions";
         given(setOperations.members("nest:updatedViews")).willReturn(Set.of());
         given(setOperations.members("nest:ad:updatedClicks")).willReturn(Set.of());
         given(setOperations.members(updatedImpressionsKey)).willReturn(Set.of("100"));
         given(valueOperations.getAndDelete("nest:ad:impressionCount:100")).willReturn("5");
 
+        // when
         redisViewCountService.syncToDb();
 
+        // then
         verify(nestAdInfoRepository).incrementImpressionsBatch(100L, 5L);
         verify(setOperations).remove(updatedImpressionsKey, "100");
     }

--- a/src/test/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/nest/service/RedisViewCountServiceTest.java
@@ -1,0 +1,73 @@
+package com.dodo.dodoserver.domain.nest.service;
+
+import com.dodo.dodoserver.domain.ad.dao.NestAdInfoRepository;
+import com.dodo.dodoserver.domain.nest.dao.NestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RedisViewCountServiceTest {
+
+    @InjectMocks
+    private RedisViewCountService redisViewCountService;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private NestRepository nestRepository;
+    @Mock
+    private NestAdInfoRepository nestAdInfoRepository;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    @Mock
+    private SetOperations<String, String> setOperations;
+
+    @BeforeEach
+    void setUp() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(redisTemplate.opsForSet()).willReturn(setOperations);
+    }
+
+    @Test
+    @DisplayName("광고 노출수 증가 - Redis 저장 확인")
+    void incrementAdImpressionCount_success() {
+        List<Long> nestIds = List.of(100L, 200L);
+
+        redisViewCountService.incrementAdImpressionCount(nestIds);
+
+        verify(valueOperations).increment("nest:ad:impressionCount:100");
+        verify(setOperations).add("nest:ad:updatedImpressions", "100");
+        verify(valueOperations).increment("nest:ad:impressionCount:200");
+        verify(setOperations).add("nest:ad:updatedImpressions", "200");
+    }
+
+    @Test
+    @DisplayName("광고 노출수 DB 동기화 성공")
+    void syncAdImpressionCountToDb_success() {
+        String updatedImpressionsKey = "nest:ad:updatedImpressions";
+        given(setOperations.members("nest:updatedViews")).willReturn(Set.of());
+        given(setOperations.members("nest:ad:updatedClicks")).willReturn(Set.of());
+        given(setOperations.members(updatedImpressionsKey)).willReturn(Set.of("100"));
+        given(valueOperations.getAndDelete("nest:ad:impressionCount:100")).willReturn("5");
+
+        redisViewCountService.syncToDb();
+
+        verify(nestAdInfoRepository).incrementImpressionsBatch(100L, 5L);
+        verify(setOperations).remove(updatedImpressionsKey, "100");
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -132,6 +132,27 @@ class PostcardServiceTest {
     }
 
     @Test
+    @DisplayName("엽서 교환 성공 - 광고 둥지인 경우 해금 이력 없이도 가능")
+    void exchangePostcard_success_adNest() {
+        // given
+        nest.setAd(true); // 광고 둥지
+        PostcardExchangeRequestDto requestDto = new PostcardExchangeRequestDto(myPostcard.getId());
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
+        // unlockHistoryRepository.existsByUserAndNest 호출하지 않아도 성공해야 함
+        given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
+        given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
+
+        // when
+        PostcardResponseDto response = postcardService.exchangePostcard(user.getId(), nest.getId(), requestDto);
+
+        // then
+        assertThat(response.getId()).isEqualTo(targetPostcard.getId());
+        assertThat(targetPostcard.getCurrentOwner()).isEqualTo(user);
+    }
+
+    @Test
     @DisplayName("엽서 교환 실패 - 본인 엽서인 경우")
     void exchangePostcard_fail_ownPostcard() {
         // given

--- a/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/postcard/service/PostcardServiceTest.java
@@ -1,8 +1,8 @@
 package com.dodo.dodoserver.domain.postcard.service;
 
 import com.dodo.dodoserver.domain.nest.dao.NestRepository;
-import com.dodo.dodoserver.domain.nest.dao.UnlockHistoryRepository;
 import com.dodo.dodoserver.domain.nest.entity.Nest;
+import com.dodo.dodoserver.domain.nest.service.NestService;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardReactionRepository;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.postcard.dto.PostcardExchangeRequestDto;
@@ -48,7 +48,7 @@ class PostcardServiceTest {
     @Mock
     private NestRepository nestRepository;
     @Mock
-    private UnlockHistoryRepository unlockHistoryRepository;
+    private NestService nestService;
     @Mock
     private PostcardNotificationService postcardNotificationService;
     @Mock
@@ -92,7 +92,7 @@ class PostcardServiceTest {
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
-        given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
+        given(nestService.isNestUnlockedForUser(nest, user)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
         given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
 
@@ -119,7 +119,7 @@ class PostcardServiceTest {
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
-        // unlockHistoryRepository.existsByUserAndNest 호출하지 않아도 성공해야 함
+        given(nestService.isNestUnlockedForUser(nest, user)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
         given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
 
@@ -140,7 +140,7 @@ class PostcardServiceTest {
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
-        // unlockHistoryRepository.existsByUserAndNest 호출하지 않아도 성공해야 함
+        given(nestService.isNestUnlockedForUser(nest, user)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
         given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
 
@@ -161,7 +161,7 @@ class PostcardServiceTest {
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
-        given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
+        given(nestService.isNestUnlockedForUser(nest, user)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
         given(postcardRepository.findSharedPostcardByNestForUpdate(nest)).willReturn(Optional.of(targetPostcard));
 
@@ -180,7 +180,7 @@ class PostcardServiceTest {
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(nestRepository.findById(nest.getId())).willReturn(Optional.of(nest));
-        given(unlockHistoryRepository.existsByUserAndNest(user, nest)).willReturn(true);
+        given(nestService.isNestUnlockedForUser(nest, user)).willReturn(true);
         given(postcardRepository.findByIdForUpdate(myPostcard.getId())).willReturn(Optional.of(myPostcard));
 
         // when & then


### PR DESCRIPTION
## 📌 개요 (Overview)
  광고주(ADVERTISER) 역할을 도입하고, 광고 게시물의 신청-심사-노출-성과 측정(통계)으로 이어지는 전 과정을 아우르는 광고 도메인 시스템을 구축했습니다. 지도의 일반 핀과 광고 핀 조회를 분리하여 우선순위 기반의 노출을 제공하며, 광고가 종료된 후에도 광고주가 성과를 분석할 수 있도록 데이터 보존 로직을 고도화했습니다.

## 🛠️ 작업 내용 (Changes)
   - [x] Role.ADVERTISER 추가 및 SecurityConfig 기반 접근 제어 설정
   - [x] 광고주 권한(AdvertiserAuthority), 신청서(AdProposal), 광고상세/통계(NestAdInfo) 엔티티 및 Repository 구축
   - [x] 관리자(Admin) 전용 광고주 관리, 신청 심사(승인/반려), 게시 광고 모니터링 API 구현
   - [x] 광고주(Advertiser) 전용 계정 상태 확인, 광고 신청/수정, 성과 통계 조회 API 구현
   - [x] 지도 핀 조회 API 분리 및 광고 핀 우선순위(priority_score) 정렬 로직(Querydsl) 적용
   - [x] 광고 노출 시 impressions 자동 증가 및 상세 조회 시 clicks 자동 증가 로직 연동
   - [x] 광고 기한 만료 및 광고주 권한 만료를 처리하는 자동화 스케줄러(AdScheduler) 구현
   - [x] SoftDeleteFilterAspect 수정을 통한 특정 경로(광고주 통계)의 종료된 광고 조회 지원
   - [x] 모든 신규 컨트롤러에 Swagger(@Tag, @Operation) 어노테이션 적용
   - [x] 서비스 및 컨트롤러 레이어에 대한 단위/통합 테스트 코드 작성 및 검증 완료

## 📸 스크린샷 / 결과 (Screenshots / Results)
   - ./gradlew classes 컴파일 성공
   - AdminAdServiceTest, AdvertiserAdServiceTest 단위 테스트 통과
   - AdminAdControllerTest, AdvertiserAdControllerTest 통합 테스트 통과
   - Swagger UI를 통한 전 엔드포인트 명세 및 동작 확인 완료


## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #82 

## 📝 추가 참고 사항 (Additional Notes)
   - 광고주의 성과 분석 편의를 위해 광고가 만료되거나 관리자가 강제 삭제하더라도 NestAdInfo(통계 데이터)는 삭제하지 않고 영구 보존하는 정책을 적용했습니다.
   - 광고주 전용 API 중 과거 이력이 필요한 경로에 대해서는 AOP를 통해 Hibernate @Filter를 동적으로 제어하여 삭제된 데이터도 조회가 가능하도록 구현했습니다.

