### PR TITLE
Feat/86/admin minor issue

### DIFF
--- a/src/main/java/com/dodo/dodoserver/domain/ad/dao/AdProposalRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/ad/dao/AdProposalRepository.java
@@ -4,6 +4,8 @@ import com.dodo.dodoserver.domain.ad.entity.AdProposal;
 import com.dodo.dodoserver.domain.ad.entity.AdProposalStatus;
 import com.dodo.dodoserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +13,7 @@ public interface AdProposalRepository extends JpaRepository<AdProposal, Long> {
     List<AdProposal> findAllByStatus(AdProposalStatus status);
     List<AdProposal> findAllByAdvertiser(User advertiser);
     long countByAdvertiserAndStatus(User advertiser, AdProposalStatus status);
+
+    @Query("SELECT p.advertiser.id, COUNT(p) FROM AdProposal p WHERE p.advertiser IN :advertisers AND p.status = :status GROUP BY p.advertiser.id")
+    List<Object[]> countPendingProposalsByAdvertisers(@Param("advertisers") List<User> advertisers, @Param("status") AdProposalStatus status);
 }

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdvertiserResponseDto.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/dto/AdvertiserResponseDto.java
@@ -16,12 +16,12 @@ public class AdvertiserResponseDto {
     private LocalDateTime expiredAt;
     private LocalDateTime createdAt;
 
-    public static AdvertiserResponseDto from(AdvertiserAuthority authority) {
+    public static AdvertiserResponseDto of(AdvertiserAuthority authority, int remainingAdCount) {
         return AdvertiserResponseDto.builder()
                 .userId(authority.getUser().getId())
                 .email(authority.getUser().getEmail())
                 .nickname(authority.getUser().getNickname())
-                .allowedAdCount(authority.getAllowedAdCount())
+                .allowedAdCount(remainingAdCount)
                 .expiredAt(authority.getExpiredAt())
                 .createdAt(authority.getCreatedAt())
                 .build();

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -99,7 +99,13 @@ public class AdminAdService {
     @Transactional(readOnly = true)
     public Page<AdvertiserResponseDto> getAllAdvertisers(Pageable pageable) {
         return advertiserAuthorityRepository.findAll(pageable)
-                .map(AdvertiserResponseDto::from);
+                .map(authority -> {
+                    User user = authority.getUser();
+                    long currentAdCount = nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user);
+                    long pendingCount = adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING);
+                    int remainingAdCount = (int) (authority.getAllowedAdCount() - currentAdCount - pendingCount);
+                    return AdvertiserResponseDto.of(authority, Math.max(0, remainingAdCount));
+                });
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/ad/service/AdminAdService.java
@@ -98,14 +98,27 @@ public class AdminAdService {
      */
     @Transactional(readOnly = true)
     public Page<AdvertiserResponseDto> getAllAdvertisers(Pageable pageable) {
-        return advertiserAuthorityRepository.findAll(pageable)
-                .map(authority -> {
-                    User user = authority.getUser();
-                    long currentAdCount = nestRepository.countByCreatorAndIsAdTrueAndDeletedAtIsNull(user);
-                    long pendingCount = adProposalRepository.countByAdvertiserAndStatus(user, AdProposalStatus.PENDING);
-                    int remainingAdCount = (int) (authority.getAllowedAdCount() - currentAdCount - pendingCount);
-                    return AdvertiserResponseDto.of(authority, Math.max(0, remainingAdCount));
-                });
+        Page<AdvertiserAuthority> authorities = advertiserAuthorityRepository.findAll(pageable);
+        List<User> users = authorities.getContent().stream()
+                .map(AdvertiserAuthority::getUser)
+                .toList();
+
+        if (users.isEmpty()) {
+            return authorities.map(a -> AdvertiserResponseDto.of(a, 0));
+        }
+
+        Map<Long, Long> currentAdCounts = nestRepository.countActiveAdsByCreators(users).stream()
+                .collect(Collectors.toMap(arr -> (Long) arr[0], arr -> (Long) arr[1]));
+        Map<Long, Long> pendingCounts = adProposalRepository.countPendingProposalsByAdvertisers(users, AdProposalStatus.PENDING).stream()
+                .collect(Collectors.toMap(arr -> (Long) arr[0], arr -> (Long) arr[1]));
+
+        return authorities.map(authority -> {
+            User user = authority.getUser();
+            long currentAdCount = currentAdCounts.getOrDefault(user.getId(), 0L);
+            long pendingCount = pendingCounts.getOrDefault(user.getId(), 0L);
+            int remainingAdCount = (int) (authority.getAllowedAdCount() - currentAdCount - pendingCount);
+            return AdvertiserResponseDto.of(authority, Math.max(0, remainingAdCount));
+        });
     }
 
     /**

--- a/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
+++ b/src/main/java/com/dodo/dodoserver/domain/admin/nest/dao/AdminNestRepositoryCustomImpl.java
@@ -57,7 +57,7 @@ public class AdminNestRepositoryCustomImpl implements AdminNestRepositoryCustom 
                 .leftJoin(nestReaction).on(nestReaction.nest.eq(nest))
                 .leftJoin(nestComment).on(nestComment.nest.eq(nest).and(nestComment.deletedAt.isNull()))
                 .leftJoin(report).on(report.targetId.eq(nest.id).and(report.reportType.eq(ReportType.NEST)))
-                .where(dateCondition, deletedCondition)
+                .where(dateCondition, deletedCondition, nest.isAd.isFalse())
                 .groupBy(nest.id)
                 .orderBy(getOrderSpecifier(sort))
                 .offset(pageable.getOffset())
@@ -67,7 +67,7 @@ public class AdminNestRepositoryCustomImpl implements AdminNestRepositoryCustom 
         Long total = queryFactory
                 .select(nest.id.count())
                 .from(nest)
-                .where(dateCondition, deletedCondition)
+                .where(dateCondition, deletedCondition, nest.isAd.isFalse())
                 .fetchOne();
 
         if (nestIds.isEmpty()) {

--- a/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
+++ b/src/main/java/com/dodo/dodoserver/domain/nest/dao/NestRepository.java
@@ -24,4 +24,7 @@ public interface NestRepository extends JpaRepository<Nest, Long>, NestRepositor
     List<Nest> findAllByCreatorAndIsAdTrueAndDeletedAtIsNull(User creator);
 
     List<Nest> findAllByCreatorAndIsAdTrue(User creator);
+
+    @Query("SELECT n.creator.id, COUNT(n) FROM Nest n WHERE n.creator IN :creators AND n.isAd = true AND n.deletedAt IS NULL GROUP BY n.creator.id")
+    List<Object[]> countActiveAdsByCreators(@Param("creators") List<User> creators);
 }


### PR DESCRIPTION
## 📌 개요 (Overview)
관리자 페이지의 마이너 이슈(광고주 목록 잔여 횟수 응답 및 전체 게시물 목록 광고 필터링)를 수정하였습니다.

## 🛠️ 작업 내용 (Changes)
   - [x] 광고주 목록 조회 로직 수정: allowedAdCount 필드에 전체 허용 개수가 아닌 '잔여 광고 가능 개수'가 반환되도록 AdminAdService의 계산 로직을 업데이트하였습니다. (필드명은 하위 호환성을 위해 유지)
   - [x] 전체 게시물 목록 광고 제외: 관리자용 전체 게시물(Nest) 관리 목록 조회 시 광고 게시물은 결과에서 제외되도록 AdminNestRepositoryCustomImpl의 Querydsl 조건을 추가하였습니다.




## 🔗 관련 이슈 (Related Issues)
- close #86 

## 📝 추가 참고 사항 (Additional Notes)
광고주 목록의 allowedAdCount는 (총 허용량) - (현재 사용 중인 둥지 수 + 대기 중인 신청 수)로 계산되며, 음수가 나올 경우 0으로 보정됩니다.