### PR TITLE
Feat/87/test coverage setup

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -3,8 +3,6 @@ name: Java CI/CD with Docker Compose
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   test:

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run Tests
-        run: ./gradlew test --no-daemon
+      - name: Run Tests and Coverage Verification
+        run: ./gradlew check --no-daemon
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,12 @@ jacocoTestCoverageVerification {
                 value = 'COVEREDRATIO'
                 minimum = 0.70
             }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,3 +108,46 @@ jacocoTestReport {
         }))
     }
 }
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+
+    violationRules {
+        rule {
+            element = 'BUNDLE'
+
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+        }
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    include: [
+                            "**/domain/**/controller/**",
+                            "**/domain/**/service/**"
+                    ],
+                    exclude: [
+                            "**/Q*",
+                            "**/*Dto*",
+                            "**/*Request*",
+                            "**/*Response*",
+                            "**/*Exception*",
+                            "**/*ErrorCode*"
+                    ]
+            )
+        }))
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/build.gradle
+++ b/build.gradle
@@ -88,25 +88,6 @@ jacocoTestReport {
         xml.required = true
         html.required = true
     }
-
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it,
-                    include: [
-                            "**/domain/**/controller/**",
-                            "**/domain/**/service/**"
-                    ],
-                    exclude: [
-                            "**/Q*",
-                            "**/*Dto*",
-                            "**/*Request*",
-                            "**/*Response*",
-                            "**/*Exception*",
-                            "**/*ErrorCode*"
-                    ]
-            )
-        }))
-    }
 }
 
 jacocoTestCoverageVerification {
@@ -135,7 +116,9 @@ jacocoTestCoverageVerification {
             }
         }
     }
+}
 
+configure([jacocoTestReport, jacocoTestCoverageVerification]) {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,91 @@
-# TEAM DODO
-SW 캡스톤디자인 1조 TEAM DODO
+# Dodo Server Backend
 
+유저 관심사 기반의 도도 서비스 백엔드 API 서버입니다.
 
-## 👥 Team Members
+## 🏗️ 프로젝트 패키지 구조 (Package Structure)
 
-| 프로필 | 이름 | 담당 | 이메일 | GitHub |
-| :---: | :---: | :---: | :---: | :---: |
-| <img src="https://github.com/kando0330.png" width="80"> | **한도훈** (팀장) | infra&server | [gks9315@ajou.ac.kr](mailto:gks9315@ajou.ac.kr) | [@kando0330](https://github.com/kando0330) |
-| <img src="https://github.com/defhoon.png" width="80"> | **정의훈** | frontend | [twilight22@ajou.ac.kr](mailto:twilight22@ajou.ac.kr) | [@defhoon](https://github.com/defhoon) |
-| <img src="https://github.com/apdlwjwjwj.png" width="80"> | **채승우** | android app | [apdlwjwjwj@ajou.ac.kr](mailto:apdlwjwjwj@ajou.ac.kr) | [@apdlwjwjwj](https://github.com/apdlwjwjwj) |
-| <img src="https://github.com/Rain-fore.png" width="80"> | **최환희** | frontend | [choihh2660@ajou.ac.kr](mailto:choihh2660@ajou.ac.kr) | [@Rain-fore](https://github.com/Rain-fore) |
+도메인 주도 설계(DDD)를 지향하며, 각 도메인별로 책임이 분리된 패키지 구조를 가집니다.
+
+```text
+src/main/java/com/dodo/dodoserver/
+├── 📂 domain             # 핵심 비즈니스 로직
+│   ├── 📂 ad             # 광고 관리
+│   ├── 📂 admin          # 관리자 기능 (통계, 유저/게시물 관리 등)
+│   ├── 📂 auth           # 인증/인가 (OAuth2, JWT)
+│   ├── 📂 nest           # 둥지(게시물) 및 공간 데이터 관리
+│   ├── 📂 user           # 사용자 프로필 및 계정 관리
+│   └── (기타 도메인: inquiry, category, notice, postcard, report, mypage)
+├── 📂 global             # 공통 설정 및 보안
+│   ├── 📂 config         # DB, Redis, Security, Firebase 등 설정
+│   ├── 📂 security       # JWT 필터 및 OAuth2 서비스 구현
+│   └── 📂 common         # 공통 응답(ApiResponseDto) 및 유틸리티
+├── 📂 infrastructure     # 외부 인프라 서비스
+│   ├── 📂 s3             # AWS S3 파일 업로드
+│   └── 📂 fcm            # Firebase 푸시 알림
+└── 📂 error              # 예외 처리 및 에러 코드 정의
+```
+
+## 🔨 빌드 방법 (Build Instructions)
+
+프로젝트 빌드 시 JaCoCo 테스트 커버리지 검증이 자동으로 수행됩니다.
+
+### 1. 로컬 빌드 및 테스트
+```bash
+# 테스트 수행 및 커버리지 확인 (70% 하한선 검사 포함)
+./gradlew check
+
+# 빌드 및 JAR 생성
+./gradlew build
+```
+
+## 📊 테스트 커버리지 정책 (Test Coverage Policy)
+
+코드 품질 관리 및 안정성 확보를 위해 **JaCoCo**를 통한 테스트 커버리지를 강제하고 있습니다.
+
+### 1. 커버리지 기준 (Quality Gate)
+- **전체 커버리지 하한선: 70%** (70% 미달 시 빌드 실패)
+- **주요 측정 지표**:
+    - **LINE**: 소스 코드 라인 기준 실행 비율
+    - **INSTRUCTION**: 자바 바이트코드 명령 단위 실행 비율 (가장 정밀한 지표)
+    - **BRANCH**: 조건문(`if`, `switch` 등)의 분기 실행 비율 (최소 50% 이상 권장)
+
+### 2. 리포트 확인 방법
+빌드 완료 후 로컬 환경에서 상세한 커버리지 리포트를 확인할 수 있습니다.
+- **경로**: `build/reports/jacoco/test/html/index.html`
+- 해당 파일을 브라우저로 열면 클래스별, 메서드별 상세 커버리지 현황(실행된 라인/미실행된 라인)을 시각적으로 확인할 수 있습니다.
+
+### 3. 측정 제외 대상 (Exclusions)
+순수 비즈니스 로직 검증에 집중하기 위해 다음 대상은 측정에서 제외됩니다.
+- **QueryDSL 생성 클래스**: `**/Q*`
+- **데이터 객체**: `**/*Dto*`, `**/*Request*`, `**/*Response*`
+- **예외 처리 및 에러 코드**: `**/*Exception*`, `**/*ErrorCode*`
+- **설정 및 보안**: `global/config/**`, `global/security/**`
+
+## 🚀 CI/CD 로직 (CI/CD Pipeline)
+
+본 프로젝트는 GitHub Actions와 Docker를 활용하여 자동화된 배포 프로세스를 따릅니다.
+
+1. **CI (Continuous Integration)**
+   - `develop` 브랜치에 코드가 `push`되거나 PR이 `merge`되면 트리거됩니다.
+   - `./gradlew check`를 통해 테스트 및 커버리지를 검증하며, 실패 시 빌드가 중단됩니다.
+2. **CD (Continuous Deployment)**
+   - 검증된 코드를 기반으로 Docker 이미지를 빌드합니다.
+   - 빌드된 이미지를 **Docker Hub**에 푸시합니다.
+   - **EC2** 서버에 접속하여 최신 이미지를 `pull` 받고 `docker-compose up`을 통해 자동화 된 배포를 수행합니다.
+
+## 🔑 GitHub Actions Secrets 설정
+
+보안을 위해 환경 변수는 GitHub Secrets를 통해 런타임에 주입됩니다. 배포를 위해 다음 시크릿 설정이 필요합니다.
+
+| 구분 | 시크릿 키 (Secret Key) | 설명 |
+| :--- | :--- | :--- |
+| **Infrastructure** | `EC2_HOST`, `EC2_SSH_KEY` | 배포 서버 접속 정보 |
+| | `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` | 도커 이미지 푸시 권한 |
+| **Application** | `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` | MySQL 데이터베이스 정보 |
+| | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | OAuth2 로그인 연동 |
+| | `JWT_SECRET`, `JWT_EXPIRATION_*` | 토큰 발급 및 만료 설정 |
+| | `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGION` | S3 스토리지 연동 |
+| **External** | `FIREBASE_SERVICE_ACCOUNT` | FCM 알림 발송용 서비스 계정 JSON |
+
+---
+

--- a/src/test/java/com/dodo/dodoserver/domain/admin/category/controller/AdminCategoryControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/category/controller/AdminCategoryControllerTest.java
@@ -1,0 +1,166 @@
+package com.dodo.dodoserver.domain.admin.category.controller;
+
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryRequestDto;
+import com.dodo.dodoserver.domain.admin.category.dto.AdminCategoryResponseDto;
+import com.dodo.dodoserver.domain.admin.category.dto.CategoryOrderUpdateRequestDto;
+import com.dodo.dodoserver.domain.admin.category.service.AdminCategoryService;
+import com.dodo.dodoserver.global.config.AppProperties;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminCategoryController.class)
+@Import(SecurityConfig.class)
+class AdminCategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdminCategoryService adminCategoryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("어드민 카테고리 목록 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getCategories_success() throws Exception {
+        // given
+        AdminCategoryResponseDto responseDto = AdminCategoryResponseDto.builder()
+                .id(1L)
+                .name("테스트 카테고리")
+                .sortOrder(0)
+                .build();
+        given(adminCategoryService.getCategories(true, null)).willReturn(List.of(responseDto));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/categories"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].name").value("테스트 카테고리"));
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void createCategory_success() throws Exception {
+        // given
+        AdminCategoryRequestDto requestDto = new AdminCategoryRequestDto("새 카테고리");
+        AdminCategoryResponseDto responseDto = AdminCategoryResponseDto.builder()
+                .id(1L)
+                .name("새 카테고리")
+                .sortOrder(1)
+                .build();
+        given(adminCategoryService.createCategory(any())).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/admin/categories")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.name").value("새 카테고리"));
+    }
+
+    @Test
+    @DisplayName("카테고리 수정 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void updateCategory_success() throws Exception {
+        // given
+        AdminCategoryRequestDto requestDto = new AdminCategoryRequestDto("수정된 카테고리");
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/admin/categories/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("카테고리 순서 수정 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void updateCategoryOrders_success() throws Exception {
+        // given
+        CategoryOrderUpdateRequestDto.CategoryOrderDto orderDto = 
+                new CategoryOrderUpdateRequestDto.CategoryOrderDto(1L, 1);
+        CategoryOrderUpdateRequestDto requestDto = 
+                new CategoryOrderUpdateRequestDto(List.of(orderDto));
+
+        // when & then
+        mockMvc.perform(put("/api/v1/admin/categories/orders")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void deleteCategory_success() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/admin/categories/1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/inquiry/controller/AdminInquiryControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/inquiry/controller/AdminInquiryControllerTest.java
@@ -1,0 +1,134 @@
+package com.dodo.dodoserver.domain.admin.inquiry.controller;
+
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryDetailResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.AdminInquiryResponseDto;
+import com.dodo.dodoserver.domain.admin.inquiry.dto.InquiryAnswerRequestDto;
+import com.dodo.dodoserver.domain.admin.inquiry.service.AdminInquiryService;
+import com.dodo.dodoserver.global.config.AppProperties;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminInquiryController.class)
+@Import(SecurityConfig.class)
+class AdminInquiryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdminInquiryService adminInquiryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("관리자 문의 리스트 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getInquiries_success() throws Exception {
+        // given
+        AdminInquiryResponseDto responseDto = AdminInquiryResponseDto.builder()
+                .id(1L)
+                .title("문의 제목")
+                .userNickname("유저1")
+                .build();
+        Page<AdminInquiryResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1);
+        given(adminInquiryService.getInquiries(any(), any())).willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/inquiries"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].title").value("문의 제목"));
+    }
+
+    @Test
+    @DisplayName("관리자 문의 상세 조회 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void getInquiryDetail_success() throws Exception {
+        // given
+        AdminInquiryDetailResponseDto responseDto = AdminInquiryDetailResponseDto.builder()
+                .id(1L)
+                .title("문의 제목")
+                .content("문의 내용")
+                .build();
+        given(adminInquiryService.getInquiryDetail(1L)).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/admin/inquiries/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content").value("문의 내용"));
+    }
+
+    @Test
+    @DisplayName("관리자 문의 답변 등록 성공")
+    @WithMockUserPrincipal(role = "ROLE_ADMIN")
+    void answerInquiry_success() throws Exception {
+        // given
+        InquiryAnswerRequestDto requestDto = new InquiryAnswerRequestDto("답변 내용");
+
+        // when & then
+        mockMvc.perform(post("/api/v1/admin/inquiries/1/answer")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+}

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -1,20 +1,23 @@
 package com.dodo.dodoserver.domain.admin.nest.service;
 
-import com.dodo.dodoserver.domain.admin.nest.dto.AdminCommentDeleteRequestDto;
-import com.dodo.dodoserver.domain.admin.nest.dto.AdminNestDeleteRequestDto;
+import com.dodo.dodoserver.domain.admin.nest.dto.*;
 import com.dodo.dodoserver.domain.nest.dao.*;
-import com.dodo.dodoserver.domain.nest.entity.Nest;
-import com.dodo.dodoserver.domain.nest.entity.NestComment;
+import com.dodo.dodoserver.domain.nest.entity.*;
 import com.dodo.dodoserver.domain.postcard.dao.PostcardRepository;
 import com.dodo.dodoserver.domain.report.dao.ReportRepository;
 import com.dodo.dodoserver.domain.report.entity.ReportStatus;
 import com.dodo.dodoserver.domain.report.entity.ReportType;
 import com.dodo.dodoserver.domain.user.dao.UserDeviceRepository;
+import com.dodo.dodoserver.domain.user.dao.UserProfileRepository;
 import com.dodo.dodoserver.domain.user.dao.UserRepository;
 import com.dodo.dodoserver.domain.user.entity.User;
 import com.dodo.dodoserver.domain.user.entity.UserDevice;
+import com.dodo.dodoserver.domain.user.entity.UserProfile;
 import com.dodo.dodoserver.infrastructure.fcm.FcmService;
-import com.dodo.dodoserver.infrastructure.fcm.NotificationEvent;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.dodo.dodoserver.error.ErrorCode;
 import com.dodo.dodoserver.error.exception.BusinessException;
@@ -24,7 +27,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -68,6 +77,9 @@ class AdminNestServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
     private UserDeviceRepository userDeviceRepository;
 
     @Mock
@@ -75,6 +87,110 @@ class AdminNestServiceTest {
 
     @Mock
     private JPAQueryFactory queryFactory;
+
+    @Test
+    @DisplayName("관리자 둥지 목록 조회 성공")
+    void getNestsForAdmin_success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        LocalDate start = LocalDate.now().minusDays(7);
+        LocalDate end = LocalDate.now();
+        Page<AdminNestResponseDto> expectedPage = new PageImpl<>(Collections.emptyList());
+
+        given(nestRepository.findNestsForAdmin(pageable, start, end, "latest", "Y"))
+                .willReturn(expectedPage);
+
+        // when
+        Page<AdminNestResponseDto> result = adminNestService.getNestsForAdmin(pageable, start, end, "latest", "Y");
+
+        // then
+        assertThat(result).isNotNull();
+        verify(nestRepository).findNestsForAdmin(pageable, start, end, "latest", "Y");
+    }
+
+    @Test
+    @DisplayName("관리자 둥지 상세 조회 성공")
+    @SuppressWarnings("unchecked")
+    void getNestDetailForAdmin_success() {
+        // given
+        Long nestId = 1L;
+        User creator = User.builder().id(10L).nickname("테스터").build();
+        Nest nest = Nest.builder()
+                .id(nestId)
+                .title("제목")
+                .content("내용")
+                .creator(creator)
+                .createdAt(LocalDateTime.now())
+                .images(Collections.emptyList())
+                .build();
+
+        given(nestRepository.findById(nestId)).willReturn(Optional.of(nest));
+        given(nestCategoryRepository.findAllByNest(nest)).willReturn(Collections.emptyList());
+        
+        // Querydsl Mocking
+        JPAQuery mockQuery = mock(JPAQuery.class);
+        given(queryFactory.select(any(Expression.class), any(Expression.class))).willReturn(mockQuery);
+        given(mockQuery.from(any(EntityPath.class))).willReturn(mockQuery);
+        given(mockQuery.where(any(Predicate[].class))).willReturn(mockQuery);
+        given(mockQuery.fetchOne()).willReturn(null);
+
+        given(nestReactionRepository.countByNestAndReactionType(nest, ReactionType.LIKE)).willReturn(5L);
+        given(nestReactionRepository.countByNestAndReactionType(nest, ReactionType.DISLIKE)).willReturn(1L);
+        given(userProfileRepository.findByUser(creator)).willReturn(Optional.of(UserProfile.builder().profileImageUrl("img").build()));
+
+        // when
+        AdminNestDetailResponseDto result = adminNestService.getNestDetailForAdmin(nestId);
+
+        // then
+        assertThat(result.getNestId()).isEqualTo(nestId);
+        assertThat(result.getTitle()).isEqualTo("제목");
+    }
+
+    @Test
+    @DisplayName("둥지 상세 조회 실패 - 존재하지 않음")
+    void getNestDetailForAdmin_fail_notFound() {
+        // given
+        given(nestRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminNestService.getNestDetailForAdmin(1L))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("둥지 댓글 조회 성공 - 트리 구조 확인")
+    @SuppressWarnings("unchecked")
+    void getNestCommentsForAdmin_success_treeStructure() {
+        // given
+        Long nestId = 1L;
+        User user = User.builder().id(10L).nickname("유저").build();
+        Nest nest = Nest.builder().id(nestId).build();
+        
+        NestComment parent = NestComment.builder().id(100L).user(user).nest(nest).content("부모").createdAt(LocalDateTime.now().minusMinutes(1)).build();
+        NestComment child = NestComment.builder().id(101L).user(user).nest(nest).parent(parent).content("자식").createdAt(LocalDateTime.now()).build();
+        
+        given(nestRepository.existsById(nestId)).willReturn(true);
+        given(nestCommentRepository.findAllByNestId(nestId)).willReturn(List.of(parent, child));
+        given(userRepository.findAllById(any())).willReturn(List.of(user));
+        given(userProfileRepository.findAllByUserIn(any())).willReturn(Collections.emptyList());
+
+        // Querydsl Mocking for reports and likes
+        JPAQuery mockQuery = mock(JPAQuery.class);
+        given(queryFactory.select(any(Expression.class), any(Expression.class))).willReturn(mockQuery);
+        given(mockQuery.from(any(EntityPath.class))).willReturn(mockQuery);
+        lenient().when(mockQuery.where(any(Predicate.class))).thenReturn(mockQuery);
+        lenient().when(mockQuery.where(any(Predicate[].class))).thenReturn(mockQuery);
+        given(mockQuery.groupBy(any(Expression.class))).willReturn(mockQuery);
+        given(mockQuery.fetch()).willReturn(Collections.emptyList());
+
+        // when
+        List<AdminCommentResponseDto> result = adminNestService.getNestCommentsForAdmin(nestId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCommentId()).isEqualTo(100L);
+        assertThat(result.get(0).getChildren()).hasSize(1);
+    }
 
     @Test
     @DisplayName("둥지 삭제 성공 - FCM 알림 및 소셜 데이터 정리 포함")

--- a/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/admin/nest/service/AdminNestServiceTest.java
@@ -93,8 +93,8 @@ class AdminNestServiceTest {
     void getNestsForAdmin_success() {
         // given
         Pageable pageable = PageRequest.of(0, 10);
-        LocalDate start = LocalDate.now().minusDays(7);
-        LocalDate end = LocalDate.now();
+        LocalDate start = LocalDate.of(2025, 1, 1);
+        LocalDate end = LocalDate.of(2025, 1, 8);
         Page<AdminNestResponseDto> expectedPage = new PageImpl<>(Collections.emptyList());
 
         given(nestRepository.findNestsForAdmin(pageable, start, end, "latest", "Y"))

--- a/src/test/java/com/dodo/dodoserver/domain/inquiry/controller/InquiryControllerTest.java
+++ b/src/test/java/com/dodo/dodoserver/domain/inquiry/controller/InquiryControllerTest.java
@@ -1,0 +1,158 @@
+package com.dodo.dodoserver.domain.inquiry.controller;
+
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryRequestDto;
+import com.dodo.dodoserver.domain.inquiry.dto.InquiryResponseDto;
+import com.dodo.dodoserver.domain.inquiry.entity.InquiryType;
+import com.dodo.dodoserver.domain.inquiry.service.InquiryService;
+import com.dodo.dodoserver.global.config.AppProperties;
+import com.dodo.dodoserver.global.config.SecurityConfig;
+import com.dodo.dodoserver.global.security.CustomOAuth2UserService;
+import com.dodo.dodoserver.global.security.JwtAuthenticationFilter;
+import com.dodo.dodoserver.global.security.JwtTokenProvider;
+import com.dodo.dodoserver.global.security.OAuth2AuthenticationSuccessHandler;
+import com.dodo.dodoserver.global.security.WithMockUserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InquiryController.class)
+@Import(SecurityConfig.class)
+class InquiryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private InquiryService inquiryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private AppProperties appProperties;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain filterChain = invocation.getArgument(2);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("1:1 문의 등록 성공")
+    @WithMockUserPrincipal
+    void createInquiry_success() throws Exception {
+        // given
+        InquiryRequestDto requestDto = new InquiryRequestDto(InquiryType.BUG, "제목", "내용");
+        InquiryResponseDto responseDto = InquiryResponseDto.builder()
+                .id(1L)
+                .title("제목")
+                .content("내용")
+                .build();
+        given(inquiryService.createInquiry(any(), any())).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/inquiries")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.title").value("제목"));
+    }
+
+    @Test
+    @DisplayName("내 문의 리스트 조회 성공")
+    @WithMockUserPrincipal
+    void getMyInquiries_success() throws Exception {
+        // given
+        InquiryResponseDto responseDto = InquiryResponseDto.builder()
+                .id(1L)
+                .title("제목")
+                .build();
+        Page<InquiryResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), PageRequest.of(0, 10), 1);
+        given(inquiryService.getMyInquiries(any(), any())).willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/inquiries/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content[0].title").value("제목"));
+    }
+
+    @Test
+    @DisplayName("문의 수정 성공")
+    @WithMockUserPrincipal
+    void updateInquiry_success() throws Exception {
+        // given
+        InquiryRequestDto requestDto = new InquiryRequestDto(InquiryType.BUG, "수정 제목", "수정 내용");
+        InquiryResponseDto responseDto = InquiryResponseDto.builder()
+                .id(1L)
+                .title("수정 제목")
+                .content("수정 내용")
+                .build();
+        given(inquiryService.updateInquiry(any(), eq(1L), any())).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(put("/api/v1/inquiries/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.title").value("수정 제목"));
+    }
+
+    @Test
+    @DisplayName("문의 삭제 성공")
+    @WithMockUserPrincipal
+    void deleteInquiry_success() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/inquiries/1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+}


### PR DESCRIPTION
## 📌 개요 (Overview)
 프로젝트의 코드 품질 유지와 안정적인 배포를 위해 JaCoCo 테스트 커버리지 검증 설정을 도입하고, 목표 수치(70%)를 달성하기 위한 테스트 코드를 보완하였습니다.

## 🛠️ 작업 내용 (Changes)
   - [x] JaCoCo 커버리지 하한선 설정: build.gradle에 jacocoTestCoverageVerification 태스크를 추가하여 LINE 및 INSTRUCTION 커버리지 70% 미달 시
     빌드 실패 설정
   - [x] CI/CD 파이프라인 강화: .github/workflows/deploy-develop.yml에서 ./gradlew test를 ./gradlew check로 변경하여 배포 전 커버리지 검증 강제
   - [x] 테스트 커버리지 보완:
       - AdminNestService: 상세 조회, 목록 조회, 댓글 트리 구조 변환 로직에 대한 단위 테스트 추가
       - AdminCategoryController: 카테고리 생성, 수정, 삭제 및 순서 변경 API 검증 테스트 작성
       - InquiryController: 사용자 1:1 문의 관련 CRUD API 단위 테스트 작성
       - AdminInquiryController: 관리자용 문의 목록/상세 조회 및 답변 등록 API 단위 테스트 작성
   - [x] 코드 품질 검증: ./gradlew check를 통해 전체 테스트 통과 및 70% 커버리지 하한선 충족 확인

## 📸 스크린샷 / 결과 (Screenshots / Results)
<img width="522" height="26" alt="image" src="https://github.com/user-attachments/assets/6e74d5fa-1870-4bda-af58-775751f76d1d" />



## 🔗 관련 이슈 (Related Issues)
해당 PR과 관련된 이슈 번호를 작성해 주세요.
- close #87 

